### PR TITLE
fix: remove numeric prefixes from miden-bank tutorial internal links

### DIFF
--- a/docs/builder/develop/tutorials/rust-compiler/miden-bank/00-project-setup.md
+++ b/docs/builder/develop/tutorials/rust-compiler/miden-bank/00-project-setup.md
@@ -323,4 +323,4 @@ Your bank can be created, but doesn't do anything useful yet. In the next parts,
 
 ## Next Steps
 
-Now that your project is set up, let's dive deeper into account components and storage in [Part 1: Account Components and Storage](./01-account-components).
+Now that your project is set up, let's dive deeper into account components and storage in [Part 1: Account Components and Storage](./account-components).

--- a/docs/builder/develop/tutorials/rust-compiler/miden-bank/01-account-components.md
+++ b/docs/builder/develop/tutorials/rust-compiler/miden-bank/01-account-components.md
@@ -414,4 +414,4 @@ See the complete bank account implementation in the [miden-bank repository](http
 
 ## Next Steps
 
-Now that you understand account components and storage, let's learn how to define business rules with [Part 2: Constants and Constraints](./02-constants-constraints).
+Now that you understand account components and storage, let's learn how to define business rules with [Part 2: Constants and Constraints](./constants-constraints).

--- a/docs/builder/develop/tutorials/rust-compiler/miden-bank/02-constants-constraints.md
+++ b/docs/builder/develop/tutorials/rust-compiler/miden-bank/02-constants-constraints.md
@@ -442,4 +442,4 @@ See the complete constraint implementation in the [miden-bank repository](https:
 
 ## Next Steps
 
-Now that you can define and enforce business rules, let's learn how to handle assets in [Part 3: Asset Management](./03-asset-management).
+Now that you can define and enforce business rules, let's learn how to handle assets in [Part 3: Asset Management](./asset-management).

--- a/docs/builder/develop/tutorials/rust-compiler/miden-bank/03-asset-management.md
+++ b/docs/builder/develop/tutorials/rust-compiler/miden-bank/03-asset-management.md
@@ -607,4 +607,4 @@ See the complete deposit and withdraw implementations in the [miden-bank reposit
 
 ## Next Steps
 
-Now that you understand asset management, let's learn how to trigger these operations with [Part 4: Note Scripts](./04-note-scripts).
+Now that you understand asset management, let's learn how to trigger these operations with [Part 4: Note Scripts](./note-scripts).

--- a/docs/builder/develop/tutorials/rust-compiler/miden-bank/04-note-scripts.md
+++ b/docs/builder/develop/tutorials/rust-compiler/miden-bank/04-note-scripts.md
@@ -517,4 +517,4 @@ See the complete note script implementations:
 
 ## Next Steps
 
-Now that you understand note scripts, let's learn how they call account methods in [Part 5: Cross-Component Calls](./05-cross-component-calls).
+Now that you understand note scripts, let's learn how they call account methods in [Part 5: Cross-Component Calls](./cross-component-calls).

--- a/docs/builder/develop/tutorials/rust-compiler/miden-bank/05-cross-component-calls.md
+++ b/docs/builder/develop/tutorials/rust-compiler/miden-bank/05-cross-component-calls.md
@@ -281,4 +281,4 @@ See the complete Cargo.toml configurations:
 
 ## Next Steps
 
-Now that you understand cross-component calls, let's create the transaction script that initializes the bank in [Part 6: Transaction Scripts](./06-transaction-scripts).
+Now that you understand cross-component calls, let's create the transaction script that initializes the bank in [Part 6: Transaction Scripts](./transaction-scripts).

--- a/docs/builder/develop/tutorials/rust-compiler/miden-bank/06-transaction-scripts.md
+++ b/docs/builder/develop/tutorials/rust-compiler/miden-bank/06-transaction-scripts.md
@@ -474,4 +474,4 @@ See the complete transaction script implementation in the [miden-bank repository
 
 ## Next Steps
 
-Now that you understand transaction scripts, let's learn the advanced topic of creating output notes in [Part 7: Creating Output Notes](./07-output-notes).
+Now that you understand transaction scripts, let's learn the advanced topic of creating output notes in [Part 7: Creating Output Notes](./output-notes).

--- a/docs/builder/develop/tutorials/rust-compiler/miden-bank/07-output-notes.md
+++ b/docs/builder/develop/tutorials/rust-compiler/miden-bank/07-output-notes.md
@@ -252,7 +252,7 @@ impl Bank {
 | `inputs` | Script inputs (account ID for P2ID) |
 
 :::warning Array Ordering
-Note the order: `suffix` comes before `prefix`. This is the opposite of how `AccountId` fields are typically accessed. See [Common Pitfalls](../../pitfalls#array-ordering-rustmasm-reversal) for details.
+Note the order: `suffix` comes before `prefix`. This is the opposite of how `AccountId` fields are typically accessed. See [Common Pitfalls](../pitfalls#array-ordering-rustmasm-reversal) for details.
 :::
 
 ### Understanding output_note::create()
@@ -753,4 +753,4 @@ See the complete implementation in the [miden-bank repository](https://github.co
 
 ## Next Steps
 
-Now that you've built all the components, let's see how they work together in [Part 8: Complete Flows](./08-complete-flows).
+Now that you've built all the components, let's see how they work together in [Part 8: Complete Flows](./complete-flows).

--- a/docs/builder/develop/tutorials/rust-compiler/miden-bank/index.md
+++ b/docs/builder/develop/tutorials/rust-compiler/miden-bank/index.md
@@ -32,15 +32,15 @@ This tutorial is designed for hands-on learning. Each part builds on the previou
 
 | Part | Topic | What You'll Build |
 |------|-------|-------------------|
-| **Part 0** | [Project Setup](./00-project-setup) | Create project with `miden new` |
-| **Part 1** | [Account Components](./01-account-components) | Bank struct with storage |
-| **Part 2** | [Constants & Constraints](./02-constants-constraints) | Business rules and validation |
-| **Part 3** | [Asset Management](./03-asset-management) | Deposit logic with balance tracking |
-| **Part 4** | [Note Scripts](./04-note-scripts) | Deposit note for receiving assets |
-| **Part 5** | [Cross-Component Calls](./05-cross-component-calls) | How bindings enable calls |
-| **Part 6** | [Transaction Scripts](./06-transaction-scripts) | Initialization script |
-| **Part 7** | [Output Notes](./07-output-notes) | Withdraw with P2ID output |
-| **Part 8** | [Complete Flows](./08-complete-flows) | End-to-end verification |
+| **Part 0** | [Project Setup](./project-setup) | Create project with `miden new` |
+| **Part 1** | [Account Components](./account-components) | Bank struct with storage |
+| **Part 2** | [Constants & Constraints](./constants-constraints) | Business rules and validation |
+| **Part 3** | [Asset Management](./asset-management) | Deposit logic with balance tracking |
+| **Part 4** | [Note Scripts](./note-scripts) | Deposit note for receiving assets |
+| **Part 5** | [Cross-Component Calls](./cross-component-calls) | How bindings enable calls |
+| **Part 6** | [Transaction Scripts](./transaction-scripts) | Initialization script |
+| **Part 7** | [Output Notes](./output-notes) | Withdraw with P2ID output |
+| **Part 8** | [Complete Flows](./complete-flows) | End-to-end verification |
 
 ## Tutorial Cards
 
@@ -51,7 +51,7 @@ import DocCard from '@theme/DocCard';
     <DocCard
       item={{
         type: 'link',
-        href: './00-project-setup',
+        href: './project-setup',
         label: 'Part 0: Project Setup',
         description: 'Create your project with miden new and understand the workspace structure.',
       }}
@@ -61,7 +61,7 @@ import DocCard from '@theme/DocCard';
     <DocCard
       item={{
         type: 'link',
-        href: './01-account-components',
+        href: './account-components',
         label: 'Part 1: Account Components',
         description: 'Learn #[component], Value storage, and StorageMap for managing state.',
       }}
@@ -74,7 +74,7 @@ import DocCard from '@theme/DocCard';
     <DocCard
       item={{
         type: 'link',
-        href: './02-constants-constraints',
+        href: './constants-constraints',
         label: 'Part 2: Constants & Constraints',
         description: 'Define business rules with constants and validate with assertions.',
       }}
@@ -84,7 +84,7 @@ import DocCard from '@theme/DocCard';
     <DocCard
       item={{
         type: 'link',
-        href: './03-asset-management',
+        href: './asset-management',
         label: 'Part 3: Asset Management',
         description: 'Handle fungible assets with vault operations and balance tracking.',
       }}
@@ -97,7 +97,7 @@ import DocCard from '@theme/DocCard';
     <DocCard
       item={{
         type: 'link',
-        href: './04-note-scripts',
+        href: './note-scripts',
         label: 'Part 4: Note Scripts',
         description: 'Write scripts that execute when notes are consumed.',
       }}
@@ -107,7 +107,7 @@ import DocCard from '@theme/DocCard';
     <DocCard
       item={{
         type: 'link',
-        href: './05-cross-component-calls',
+        href: './cross-component-calls',
         label: 'Part 5: Cross-Component Calls',
         description: 'Call account methods from note scripts via bindings.',
       }}
@@ -120,7 +120,7 @@ import DocCard from '@theme/DocCard';
     <DocCard
       item={{
         type: 'link',
-        href: './06-transaction-scripts',
+        href: './transaction-scripts',
         label: 'Part 6: Transaction Scripts',
         description: 'Write scripts for account initialization and owner operations.',
       }}
@@ -130,7 +130,7 @@ import DocCard from '@theme/DocCard';
     <DocCard
       item={{
         type: 'link',
-        href: './07-output-notes',
+        href: './output-notes',
         label: 'Part 7: Creating Output Notes',
         description: 'Create P2ID notes programmatically for withdrawals.',
       }}
@@ -143,7 +143,7 @@ import DocCard from '@theme/DocCard';
     <DocCard
       item={{
         type: 'link',
-        href: './08-complete-flows',
+        href: './complete-flows',
         label: 'Part 8: Complete Flows',
         description: 'Walk through end-to-end deposit and withdraw operations.',
       }}
@@ -155,7 +155,7 @@ import DocCard from '@theme/DocCard';
 
 Before starting this tutorial, ensure you have:
 
-- Completed the [Quick Start guide](../../../quick-start/) (familiarity with `midenup`, `miden new`, basic tooling)
+- Completed the [Quick Start guide](../../../../quick-start/) (familiarity with `midenup`, `miden new`, basic tooling)
 - Basic understanding of Miden concepts (accounts, notes, transactions)
 - Rust programming experience
 
@@ -192,9 +192,9 @@ cd miden-bank
 
 These standalone guides complement the tutorial:
 
-- **[Testing with MockChain](../../testing)** - Learn to test your contracts
-- **[Debugging](../../debugging)** - Troubleshoot common issues
-- **[Common Pitfalls](../../pitfalls)** - Avoid known gotchas
+- **[Testing with MockChain](../testing)** - Learn to test your contracts
+- **[Debugging](../debugging)** - Troubleshoot common issues
+- **[Common Pitfalls](../pitfalls)** - Avoid known gotchas
 
 ## Getting Help
 
@@ -204,4 +204,4 @@ If you get stuck during this tutorial:
 - Join the [Build On Miden](https://t.me/BuildOnMiden) Telegram community for support
 - Review the complete code in the [miden-bank repository](https://github.com/keinberger/miden-bank)
 
-Ready to build your first Miden banking application? Let's get started with [Part 0: Project Setup](./00-project-setup)!
+Ready to build your first Miden banking application? Let's get started with [Part 0: Project Setup](./project-setup)!


### PR DESCRIPTION
## Summary

Fixes broken internal links across the Miden Bank tutorial series. Docusaurus strips numeric prefixes (`00-`, `01-`, etc.) from slugs during routing, but the markdown links were using the full filenames.

## Changes

- **Parts 00–07 "Next Steps" links**: `./01-account-components` → `./account-components`, etc.
- **`index.md` table & DocCard hrefs**: same numeric prefix removal
- **`index.md` relative paths**: fixed depth for `quick-start`, `testing`, `debugging`, `pitfalls` links (were off by one level)
- **`07-output-notes.md`**: fixed pitfalls link depth

## Files Changed (9)

All under `docs/builder/develop/tutorials/rust-compiler/miden-bank/`:
- `00-project-setup.md` through `07-output-notes.md`
- `index.md`

## Verification

- `npm run build` passes cleanly with no broken link warnings.