### PR TITLE
fix: move note-types.md from develop/ to smart-contracts/notes/

### DIFF
--- a/docs/builder/smart-contracts/notes/introduction.md
+++ b/docs/builder/smart-contracts/notes/introduction.md
@@ -63,7 +63,7 @@ Notes come in two visibility modes:
 
 Private notes provide stronger privacy guarantees — the network can't even see what assets a note carries — but they require the sender and recipient to have a communication channel outside the protocol.
 
-Miden provides built-in note patterns (P2ID, P2IDE, SWAP) for common transfer scenarios — see [Standard Note Types](../../develop/note-types). You can also write fully custom note scripts for arbitrary consumption logic.
+Miden provides built-in note patterns (P2ID, P2IDE, SWAP) for common transfer scenarios — see [Standard Note Types](./note-types). You can also write fully custom note scripts for arbitrary consumption logic.
 
 ## How notes differ from EVM transfers
 

--- a/docs/builder/smart-contracts/notes/note-types.md
+++ b/docs/builder/smart-contracts/notes/note-types.md
@@ -155,8 +155,8 @@ create_swap_note(
 
 Returns a tuple of `(Note, NoteDetails)` — the SWAP note to submit and the expected payback note details (for tracking).
 
-`NoteAttachment` is defined in the `miden-standards` crate (not the core `miden` SDK). It wraps the attachment data that gets set on output notes — see [note attachments](../smart-contracts/notes/output-notes#note-attachments) for the underlying SDK API.
+`NoteAttachment` is defined in the `miden-standards` crate (not the core `miden` SDK). It wraps the attachment data that gets set on output notes — see [note attachments](./output-notes#note-attachments) for the underlying SDK API.
 
 ## More note types
 
-For writing custom note scripts, see [Note Scripts](../smart-contracts/notes/note-scripts). For the transaction context and `#[tx_script]`, see [Transaction Context](../smart-contracts/transactions/transaction-context).
+For writing custom note scripts, see [Note Scripts](./note-scripts). For the transaction context and `#[tx_script]`, see [Transaction Context](../transactions/transaction-context).

--- a/versioned_docs/version-0.13/builder/smart-contracts/notes/introduction.md
+++ b/versioned_docs/version-0.13/builder/smart-contracts/notes/introduction.md
@@ -63,7 +63,7 @@ Notes come in two visibility modes:
 
 Private notes provide stronger privacy guarantees — the network can't even see what assets a note carries — but they require the sender and recipient to have a communication channel outside the protocol.
 
-Miden provides built-in note patterns (P2ID, P2IDE, SWAP) for common transfer scenarios — see [Standard Note Types](../../develop/note-types). You can also write fully custom note scripts for arbitrary consumption logic.
+Miden provides built-in note patterns (P2ID, P2IDE, SWAP) for common transfer scenarios — see [Standard Note Types](./note-types). You can also write fully custom note scripts for arbitrary consumption logic.
 
 ## How notes differ from EVM transfers
 

--- a/versioned_docs/version-0.13/builder/smart-contracts/notes/note-types.md
+++ b/versioned_docs/version-0.13/builder/smart-contracts/notes/note-types.md
@@ -155,8 +155,8 @@ create_swap_note(
 
 Returns a tuple of `(Note, NoteDetails)` — the SWAP note to submit and the expected payback note details (for tracking).
 
-`NoteAttachment` is defined in the `miden-standards` crate (not the core `miden` SDK). It wraps the attachment data that gets set on output notes — see [note attachments](../smart-contracts/notes/output-notes#note-attachments) for the underlying SDK API.
+`NoteAttachment` is defined in the `miden-standards` crate (not the core `miden` SDK). It wraps the attachment data that gets set on output notes — see [note attachments](./output-notes#note-attachments) for the underlying SDK API.
 
 ## More note types
 
-For writing custom note scripts, see [Note Scripts](../smart-contracts/notes/note-scripts). For the transaction context and `#[tx_script]`, see [Transaction Context](../smart-contracts/transactions/transaction-context).
+For writing custom note scripts, see [Note Scripts](./note-scripts). For the transaction context and `#[tx_script]`, see [Transaction Context](../transactions/transaction-context).


### PR DESCRIPTION
note-types.md documents standard note types (P2ID, P2IDE, SWAP) from the miden-standards crate. It belongs alongside other notes docs in builder/smart-contracts/notes/, not in builder/develop/.

Updated all internal relative links in note-types.md and introduction.md for both docs/ and versioned_docs/version-0.13/.