### PR TITLE
docs: minor typo correction in the code

### DIFF
--- a/docs/builder/quick-start/your-first-smart-contract/test.md
+++ b/docs/builder/quick-start/your-first-smart-contract/test.md
@@ -235,7 +235,7 @@ let mut mock_chain = builder.build()?;
 ### 5. Creating and Executing the Transaction
 
 ```rust
-let tx_context = mock_chain.
+let tx_context = mock_chain
     .build_tx_context(counter_account.id(), &[counter_note.id()], &[])?
     .build()?;
 


### PR DESCRIPTION
Section `“5. Creating and Executing the Transaction”` contains the following fragment: `let tx_context = mock_chain.\n .build_tx_context(...)` In Rust, this results in an invalid chain of calls `mock_chain..build_tx_context`.

Removed the period, now the example looks like this: `mock_chain.build_tx_context`