### PR TITLE
fix: Document how to run the dev script with webpack

### DIFF
--- a/versioned_docs/version-0.12/miden-tutorials/web-client/counter_contract_tutorial.md
+++ b/versioned_docs/version-0.12/miden-tutorials/web-client/counter_contract_tutorial.md
@@ -47,13 +47,13 @@ This tutorial assumes you have a basic understanding of Miden assembly. To quick
    pnpm i @demox-labs/miden-sdk@0.11.1
    ```
 
-**NOTE!**: Be sure to remove the `--turbopack` command from your `package.json` when running the `dev script`. The dev script should look like this:
+**NOTE!**: Be sure to add the `--webpack` command to your `package.json` when running the `dev script`. The dev script should look like this:
 
 `package.json`
 
 ```json
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     ...
   }
 ```

--- a/versioned_docs/version-0.12/miden-tutorials/web-client/creating_multiple_notes_tutorial.md
+++ b/versioned_docs/version-0.12/miden-tutorials/web-client/creating_multiple_notes_tutorial.md
@@ -60,13 +60,13 @@ Anyone can run their own delegated prover server. If you are building a product 
    pnpm install @demox-labs/miden-sdk@0.11.1
    ```
 
-**NOTE!**: Be sure to remove the `--turbopack` command from your `package.json` when running the `dev script`. The dev script should look like this:
+**NOTE!**: Be sure to add the `--webpack` command to your `package.json` when running the `dev script`. The dev script should look like this:
 
 `package.json`
 
 ```json
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     ...
   }
 ```

--- a/versioned_docs/version-0.12/miden-tutorials/web-client/foreign_procedure_invocation_tutorial.md
+++ b/versioned_docs/version-0.12/miden-tutorials/web-client/foreign_procedure_invocation_tutorial.md
@@ -60,13 +60,13 @@ This tutorial assumes you have a basic understanding of Miden assembly and compl
    pnpm i @demox-labs/miden-sdk@0.11.1
    ```
 
-**NOTE!**: Be sure to remove the `--turbopack` command from your `package.json` when running the `dev script`. The dev script should look like this:
+**NOTE!**: Be sure to add the `--webpack` command to your `package.json` when running the `dev script`. The dev script should look like this:
 
 `package.json`
 
 ```json
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     ...
   }
 ```

--- a/versioned_docs/version-0.12/miden-tutorials/web-client/unauthenticated_note_how_to.md
+++ b/versioned_docs/version-0.12/miden-tutorials/web-client/unauthenticated_note_how_to.md
@@ -80,13 +80,13 @@ This tutorial assumes you have a basic understanding of Miden assembly. To quick
    pnpm install @demox-labs/miden-sdk@0.11.1
    ```
 
-**NOTE!**: Be sure to remove the `--turbopack` command from your `package.json` when running the `dev script`. The dev script should look like this:
+**NOTE!**: Be sure to add the `--webpack` command to your `package.json` when running the `dev script`. The dev script should look like this:
 
 `package.json`
 
 ```json
   "scripts": {
-    "dev": "next dev",
+    "dev": "next dev --webpack",
     ...
   }
 ```


### PR DESCRIPTION
The WASM relative path construction fails when turbopack is used. Since turbopack is the default for Next.JS v16, it is not enough anymore to just remove the --turbopack option. Instead, we use the --webpack option to force the webpack (the non-default).