### PR TITLE
fix: update account ID size from 64-bit to 120-bit

### DIFF
--- a/docs/design/index.md
+++ b/docs/design/index.md
@@ -48,7 +48,7 @@ The protocol layer defines Miden's data structures, state model, and transaction
 
 Accounts are programmable entities that hold assets and execute code:
 
-- **ID** – Unique 64-bit identifier derived from initial code and storage
+- **ID** – Unique 120-bit identifier derived from initial code and storage
 - **Code** – Immutable smart contract logic defining the account's interface
 - **Storage** – Key-value store with up to 256 slots for persistent data
 - **Vault** – Container holding fungible and non-fungible assets


### PR DESCRIPTION
## Description:
Corrected a discrepancy in the documentation: the account ID size is specified as 64-bit, although the current specification uses 120-bit.

## Problem: 

`docs/design/index.md (line 51)` specifies a 64-bit Account ID, which contradicts:
- docs/builder/quick-start/accounts.md:52 (120-bit)
- docs/builder/quick-start/setup/cli-basics.md:95 (120-bit) 
- all current v0.12 documentation

## Changes: 

Replaced “64-bit” with “120-bit” in the Account ID description.