### PR TITLE
fix: documentation typos, grammar errors, and outdated GitHub references

### DIFF
--- a/versioned_docs/version-0.11/compiler/appendix/canonabi-adhocabi-mismatch.md
+++ b/versioned_docs/version-0.11/compiler/appendix/canonabi-adhocabi-mismatch.md
@@ -50,7 +50,7 @@ happen for any type that is larger than 8 bytes (i64).
 :::tip
 
 For a complete list of the transaction kernel functions, in WIT format, see
-[miden.wit](https://github.com/0xPolygonMiden/compiler/blob/main/tests/rust-apps-wasm/wit-sdk/sdk/wit/miden.wit).
+[miden.wit](https://github.com/0xMiden/compiler/blob/main/tests/rust-apps-wasm/wit-sdk/sdk/wit/miden.wit).
 
 :::
 

--- a/versioned_docs/version-0.11/compiler/appendix/known-limitations.md
+++ b/versioned_docs/version-0.11/compiler/appendix/known-limitations.md
@@ -8,7 +8,7 @@ draft: true
 
 :::tip
 
-See the [issue tracker](https://github.com/0xpolygonmiden/compiler/issues) for information
+See the [issue tracker](https://github.com/0xMiden/compiler/issues) for information
 on known bugs. This document focuses on missing/incomplete features, rather than bugs.
 
 :::
@@ -45,8 +45,8 @@ find a better/more natural representation for `Felt` in WebAssembly.
 ### Function call indirection
 
 - Status: **Unimplemented**
-- Tracking Issue: [#32](https://github.com/0xPolygonMiden/compiler/issues/32)
-- Release Milestone: [Beta 1](https://github.com/0xPolygonMiden/compiler/milestone/4)
+- Tracking Issue: [#32](https://github.com/0xMiden/compiler/issues/32)
+- Release Milestone: [Beta 1](https://github.com/0xMiden/compiler/milestone/4)
 
 This feature corresponds to `call_indirect` in WebAssembly, and is associated with Rust features
 such as trait objects (which use indirection to call trait methods), and closures. Note that the
@@ -121,8 +121,8 @@ fn main() -> u32 {
 ### Miden SDK
 
 - Status: **Incomplete**
-- Tracking Issue: [#159](https://github.com/0xPolygonMiden/compiler/issues/159) and [#158](https://github.com/0xPolygonMiden/compiler/issues/158)
-- Release Milestone: [Beta 1](https://github.com/0xPolygonMiden/compiler/milestone/4)
+- Tracking Issue: [#159](https://github.com/0xMiden/compiler/issues/159) and [#158](https://github.com/0xMiden/compiler/issues/158)
+- Release Milestone: [Beta 1](https://github.com/0xMiden/compiler/milestone/4)
 
 The Miden SDK for Rust, is a Rust crate that provides the implementation of native Miden types, as
 well as bindings to the Miden standard library and transaction kernel APIs.
@@ -136,7 +136,7 @@ APIs which are lesser used.
 ### Rust/Miden FFI (foreign function interface) and interop
 
 - Status: **Internal Use Only**
-- Tracking Issue: [#304](https://github.com/0xPolygonMiden/compiler/issues/304)
+- Tracking Issue: [#304](https://github.com/0xMiden/compiler/issues/304)
 - Release Milestone: TBD
 
 While the compiler has functionality to link against native Miden Assembly libraries, binding
@@ -162,8 +162,8 @@ and Miden packaging. Once present, we can open up the FFI for general use.
 ### Dynamic procedure invocation
 
 - Status: **Unimplemented**
-- Tracking Issue: [#32](https://github.com/0xPolygonMiden/compiler/issues/32)
-- Release Milestone: [Beta 1](https://github.com/0xPolygonMiden/compiler/milestone/4)
+- Tracking Issue: [#32](https://github.com/0xMiden/compiler/issues/32)
+- Release Milestone: [Beta 1](https://github.com/0xMiden/compiler/milestone/4)
 
 This is a dependency of [Function Call Indirection](#function-call-indirection) described above,
 and is the mechanism by which we can perform indirect calls in Miden. In order to implement support
@@ -187,8 +187,8 @@ which has its "address" taken, and use the hash of the stub in place of the actu
 ### Cross-context procedure invocation
 
 - Status: **Unimplemented**
-- Tracking Issue: [#303](https://github.com/0xPolygonMiden/compiler/issues/303)
-- Release Milestone: [Beta 2](https://github.com/0xPolygonMiden/compiler/milestone/5)
+- Tracking Issue: [#303](https://github.com/0xMiden/compiler/issues/303)
+- Release Milestone: [Beta 2](https://github.com/0xMiden/compiler/milestone/5)
 
 This is required in order to support representing Miden accounts and note scripts in Rust, and
 compilation to Miden Assembly.
@@ -225,8 +225,8 @@ subfeatures being implemented first.
 ### Package format
 
 - Status: **Experimental**
-- Tracking Issue: [#121](https://github.com/0xPolygonMiden/compiler/issues/121)
-- Release Milestone: [Beta 1](https://github.com/0xPolygonMiden/compiler/milestone/4)
+- Tracking Issue: [#121](https://github.com/0xMiden/compiler/issues/121)
+- Release Milestone: [Beta 1](https://github.com/0xMiden/compiler/milestone/4)
 
 This feature represents the ability to compile and distribute a single artifact that contains
 the compiled MAST, and all required and optional metadata to make linking against, and executing

--- a/versioned_docs/version-0.11/compiler/guides/develop_miden_in_rust.md
+++ b/versioned_docs/version-0.11/compiler/guides/develop_miden_in_rust.md
@@ -7,7 +7,7 @@ sidebar_position: 3
 
 This chapter will walk through how to develop Miden programs in Rust using the standard library
 provided by the `miden-stdlib-sys` crate (see the
-[README](https://github.com/0xPolygonMiden/compiler/blob/main/sdk/stdlib-sys/README.md).
+[README](https://github.com/0xMiden/compiler/blob/main/sdk/stdlib-sys/README.md).
 
 ## Getting started
 

--- a/versioned_docs/version-0.11/compiler/index.md
+++ b/versioned_docs/version-0.11/compiler/index.md
@@ -18,7 +18,7 @@ yourself, and give us feedback on any issues or sharp edges you encounter.
 The documentation found here should provide a good starting point for the current capabilities of
 the toolchain, however if you find something that is not covered, but is not listed as
 unimplemented or a known limitation, please let us know by reporting an issue on the compiler
-[issue tracker](https://github.com/0xpolygonmiden/compiler/issues).
+[issue tracker](https://github.com/0xMiden/compiler/issues).
 
 ## What is provided?
 
@@ -45,7 +45,7 @@ The compiler toolchain consists of the following primary components:
 - A terminal-based interactive debugger, available via `midenc debug`, which provides a UI very
   similar to `lldb` or `gdb` when using the TUI mode. You can use this to run a program, or step
   through it cycle-by-cycle. You can set various types of breakpoints; see the source code, call
-  stack, and contents of the operand stack at the current program point; as well as interatively
+  stack, and contents of the operand stack at the current program point; as well as interactively
   read memory and format it in various ways for display.
 - A Miden SDK for Rust, which provides types and bindings to functionality exported from the Miden
   standard library, as well as the Miden transaction kernel API. You can use this to access native
@@ -87,7 +87,7 @@ in the future, but for now it is expected that you implement your own optimizati
 
 ## Known bugs and limitations
 
-For the latest information on known bugs, see the [issue tracker](https://github.com/0xpolygonmiden/compiler/issues).
+For the latest information on known bugs, see the [issue tracker](https://github.com/0xMiden/compiler/issues).
 
 See Known Limitations for details on what functionality is
 missing or only partially implemented.

--- a/versioned_docs/version-0.11/compiler/usage/midenc.md
+++ b/versioned_docs/version-0.11/compiler/usage/midenc.md
@@ -28,7 +28,7 @@ Then, simply install `midenc` using Cargo in one of the following ways:
     cargo make install
 
     # If you have Rust installed, but have not cloned the git repo:
-    cargo install --git https://github.com/0xpolygonmiden/compiler midenc
+    cargo install --git https://github.com/0xMiden/compiler midenc
 
 :::tip
 
@@ -124,5 +124,5 @@ We have put together two useful guides to walk through more detail on compiling 
 2. If you already have a WebAssembly module, or know how to produce one, and want to learn how to
    compile it to Miden Assembly, see [this guide](../guides/wasm_to_masm.md).
 
-You may also be interested in our [basic account project template](https://github.com/0xpolygonmiden/rust-templates/tree/main/account/template),
+You may also be interested in our [basic account project template](https://github.com/0xMiden/rust-templates/tree/main/account/template),
 as a starting point for your own Rust project.

--- a/versioned_docs/version-0.11/miden-client/rust-client/install-and-run.md
+++ b/versioned_docs/version-0.11/miden-client/rust-client/install-and-run.md
@@ -32,4 +32,4 @@ miden-client --help
 
 This will show you the available commands and options for the client.
 
-An more in depth tutorial can be fund in the [Getting started section](./get-started).
+A more in-depth tutorial can be found in the [Getting started section](./get-started).

--- a/versioned_docs/version-0.11/miden-tutorials/rust-client/foreign_procedure_invocation_tutorial.md
+++ b/versioned_docs/version-0.11/miden-tutorials/rust-client/foreign_procedure_invocation_tutorial.md
@@ -755,4 +755,3 @@ cargo run --release --bin counter_contract_fpi
 ### Continue learning
 
 Next tutorial: [How to Use Unauthenticated Notes](unauthenticated_note_how_to.md)
-Next tutorial: [How to Use Unauthenticated Notes](unauthenticated_note_how_to.md)

--- a/versioned_docs/version-0.12/compiler/index.md
+++ b/versioned_docs/version-0.12/compiler/index.md
@@ -45,7 +45,7 @@ The compiler toolchain consists of the following primary components:
 - A terminal-based interactive debugger, available via `midenc debug`, which provides a UI very
   similar to `lldb` or `gdb` when using the TUI mode. You can use this to run a program, or step
   through it cycle-by-cycle. You can set various types of breakpoints; see the source code, call
-  stack, and contents of the operand stack at the current program point; as well as interatively
+  stack, and contents of the operand stack at the current program point; as well as interactively
   read memory and format it in various ways for display.
 - A Miden SDK for Rust, which provides types and bindings to functionality exported from the Miden
   standard library, as well as the Miden transaction kernel API. You can use this to access native

--- a/versioned_docs/version-0.12/miden-client/rust-client/install-and-run.md
+++ b/versioned_docs/version-0.12/miden-client/rust-client/install-and-run.md
@@ -32,4 +32,4 @@ miden-client --help
 
 This will show you the available commands and options for the client.
 
-An more in depth tutorial can be fund in the [Getting started section](./get-started).
+A more in-depth tutorial can be found in the [Getting started section](./get-started).

--- a/versioned_docs/version-0.12/miden-tutorials/web-client/foreign_procedure_invocation_tutorial.md
+++ b/versioned_docs/version-0.12/miden-tutorials/web-client/foreign_procedure_invocation_tutorial.md
@@ -57,7 +57,7 @@ This tutorial assumes you have a basic understanding of Miden assembly and compl
 
 3. Install the Miden WebClient SDK:
    ```bash
-   yarn install @demox-labs/miden-sdk@0.12.3
+   yarn add @demox-labs/miden-sdk@0.12.3
    ```
 
 **NOTE!**: Be sure to add the `--webpack` command to your `package.json` when running the `dev script`. The dev script should look like this:


### PR DESCRIPTION
## Summary

This PR fixes multiple documentation issues found during an audit of the Miden documentation.

## Changes Made

### 1. Typos Fixed
- **'interatively'  'interactively'** in compiler/index.md (v0.11, v0.12)

### 2. Grammar Errors Fixed
- **'An more in depth tutorial can be fund'  'A more in-depth tutorial can be found'** in install-and-run.md (v0.11, v0.12)
  - Fixed 'An'  'A' (grammar)
  - Fixed 'in depth'  'in-depth' (hyphenation)
  - Fixed 'fund'  'found' (typo)

### 3. Incorrect Commands Fixed
- **'yarn install @demox-labs/miden-sdk'  'yarn add @demox-labs/miden-sdk'** in foreign_procedure_invocation_tutorial.md (v0.12)
  - \yarn install\ installs all deps from package.json; \yarn add\ adds a specific package

### 4. Duplicate Lines Removed
- Removed duplicate 'Next tutorial' line in foreign_procedure_invocation_tutorial.md (v0.11)

### 5. Outdated GitHub Organization References Updated
Updated all '0xPolygonMiden' and '0xpolygonmiden' references to '0xMiden' in:
- versioned_docs/version-0.11/compiler/index.md
- versioned_docs/version-0.11/compiler/usage/midenc.md
- versioned_docs/version-0.11/compiler/appendix/known-limitations.md
- versioned_docs/version-0.11/compiler/appendix/canonabi-adhocabi-mismatch.md
- versioned_docs/version-0.11/compiler/guides/develop_miden_in_rust.md

## Files Modified

| File | Changes |
|------|---------|
| version-0.11/compiler/index.md | Fixed typo + updated 2 GitHub links |
| version-0.12/compiler/index.md | Fixed typo |
| version-0.11/miden-client/rust-client/install-and-run.md | Fixed grammar errors |
| version-0.12/miden-client/rust-client/install-and-run.md | Fixed grammar errors |
| version-0.12/miden-tutorials/web-client/foreign_procedure_invocation_tutorial.md | Fixed yarn command |
| version-0.11/miden-tutorials/rust-client/foreign_procedure_invocation_tutorial.md | Removed duplicate line |
| version-0.11/compiler/usage/midenc.md | Updated 2 GitHub links |
| version-0.11/compiler/appendix/known-limitations.md | Updated 10 GitHub links |
| version-0.11/compiler/appendix/canonabi-adhocabi-mismatch.md | Updated 1 GitHub link |
| version-0.11/compiler/guides/develop_miden_in_rust.md | Updated 1 GitHub link |

## Related Issues

Closes #133, Closes #134, Closes #135, Closes #136, Closes #137

## Testing

- [x] Documentation builds successfully
- [x] All links point to valid GitHub URLs