### PR TITLE
docs: add MASM named storage slot examples and word() syntax

### DIFF
--- a/versioned_docs/version-0.13/builder/migration/02-account-changes.md
+++ b/versioned_docs/version-0.13/builder/migration/02-account-changes.md
@@ -42,7 +42,37 @@ Replace index-based storage access with `StorageSlotName` identifiers.
 + account.storage_mut().set_slot(&slot_name, new_value)?;
 ```
 
-### MASM Updates
+### MASM
+
+In MASM, use the `word("...")` syntax to define named storage slot constants. The `word()` function hashes the slot name to produce a `Word`, and you extract the slot ID using `[0..2]` slice notation:
+
+```diff title="src/contract.masm"
+- # Before (v0.12): index-based storage access
+- use.miden::account
+- const.MY_SLOT=0
+- push.MY_SLOT
+- exec.account::get_item
+
++ # After (v0.13): name-based storage access
++ use miden::protocol::active_account
++ const MY_SLOT = word("my_project::my_component::my_slot")
++ push.MY_SLOT[0..2]
++ exec.active_account::get_item
++ # => [VALUE]
+```
+
+Writing to storage follows the same pattern:
+
+```masm title="src/contract.masm"
+use miden::protocol::native_account
+
+const MY_SLOT = word("my_project::my_component::my_slot")
+
+# Set a value in the slot
+push.MY_SLOT[0..2]
+exec.native_account::set_item
+# => [OLD_VALUE]
+```
 
 The `set_map_item` procedure now takes slot IDs and returns only old values:
 
@@ -52,13 +82,15 @@ The `set_map_item` procedure now takes slot IDs and returns only old values:
 - # Returns: [OLD_MAP_ROOT, OLD_VALUE, ...]
 
 + # After
-+ exec.account::set_map_item
++ exec.native_account::set_map_item
 + # Returns: [OLD_VALUE, ...]
 ```
 
 :::info Good to know
 The return value change means you may need to update stack manipulation after calling `set_map_item`.
 :::
+
+For details on the `word("...")` syntax, see the [MASM Changes](06-masm-changes.md#named-storage-slots) migration page. For the full list of storage procedures, see the [Protocol Library Reference](../../design/miden-base/protocol_library.md).
 
 ---
 

--- a/versioned_docs/version-0.13/design/miden-vm/user_docs/assembly/code_organization.md
+++ b/versioned_docs/version-0.13/design/miden-vm/user_docs/assembly/code_organization.md
@@ -270,6 +270,23 @@ begin
 end
 ```
 
+#### Word constants from strings
+
+A word constant can also be derived from a string using the `word("...")` syntax. This computes a deterministic `Word` by hashing the provided string with Blake3 and mapping the result to four field elements:
+
+```
+const MY_IDENTIFIER = word("my_project::my_module::my_name")
+
+begin
+    push.MY_IDENTIFIER       # pushes all 4 elements of the derived word
+    push.MY_IDENTIFIER[0..2] # pushes only the first 2 elements (slice notation)
+end
+```
+
+The `word("...")` constructor can be combined with [slice notation](#constant-slices) just like array-based word constants. This is commonly used for named storage slot IDs in Miden account programs.
+
+Similarly, the `event("...")` syntax derives a single field element from a string, for use with `emit` instructions.
+
 ### Types
 
 Miden Assembly supports types for the purpose of specifying the _type signature_ of a procedure. This is used by other tooling in the Miden toolchain to bind against procedures written in Miden Assembly from higher-level languages, e.g. Rust. The type system is low-level and structural, but some conveniences are provided in Miden Assembly to improve ergonomics and aid in the construction of future static analyses.


### PR DESCRIPTION
## Summary

- Add "Named Storage Slots" section to `06-masm-changes.md` with diff showing index-based → name-based MASM migration using `word("...")` and `[0..2]` slice notation
- Expand MASM section in `02-account-changes.md` with full read/write/set_map_item examples using `active_account` and `native_account` procedures
- Update the "Complete MASM Migration Example" to use `word("...")`, `active_account::get_item`, and `rpo256::hash_words`
- Document `word("...")` and `event("...")` constant constructors in the VM assembly `code_organization.md` reference

Fixes #157

Upstream: 0xMiden/miden-vm#2688