### PR TITLE
docs: rename quick-start to get-started and fix sidebar overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ The build uses:
 - **Never** manually copy external content into `docs/` (use CI/CD ingestion)
 - **Never** create root-level `docs/miden-base/`, `docs/miden-vm/`, etc. (use nested paths in `docs/core-concepts/`)
 - **Never** edit `versioned_docs/` directly (snapshots are immutable)
-- **Never** create a root-level `docs/quick-start/` (Get Started lives in `docs/builder/`)
+- **Never** create a root-level `docs/quick-start/` or `docs/get-started/` (Get Started lives in `docs/builder/`)
 
 ### Quick Reference
 
@@ -253,6 +253,6 @@ The site uses **Simple Analytics** for privacy-first, cookie-less metrics.
 ### Updating llms.txt
 
 Edit `static/llms.txt` directly. Content should:
-- List canonical entry points (Get Started, Builder, Design)
+- List canonical entry points (Get Started, Builder, Core Concepts)
 - Use relative paths (`/builder/get-started/`)
 - Avoid "Polygon Miden" branding (use "Miden" only)

--- a/docs/builder/migration/index.md
+++ b/docs/builder/migration/index.md
@@ -35,7 +35,7 @@ This guide is for:
 - **App developers** using `miden-objects`, `miden-lib`, or legacy MASM syntax
 - **Smart contract authors** using storage slots or note APIs
 
-If you're starting fresh on v0.13, you can skip this guide and go directly to the [Get Started guide](../get-started).
+If you're starting fresh on v0.13, you can skip this guide and go directly to the [Get Started](../get-started) guide.
 :::
 
 ---

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -97,6 +97,7 @@ const config: Config = {
             redirects.push("/intro");
           }
           if (existingPath.startsWith("/builder/get-started")) {
+            // Redirect old quick-start paths to new get-started paths
             redirects.push(existingPath.replace("/builder/get-started", "/quick-start"));
             redirects.push(existingPath.replace("/builder/get-started", "/builder/quick-start"));
           }

--- a/src/custom/_sidebar.css
+++ b/src/custom/_sidebar.css
@@ -342,3 +342,51 @@ aside[class*="docSidebarContainer"] .menu__caret {
 .navbar-sidebar .menu__list-item-collapsible {
   border-radius: var(--radius-md);
 }
+
+/* ==========================================
+   4.6) SIDEBAR OVERFLOW HANDLING
+   Fixes #170 - long titles overflow in sidebar
+   ========================================== */
+
+/* Ensure sidebar container clips overflow */
+aside[class*="docSidebarContainer"] {
+  overflow-x: hidden;
+}
+
+/* Main menu element clips content */
+aside[class*="docSidebarContainer"] .menu {
+  overflow-x: hidden;
+}
+
+/* Menu links handle long text gracefully */
+.theme-doc-sidebar-menu .menu__link {
+  /* Allow natural word wrapping for better readability */
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  hyphens: auto;
+  /* Prevent horizontal overflow */
+  max-width: 100%;
+}
+
+/* Handle code elements within sidebar links */
+.theme-doc-sidebar-menu .menu__link code {
+  /* Prevent code from causing overflow */
+  word-break: break-all;
+  white-space: normal;
+  /* Reduce code styling in sidebar for compactness */
+  font-size: 0.9em;
+  padding: 0.1em 0.3em;
+}
+
+/* Category labels also need overflow handling */
+.menu__list-item-collapsible > .menu__link {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  /* Single line truncation for category headers */
+  white-space: nowrap;
+}
+
+/* But leaf items (actual page links) can wrap to multiple lines */
+.theme-doc-sidebar-item-link .menu__link {
+  white-space: normal;
+}

--- a/versioned_docs/version-0.13/builder/migration/index.md
+++ b/versioned_docs/version-0.13/builder/migration/index.md
@@ -35,7 +35,7 @@ This guide is for:
 - **App developers** using `miden-objects`, `miden-lib`, or legacy MASM syntax
 - **Smart contract authors** using storage slots or note APIs
 
-If you're starting fresh on v0.13, you can skip this guide and go directly to the [Get Started](../get-started).
+If you're starting fresh on v0.13, you can skip this guide and go directly to the [Get Started](../get-started) guide.
 :::
 
 ---


### PR DESCRIPTION
## Summary

This PR addresses two documentation issues:

### Issue #191: Rename quick-start to get-started

Renamed 'Quick Start' section to 'Get Started' to align with naming conventions used by other protocols (Aptos, Sui, Starknet).

**Changes:**
- Renamed \docs/builder/quick-start/\  \docs/builder/get-started/\
- Renamed \ersioned_docs/version-0.13/builder/quick-start/\  \get-started/\
- Updated all \_category_.json\ files with new labels and doc IDs
- Updated \sidebars.ts\ with new paths
- Updated all internal links across:
  - \docs/builder/index.md\
  - \docs/core-concepts/index.md\
  - \docs/builder/migration/index.md\
  - \docs/builder/tutorials/rust-compiler/*.md\
  - \static/llms.txt\
  - \CLAUDE.md\
  - \README.md\
- Added redirects in \docusaurus.config.ts\ for backward compatibility:
  - \/quick-start/*\  \/builder/get-started/*\
  - \/builder/quick-start/*\  \/builder/get-started/*\

v0.11 and v0.12 snapshots left unchanged (historical).

### Issue #170: Sidebar CSS overflow for long titles

Long titles in the smart-contracts section were overflowing the sidebar container.

**Changes (src/custom/_sidebar.css):**
- Added \overflow-x: hidden\ to sidebar container and menu
- Category labels truncate with ellipsis (single line)
- Leaf item links wrap naturally for better readability
- Code elements in sidebar use \reak-all\ to prevent overflow
- Added \word-wrap\, \overflow-wrap\ and \hyphens\ for graceful text handling

## Test Plan

- [ ] Build passes with \
pm run build\
- [ ] Redirects work for old quick-start URLs
- [ ] Sidebar displays correctly with long titles
- [ ] All internal links resolve correctly

Fixes #191
Fixes #170