### PR TITLE
fix: remove orange headings on light mode

### DIFF
--- a/src/custom/styles.css
+++ b/src/custom/styles.css
@@ -257,7 +257,7 @@ h6 {
   font-family: var(--font-sans);
   letter-spacing: 0em;
   font-weight: bold;
-  color: var(--ifm-color-primary);
+  color: var(--color-text);
 }
 
 [data-theme="dark"] h1,


### PR DESCRIPTION
This PR changes the heading color for light mode

Closes #112 