### PR TITLE
docs: add information about underflow overflow errors

### DIFF
--- a/docs/builder/develop/tutorials/rust-compiler/miden-bank/02-constants-constraints.md
+++ b/docs/builder/develop/tutorials/rust-compiler/miden-bank/02-constants-constraints.md
@@ -95,17 +95,13 @@ Here's our complete deposit validation with constraints:
 
 ```rust title="contracts/bank-account/src/lib.rs"
 pub fn deposit(&mut self, depositor: AccountId, deposit_asset: Asset) {
-    // ========================================================================
-    // CONSTRAINT: Bank must be initialized
-    // ========================================================================
+    // Ensure the bank is initialized before accepting deposits
     self.require_initialized();
 
     // Extract the fungible amount from the asset
     let deposit_amount = deposit_asset.inner[0];
 
-    // ========================================================================
-    // CONSTRAINT: Maximum deposit amount check
-    // ========================================================================
+    // Validate deposit amount does not exceed maximum
     assert!(
         deposit_amount.as_u64() <= MAX_DEPOSIT_AMOUNT,
         "Deposit amount exceeds maximum allowed"
@@ -208,6 +204,10 @@ fn require_sufficient_balance(&self, amount: Felt) {
     );
 }
 ```
+
+:::danger Critical: Always Validate Before Subtraction
+This pattern is **mandatory** for any operation that subtracts from a balance. Miden uses field element (Felt) arithmetic, which is modular. Without this check, subtracting more than the balance would NOT cause an error - instead, the value would silently wrap around to a large positive number, effectively allowing unlimited withdrawals. See [Common Pitfalls](../pitfalls#felt-arithmetic-underflowoverflow) for more details.
+:::
 
 ### 2. State Checks
 

--- a/docs/builder/develop/tutorials/rust-compiler/miden-bank/08-complete-flows.md
+++ b/docs/builder/develop/tutorials/rust-compiler/miden-bank/08-complete-flows.md
@@ -267,6 +267,8 @@ let executed_tx = tx_context.execute().await?;
 │              │                                                      │
 │              ▼                                                      │
 │  3. WITHDRAW METHOD RUNS                                           │
+│     - require_initialized() ✓                                      │
+│     - Check balance >= withdraw_amount ✓                           │
 │     - balances[User] -= 500                                        │
 │     - create_p2id_note()                                           │
 │              │                                                      │


### PR DESCRIPTION
# Summary
- Updates withdraw code examples to include mandatory balance validation before subtraction
- Adds new "Felt Arithmetic Underflow" section to Common Pitfalls documentation
- Adds warning callout linking to pitfalls from the balance check pattern

## Changes
- 03-asset-management.md: Fixed withdraw implementation to validate balance before subtraction
- 02-constants-constraints.md: Added danger callout explaining why balance checks are mandatory
- 08-complete-flows.md: Updated withdraw flow diagram to show validation steps
- pitfalls.md: Added new section documenting Felt underflow risks with examples

## Context
Miden uses modular field arithmetic for Felt types. Subtracting a larger value from a smaller one does not error, it silently wraps to a large positive number. The previous tutorial code showed withdraw without balance validation.