### PR TITLE
Adjust tutorials (Creating Multiple Notes, Unauth Note)

### DIFF
--- a/versioned_docs/version-0.12/miden-tutorials/web-client/creating_multiple_notes_tutorial.md
+++ b/versioned_docs/version-0.12/miden-tutorials/web-client/creating_multiple_notes_tutorial.md
@@ -241,7 +241,7 @@ console.log('All notes created ✅');
 Your `lib/multiSendWithDelegatedProver.ts` file sould now look like this:
 
 ```ts
-//**
+/**
  * Demonstrates multi-send functionality using a delegated prover on the Miden Network
  * Creates multiple P2ID (Pay to ID) notes for different recipients
  *


### PR DESCRIPTION
Adjusts the Creating Multiple Notes and Unauthenticated Note tutorials for 0.12.

Couple of notes, as in I know ideally the tutorials shouldn't change much, but just couldn't stop myself from making a couple of sane changes. Happy to discuss strat for this though. I think its sane but open to feedback.

1. Im putting the transaction blocks in separate scopes. This means we dont need to do things like txResult_1, txResult_2 etc, but we keep names consistent across the board. I think it just reads much better and is easier/faster to maintain. We can also make functions out of them if it hurts the eyes (I know some people dont like them, but hey language feature is a feature imo).
2. Prettier pass (default settings).
3. Removed unused imports

ALSO:
1. There is a (breaking?) change with the refactor of OutputNotesArray to OutputNoteArray. The typing is invalid in current client version, which I opened a client PR for (https://github.com/0xMiden/miden-client/pull/1541). I adjusted the usage here, but linters wont catch on obviously until next client release. (/sadpanda)
2. I'm currently having issues with the remote prover (CORS preflight + gRPC header mismatch). This is handled separately, and doesn't really affect the tutorial code I think, since when I switch to local prover, it works, and the instantiation of remote prover is kosher.