### PR TITLE
docs: update stale miden-vm version in dependency diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ flowchart TD
 
     %% External repos feed into both workflows
     MidenBase -->|"ingested @v0.12.3"| CutVersions
-    MidenVM -->|"ingested @v0.19.1"| CutVersions
+    MidenVM -->|"ingested @v0.20.0"| CutVersions
     MidenNode -->|"ingested @v0.12.3"| CutVersions
     Compiler -->|"ingested @0.5.1"| CutVersions
     MidenClient -->|"ingested @v0.12.3"| CutVersions

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ MidenVM -->|"ingested @<release-tag>"| CutVersions
 MidenNode -->|"ingested @<release-tag>"| CutVersions
 Compiler -->|"ingested @<release-tag>"| CutVersions
 MidenClient -->|"ingested @<release-tag>"| CutVersions
-    MidenTutorials -->|"ingested @main"| CutVersions
+    MidenTutorials -->|"ingested @<release-tag>"| CutVersions
 
     MidenBase -->|"ingested @next"| DeployDocs
     MidenVM -->|"ingested @next"| DeployDocs

--- a/README.md
+++ b/README.md
@@ -60,11 +60,11 @@ flowchart TD
     DeployDocs["CICD deploy-docs.yml<br/>(ingest + build)"]
 
     %% External repos feed into both workflows
-    MidenBase -->|"ingested @v0.12.3"| CutVersions
-    MidenVM -->|"ingested @v0.20.0"| CutVersions
-    MidenNode -->|"ingested @v0.12.3"| CutVersions
-    Compiler -->|"ingested @0.6.0"| CutVersions
-    MidenClient -->|"ingested @v0.12.3"| CutVersions
+    MidenBase -->|"ingested @<release-tag>"| CutVersions
+MidenVM -->|"ingested @<release-tag>"| CutVersions
+MidenNode -->|"ingested @<release-tag>"| CutVersions
+Compiler -->|"ingested @<release-tag>"| CutVersions
+MidenClient -->|"ingested @<release-tag>"| CutVersions
     MidenTutorials -->|"ingested @main"| CutVersions
 
     MidenBase -->|"ingested @next"| DeployDocs

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ flowchart TD
     MidenBase -->|"ingested @v0.12.3"| CutVersions
     MidenVM -->|"ingested @v0.20.0"| CutVersions
     MidenNode -->|"ingested @v0.12.3"| CutVersions
-    Compiler -->|"ingested @0.5.1"| CutVersions
+    Compiler -->|"ingested @0.6.0"| CutVersions
     MidenClient -->|"ingested @v0.12.3"| CutVersions
     MidenTutorials -->|"ingested @main"| CutVersions
 


### PR DESCRIPTION
The dependency diagram references miden-vm v0.19.1 but the release manifest example and latest release is v0.20.0. Updated for consistency.