### PR TITLE
fix: undeclared variable `contract_package` in code example

### DIFF
--- a/docs/builder/quick-start/your-first-smart-contract/deploy.md
+++ b/docs/builder/quick-start/your-first-smart-contract/deploy.md
@@ -175,7 +175,7 @@ let counter_cfg = AccountCreationConfig {
 // Convert the counter package into a deployable account
 let counter_account = create_account_from_package(
     &mut client,
-    contract_package.clone(),
+    counter_package.clone(),
     counter_cfg
 )
 .await


### PR DESCRIPTION
In the “Building Contracts from Source” section of the documentation, the example uses `contract_package` when creating the counter account, but this variable is not declared in the current context. This will cause a compilation error if someone tries to run the example.

Earlier in the example, two variables are declared:
- `counter_package` - the counter account contract package
- `note_package` - the increment note script package

However, when calling `create_account_from_package()`, `contract_package.clone()` is used, which is undefined.

Fixed:
Replaced `contract_package.clone()` with `counter_package.clone()` in the `create_account_from_package() call`.

