### PR TITLE
fix: turn off rust playground

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -12,6 +12,9 @@ no-section-label = true
 [output.html.fold]
 enable = true
 
+[output.html.playground]
+runnable = false
+
 [preprocessor.katex]
 after = ["links"]
 


### PR DESCRIPTION
- [x] [turn off](https://rust-lang.github.io/mdBook/format/mdbook.html#rust-playground) the rust playground as running the code snippets requires miden dependencies (see also https://github.com/rust-lang/rust-playground?tab=readme-ov-file#whats-it-do)