### PR TITLE
docs: add miden mint command to CLI basics

### DIFF
--- a/docs/builder/quick-start/setup/cli-basics.md
+++ b/docs/builder/quick-start/setup/cli-basics.md
@@ -126,7 +126,7 @@ miden mint --target-account <ACCOUNT_ID> --amount 1000
 
 This sends a mint request to the [public testnet faucet](https://faucet-api.testnet.miden.io) and automatically consumes the resulting note, depositing the tokens into your account.
 
-Verify your balance:
+Display your balance:
 
 ```bash title=">_ Terminal"
 miden client sync

--- a/versioned_docs/version-0.13/builder/quick-start/setup/cli-basics.md
+++ b/versioned_docs/version-0.13/builder/quick-start/setup/cli-basics.md
@@ -126,7 +126,7 @@ miden mint --target-account <ACCOUNT_ID> --amount 1000
 
 This sends a mint request to the [public testnet faucet](https://faucet-api.testnet.miden.io) and automatically consumes the resulting note, depositing the tokens into your account.
 
-Verify your balance:
+Display your balance:
 
 ```bash title=">_ Terminal"
 miden client sync


### PR DESCRIPTION
## Summary

- Adds a "Mint Your First Tokens" section to the CLI Basics quick-start guide
- Documents the `miden mint` command for requesting tokens from the public testnet faucet

Closes #166