### PR TITLE
fix: read storage Quick Start code snippet

### DIFF
--- a/docs/quick-start/read-storage.md
+++ b/docs/quick-start/read-storage.md
@@ -81,7 +81,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // READ PUBLIC STATE OF THE COUNTER ACCOUNT
     //------------------------------------------------------------
 
-    let counter_account_id = AccountId::from_hex("0xf3e8e740c0d3960013418eecb98ccf")?;
+    let counter_account_id = AccountId::from_hex("0xe59d8cd3c9ff2a0055da0b83ed6432")?;
 
     client.import_account_by_id(counter_account_id).await?;
 
@@ -116,7 +116,7 @@ export async function demo() {
     const client = await WebClient.createClient(nodeEndpoint);
     await client.syncState();
 
-    const accountId = AccountId.fromHex("0xf3e8e740c0d3960013418eecb98ccf");
+    const accountId = AccountId.fromHex("0xe59d8cd3c9ff2a0055da0b83ed6432");
 
     // Import the account into the client's database
     let account = await client.getAccount(accountId);

--- a/versioned_docs/version-0.12/quick-start/read-storage.md
+++ b/versioned_docs/version-0.12/quick-start/read-storage.md
@@ -81,7 +81,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // READ PUBLIC STATE OF THE COUNTER ACCOUNT
     //------------------------------------------------------------
 
-    let counter_account_id = AccountId::from_hex("0xf3e8e740c0d3960013418eecb98ccf")?;
+    let counter_account_id = AccountId::from_hex("0xe59d8cd3c9ff2a0055da0b83ed6432")?;
 
     client.import_account_by_id(counter_account_id).await?;
 
@@ -116,7 +116,7 @@ export async function demo() {
     const client = await WebClient.createClient(nodeEndpoint);
     await client.syncState();
 
-    const accountId = AccountId.fromHex("0xf3e8e740c0d3960013418eecb98ccf");
+    const accountId = AccountId.fromHex("0xe59d8cd3c9ff2a0055da0b83ed6432");
 
     // Import the account into the client's database
     let account = await client.getAccount(accountId);


### PR DESCRIPTION
The current address of the Read Storage Quick Start tutorial is incorrect. This PR fixes that.

Closes #122 