### PR TITLE
Add write permission to yaml

### DIFF
--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -2,11 +2,13 @@ name: update documentation
 
 on:
   schedule:
-    - cron: '0 0 * * *'
+    - cron: "0 0 * * *"
 
 jobs:
   update-docs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Grant write access to the repository
 
     steps:
       - name: Checkout Repository


### PR DESCRIPTION
Adding write permissions to YAML file for auto-update of docs + updating access token / secret in settings.

Goal is to fix the broken deployments of the docs.

```error
update-docs
failed 8 hours ago in 10s
Search logs
0s
2s
0s
5s
0s
Run git add -A
[main 1dedd7f] Automated update of documentation
 56 files changed, 1527 insertions(+), 314 deletions(-)
 create mode 100644 src/imported/miden-client/src/web-client/api/classes/AccountStorageRequirements.md
 create mode 100644 src/imported/miden-client/src/web-client/api/classes/ForeignAccount.md
 delete mode 100644 src/imported/miden-client/src/web-client/api/classes/NotesArray.md
 create mode 100644 src/imported/miden-client/src/web-client/api/classes/PublicKey.md
 create mode 100644 src/imported/miden-client/src/web-client/api/classes/RecipientArray.md
 create mode 100644 src/imported/miden-client/src/web-client/api/classes/SecretKey.md
 create mode 100644 src/imported/miden-client/src/web-client/api/classes/SlotAndKeys.md
 create mode 100644 src/imported/miden-tutorials/src/web-client/counter_contract_tutorial.md
 create mode 100644 src/imported/miden-tutorials/src/web-client/creating_multiple_notes_tutorial.md
remote: Permission to 0xMiden/miden-docs.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/0xMiden/miden-docs/': The requested URL returned error: 403
Error: Process completed with exit code 128.
0s
```