### PR TITLE
fix: target main branches

### DIFF
--- a/scripts/update_docs.sh
+++ b/scripts/update_docs.sh
@@ -68,10 +68,10 @@ update_docs() {
 }
 
 # Update docs
-update_docs "$MIDEN_CLIENT_REPO" "$CLIENT_DIR" "next"
-update_docs "$MIDEN_NODE_REPO" "$NODE_DIR" "next"
+update_docs "$MIDEN_CLIENT_REPO" "$CLIENT_DIR" "main"
+update_docs "$MIDEN_NODE_REPO" "$NODE_DIR" "main"
 update_docs "$MIDEN_BASE_REPO" "$BASE_DIR"
-update_docs "$MIDEN_VM_REPO" "$VM_DIR" "next"
+update_docs "$MIDEN_VM_REPO" "$VM_DIR" "main"
 update_docs "$MIDEN_COMPILER_REPO" "$COMPILER_DIR" "next"
 update_docs "$MIDEN_TUTORIALS_REPO" "$TUTORIALS_DIR"
 update_docs "$AWESOME_MIDEN_REPO" "$AWESOME_MIDEN_DIR" "main" "."


### PR DESCRIPTION
This PR updates the `./scripts/update_docs.sh` script so that it pulls in documentation from the `main` branch of child directories as opposed to the `next` branch.