### PR TITLE
docs: add macOS build prerequisites to v0.13 snapshot

### DIFF
--- a/versioned_docs/version-0.13/builder/develop/tutorials/miden_node_setup.md
+++ b/versioned_docs/version-0.13/builder/develop/tutorials/miden_node_setup.md
@@ -14,9 +14,19 @@ There are two ways to connect to a Miden node:
 
 ## Running the Miden node locally
 
+:::tip[Prerequisites]
+Building the node from source requires a C/C++ toolchain (for compiling RocksDB). On **macOS**, make sure you have the Xcode Command Line Tools installed:
+
+```bash
+xcode-select --install
+```
+
+On **Ubuntu**, see the [node installation page](../../../design/miden-node/operator/installation.md#install-using-cargo) for the required packages. If you run into `'cstdint' file not found` errors on macOS, see the [troubleshooting section](../../../design/miden-node/operator/installation.md#install-using-cargo) on the installation page.
+:::
+
 ### Step 1: Install the Miden node
 
-Next, install the miden-node crate using this command:
+Install the miden-node crate using this command:
 
 ```bash
 cargo install miden-node --locked --version 0.13.0

--- a/versioned_docs/version-0.13/design/miden-node/operator/installation.md
+++ b/versioned_docs/version-0.13/design/miden-node/operator/installation.md
@@ -39,6 +39,18 @@ command ensures that all required libraries are installed.
 sudo apt install llvm clang bindgen pkg-config libssl-dev libsqlite3-dev
 ```
 
+On macOS, ensure the Xcode Command Line Tools are installed:
+
+```sh
+xcode-select --install
+```
+
+If you still see `'cstdint' file not found` errors after installing the Command Line Tools (common after a macOS upgrade), try setting the SDK root explicitly:
+
+```sh
+export SDKROOT="$(xcrun --sdk macosx --show-sdk-path)"
+```
+
 Install the latest node binary:
 
 ```sh


### PR DESCRIPTION
Backport macOS prerequisites to the frozen v0.13 snapshot (upstream fixes won't flow in automatically).

- `installation.md`: add `xcode-select --install` + `SDKROOT` troubleshooting
- `miden_node_setup.md`: add prerequisites tip with cross-reference

Closes #159

Upstream: 0xMiden/miden-node#1671, 0xMiden/miden-tutorials#161