### PR TITLE
docs: fix broken links, replace "Polygon Miden" with "Miden" 

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Polygon Miden
+Copyright (c) 2025 Miden
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/book.toml
+++ b/book.toml
@@ -6,7 +6,7 @@ multilingual = false
 title = "The Miden book"
 
 [output.html]
-git-repository-url = "https://github.com/0xPolygonMiden/miden-docs"
+git-repository-url = "https://github.com/0xMiden/miden-docs"
 no-section-label = true
 
 [output.html.fold]

--- a/src/imported/awesome-miden/README.md
+++ b/src/imported/awesome-miden/README.md
@@ -42,7 +42,7 @@ Visit our [website](https://miden.xyz/)!
 
 ## Research papers
 
-- [Generalized Indifferentiable Sponge and its Application to Polygon Miden VM](https://eprint.iacr.org/2024/911)
+- [Generalized Indifferentiable Sponge and its Application to Miden VM](https://eprint.iacr.org/2024/911)
 - [XHash: Efficient STARK-friendly Hash Function](https://eprint.iacr.org/2023/1045)
 - [Rescue-Prime Optimized](https://eprint.iacr.org/2022/1577)
 - [Lattice-Based Cryptography in Miden VM](https://eprint.iacr.org/2022/1041)
@@ -52,6 +52,8 @@ Visit our [website](https://miden.xyz/)!
 
 ## Blog posts
 
+- [Miden Testnet Update: Private Notes, Multi-Sig, Rust Compiler](https://miden.xyz/resource/blog/testnet-alpha-7)
+- [The Miden Compiler v0.4.0 – A Major Milestone](https://miden.xyz/resource/blog/compiler-release-04)
 - [Miden: The Edge Blockchain](https://miden.xyz/resource/blog/vision)
 - [Privacy scales better](https://polygon.technology/blog/privacy-a-fundamental-right-and-a-practical-necessity)
 - [The Future of Blockchain Is Off-Chain](https://miden.xyz/resource/blog/the-future-of-blockchains-is-off-chain)
@@ -74,37 +76,37 @@ Visit our [website](https://miden.xyz/)!
 - [ZK Whiteboard Sessions: Your Dev-Driven Curricula for All Things ZK](https://polygon.technology/blog/zk-whiteboard-sessions-your-dev-driven-curricula-for-all-things-zero-knowledge)
 - [Meet the Humans Building Polygon ZK](https://polygon.technology/blog/meet-the-humans-building-polygon-zk)
 - [Polygon's Zero Knowledge Strategy Explained](https://polygon.technology/blog/polygons-zero-knowledge-strategy-explained)
-- [Polygon Announces Polygon Miden](https://polygon.technology/blog/polygon-announces-polygon-miden-a-stark-based-ethereum-compatible-rollup)
+- [Polygon Announces Miden](https://polygon.technology/blog/polygon-announces-polygon-miden-a-stark-based-ethereum-compatible-rollup)
 
-## Videos
+## Talks
 
-- [ZK Day at SBC - Workshop by Paul-Henry Kajfasz, Senior Protocol Engineer at Polygon Miden](https://www.youtube.com/watch?v=RdeIx4LHb2A) - Paul-Henry Kajfasz, ZK Day at SBC
-- [Polygon Miden: A New VM for the ZK Future | Avail Whiteboard Series](https://www.youtube.com/watch?v=QuLhkaszLtA&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=1&t=1s) - Bobbin Threadbare, Avail Whiteboard Series
-- [ZK8: The power of multiset checks in STARK-based VMs - grjte - Polygon Miden](https://www.youtube.com/watch?v=PA8jT_POYUo&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=2) - grjte, ZK Summit 8
+- [ZK Day at SBC - Workshop by Paul-Henry Kajfasz, Senior Protocol Engineer at Miden](https://www.youtube.com/watch?v=RdeIx4LHb2A) - Paul-Henry Kajfasz, ZK Day at SBC
+- [Miden: A New VM for the ZK Future | Avail Whiteboard Series](https://www.youtube.com/watch?v=QuLhkaszLtA&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=1&t=1s) - Bobbin Threadbare, Avail Whiteboard Series
+- [ZK8: The power of multiset checks in STARK-based VMs - grjte - Miden](https://www.youtube.com/watch?v=PA8jT_POYUo&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=2) - grjte, ZK Summit 8
 - [ZK9: AirScript - a simple and efficient way to write AIR constraints](https://www.youtube.com/watch?v=PA8jT_POYUo&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=2) - grjte, ZK Summit 9
-- [ZK10: Optimizing recursive STARK verification in Polygon Miden VM](https://www.youtube.com/watch?v=uL2J31dQfLI&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=4) - Bobbin Threadbare, ZK Summit 10
+- [ZK10: Optimizing recursive STARK verification in Miden VM](https://www.youtube.com/watch?v=uL2J31dQfLI&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=4) - Bobbin Threadbare, ZK Summit 10
 - [zkStudyClub: AirScript presented by Bobbin Threadbare]() - Bobbin Threadbare, ZK Study Club
 - [ZK Whiteboard Sessions - Module Four: SNARKs vs STARKs with Bobbin Threadbare](https://www.youtube.com/watch?v=qUrA97TG2YU&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=6) - Bobbin Threadbare, Brendan Farmer, ZK Whiteboard Sessions
-- [ZK HACK IV - Provable State Changes: Polygon Miden Transaction Kernel](https://www.youtube.com/watch?v=V4fzsti11qU&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=7) - Dominik Schmid, Bobbin Threadbare, ZK Hack IV
+- [ZK HACK IV - Provable State Changes: Miden Transaction Kernel](https://www.youtube.com/watch?v=V4fzsti11qU&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=7) - Dominik Schmid, Bobbin Threadbare, ZK Hack IV
 - [ZK Whiteboard Sessions – Module Nine: Introduction to zkRollups with Barry Whitehat](https://www.youtube.com/watch?v=lJS4z2n4P1E&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=8) - Bobbin Threadbare, Barry Whitehat, ZK Whiteboard Sessions
 - [ZK Whiteboard Sessions – Module Eight: Achieving Decentralised Private Computation](https://www.youtube.com/watch?v=_oW29AOKWTs&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=9) - Bobbin Threadbare, Pratyush Mishra, ZK Whiteboard Sessions
 - [ZK Whiteboard Sessions – Module Seven: Zero Knowledge Virtual Machines (zkVM) with grjte](https://www.youtube.com/watch?v=GRFPGJW0hic&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=10) - Bobbin Threadbare, grjte, ZK Whiteboard Sessions
 - [AirScript: a DSL for writing AIR constraints | Bobbin Threadbare | PROGCRYPTO](https://www.youtube.com/watch?v=UxCW33hvnfc&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=11) - Bobbin Threadbare, PROGCRYPTO
 - [StarkWare Sessions 23 | AirScript: A DSL for Writing AIR Constraints | Bobbin Threadbare](https://www.youtube.com/watch?v=8Rk2DOD4ba8&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=12) - Bobbin Threadbare, StarkWare Sessions 2023
-- [Miden & the Future of Privacy Preserving Protocols presented by Paul-Henry Kajfasz of Polygon Miden](https://www.youtube.com/watch?v=GC4jR2rh-5U&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=13&t=3s) - Paul-Henry Kajfasz, ZK Accelerate Athens
-- [Recursion in the Miden VM, by Augusto Hack of Polygon Miden](https://www.youtube.com/watch?v=P1ZM6Ead6fo&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=14) - Augusto Hack, ZK Accelerate Istanbul
-- [Polygon Miden VM | Avail's Hot Take Series: The Execution Race (EthDenver)](https://www.youtube.com/watch?v=fl51Cer7-bY&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=15) - Dominik Schmid, EthDenver
+- [Miden & the Future of Privacy Preserving Protocols presented by Paul-Henry Kajfasz of Miden](https://www.youtube.com/watch?v=GC4jR2rh-5U&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=13&t=3s) - Paul-Henry Kajfasz, ZK Accelerate Athens
+- [Recursion in the Miden VM, by Augusto Hack of Miden](https://www.youtube.com/watch?v=P1ZM6Ead6fo&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=14) - Augusto Hack, ZK Accelerate Istanbul
+- [Miden VM | Avail's Hot Take Series: The Execution Race (EthDenver)](https://www.youtube.com/watch?v=fl51Cer7-bY&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=15) - Dominik Schmid, EthDenver
 - [ZK7: Miden VM: a STARK-friendly VM for blockchains - Bobbin Threadbare – Polygon](https://www.youtube.com/watch?v=81UAaiIgIYA&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=16) - Bobbin Threadbare, ZK Summit 7
 - [09 Miden VM architecture overview](https://www.youtube.com/watch?v=mO5ZDrjtb3I&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=17) - Bobbin Threadbare, 0xParc
-- [Bobbin Threadbare - Miden VM: the heart of Polygon Miden](https://www.youtube.com/watch?v=S2NfpC8cJog&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=18&t=1137s) - Bobbin Threadbare, Layer Two Amsterdam
-- [Polygon Miden: Extending Ethereum’s Feature Set | Dominik Schmid (April 2023)](https://www.youtube.com/watch?v=jMTMidok9sA&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=19) - Dominik Schmid, Ethereum Berlin
+- [Bobbin Threadbare - Miden VM: the heart of Miden](https://www.youtube.com/watch?v=S2NfpC8cJog&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=18&t=1137s) - Bobbin Threadbare, Layer Two Amsterdam
+- [Miden: Extending Ethereum’s Feature Set | Dominik Schmid (April 2023)](https://www.youtube.com/watch?v=jMTMidok9sA&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=19) - Dominik Schmid, Ethereum Berlin
 - [Using a Hybrid UTXO and Account-based State Model in a ZK Rollup by Bobbin Threadbare](https://www.youtube.com/watch?v=TEPY19-hie4&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=20) - Bobbin Threadbare, Devcon Bogota
 - [Miden: Ethereum Extended](https://www.youtube.com/watch?v=FEh7mYASia4&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=21) - Dominik Schmid, Ethereum Engineering Group
-- [Polygon Miden - a STARK based ZK Rollup](https://www.youtube.com/watch?v=pLu7XeEN-f4&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=22) - Bobbin Threadbare, ETH Global
+- [Miden - a STARK based ZK Rollup](https://www.youtube.com/watch?v=pLu7XeEN-f4&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=22) - Bobbin Threadbare, ETH Global
 - [Episode 210: The Road to STARKs and Miden with Bobbin Threadbare](https://www.youtube.com/watch?v=cpGb6daIKm4&list=PLslsfan1R_z20bEgUU_ZyY64AHx5C6vgg&index=23) - Bobbin Threadbare, ZK Podcast
-- [Provable Compliance on Polygon Miden and beyond / Anne-Grace Kleczewski](https://www.youtube.com/watch?v=t6NQ8nFDMvg) - Anne-Grace Kleczewski, Duct Tape
+- [Provable Compliance on Miden and beyond / Anne-Grace Kleczewski](https://www.youtube.com/watch?v=t6NQ8nFDMvg) - Anne-Grace Kleczewski, Duct Tape
 - [Privacy Scales Better by Dominik Schmid, Polygon | L2con Brussels](https://www.youtube.com/watch?v=gmamoa8N_N0) - Dominik Schmid, L2con Brussels
-- [Mass adoption with private and asynchronous blockchains, by Bobbin Threadbare of Polygon Miden](https://www.youtube.com/watch?v=pfX6T29TolY) - Bobbin Threadbare, ZK Accelerate Bangkok
+- [Mass adoption with private and asynchronous blockchains, by Bobbin Threadbare of Miden](https://www.youtube.com/watch?v=pfX6T29TolY) - Bobbin Threadbare, ZK Accelerate Bangkok
 
 ## Contributing
 

--- a/src/index.md
+++ b/src/index.md
@@ -7,12 +7,12 @@
 
 Miden is a rollup for high-throughput, private applications.
 
-Using Polygon Miden, builders can create novel, high-throughput, private applications for payments, DeFi, digital assets, and gaming. Applications and users are secured by Ethereum and AggLayer.
+Using Miden, builders can create novel, high-throughput, private applications for payments, DeFi, digital assets, and gaming. Applications and users are secured by Ethereum and AggLayer.
 
 If you want to join the technical discussion, please check out the following:
 
 * [Telegram](https://t.me/BuildOnMiden)
-* [Miden Github](https://github.com/0xPolygonMiden)
+* [Miden Github](https://github.com/0xMiden)
 * [Roadmap](roadmap.md)
 
 > [!WARNING]
@@ -21,12 +21,12 @@ If you want to join the technical discussion, please check out the following:
 
 ## Status and features
 
-Polygon Miden is currently on release v0.8 This is an early version of the protocol and its components. 
+Miden is currently on release v0.8 This is an early version of the protocol and its components. 
 
 > [!WARNING]
 > We expect breaking changes on all components.
 
-At the time of writing, Polygon Miden doesn't offer all the features you may expect from a zkRollup yet. During 2025, we expect to gradually implement more features.
+At the time of writing, Miden doesn't offer all the features you may expect from a zkRollup yet. During 2025, we expect to gradually implement more features.
 
 ### Feature highlights
 
@@ -40,7 +40,7 @@ Like private accounts, the Miden operator only tracks a commitment to notes in t
 
 #### Public accounts
 
-Polygon Miden supports public smart contracts like Ethereum. The code and state of those accounts are visible to the network and anyone can execute transactions against them.
+Miden supports public smart contracts like Ethereum. The code and state of those accounts are visible to the network and anyone can execute transactions against them.
 
 #### Public notes
 
@@ -58,7 +58,7 @@ The Miden client allows for proof generation by an external service if the user 
 
 Currently, there are three different standardized smart contracts available. A basic wallet smart contract that sends and receives assets, and fungible and non-fungible faucets to mint and burn assets.
 
-All accounts are written in [MASM](https://0xpolygonmiden.github.io/miden-vm/user_docs/assembly/main.html).
+All accounts are written in [MASM](https://0xmiden.github.io/miden-vm/user_docs/assembly/main.html).
 
 #### Customized smart contracts
 
@@ -97,7 +97,7 @@ In order to write account code, note or transaction scripts, in Rust, there will
 
 The Miden node will recursively verify transactions and in doing so build batches of transactions, blocks, and epochs.
 
-## Benefits of Polygon Miden
+## Benefits of Miden
 
 * Ethereum security.
 * Developers can build applications that are infeasible on other systems. For example:


### PR DESCRIPTION
Closes #56 
This PR makes several documentation updates to improve consistency and fix outdated references:

-Fixed broken and outdated links pointing to the old `0xPolygonMiden` organization.
-Replaced all mentions of “Polygon Miden” with “Miden” across documentation files (`index.md, awesome-miden/README.md, etc.`).
-Updated the GitHub repository URL in `book.toml` to point to the correct `0xMiden/miden-docs` repository.
-Corrected the GitHub Pages link from `0xpolygonmiden.github.io` to `0xmiden.github.io`.
-Updated the copyright notice in `LICENSE` to reflect 2025 Miden.
-Renamed the blog section heading from `## Videos` to `## Talks`for consistency with [miden.xyz/resources](https://miden.xyz/resources)
-Added two new blog posts to `awesome-miden/index.html` to align with the official resources page.