### PR TITLE
fix: update references to renamed repositories

### DIFF
--- a/.github/workflows/cut-versions.yml
+++ b/.github/workflows/cut-versions.yml
@@ -3,8 +3,8 @@
 # This workflow ingests external repos and creates versioned snapshots.
 #
 # v0.4 Information Architecture:
-#   - Core Concepts docs (miden-base, miden-vm, compiler, miden-node) → docs/core-concepts/
-#   - Builder docs (miden-tutorials, miden-client) → docs/builder/tutorials/, docs/builder/tools/client/
+#   - Core Concepts docs (protocol, miden-vm, compiler, node) → docs/core-concepts/
+#   - Builder docs (tutorials, miden-client) → docs/builder/tutorials/, docs/builder/tools/client/
 #
 # Workflow responsibilities:
 #   1. Check out external repos at pinned refs
@@ -47,12 +47,12 @@ jobs:
   cut:
     runs-on: ubuntu-latest
     env:
-      REPO_NODE: 0xMiden/miden-node
+      REPO_NODE: 0xMiden/node
       REPO_VM: 0xMiden/miden-vm
-      REPO_BASE: 0xMiden/miden-base
+      REPO_BASE: 0xMiden/protocol
       REPO_CLIENT: 0xMiden/miden-client
       REPO_COMPILER: 0xMiden/compiler
-      REPO_TUTORIALS: 0xMiden/miden-tutorials
+      REPO_TUTORIALS: 0xMiden/tutorials
     steps:
       - name: Checkout aggregator
         uses: actions/checkout@v4
@@ -88,12 +88,12 @@ jobs:
           // Build outputs
           const out = {
             version_label: inputs.version_label || (m.version || '').trim(),
-            miden_node_ref:      getRef(process.env.INPUT_MIDEN_NODE_REF,      refs['miden-node']),
+            miden_node_ref:      getRef(process.env.INPUT_MIDEN_NODE_REF,      refs['node']),
             miden_vm_ref:        getRef(process.env.INPUT_MIDEN_VM_REF,        refs['miden-vm']),
-            miden_base_ref:      getRef(process.env.INPUT_MIDEN_BASE_REF,      refs['miden-base']),
+            miden_base_ref:      getRef(process.env.INPUT_MIDEN_BASE_REF,      refs['protocol']),
             miden_client_ref:    getRef(process.env.INPUT_MIDEN_CLIENT_REF,    refs['miden-client']),
             compiler_ref:  getRef(process.env.INPUT_COMPILER_REF,  refs['compiler']),
-            miden_tutorials_ref: getRef(process.env.INPUT_MIDEN_TUTORIALS_REF, refs['miden-tutorials']),
+            miden_tutorials_ref: getRef(process.env.INPUT_MIDEN_TUTORIALS_REF, refs['tutorials']),
           };
 
           if (!out.version_label) {
@@ -134,12 +134,12 @@ jobs:
             git clone "https://github.com/$repo" "$path"
             (cd "$path" && git fetch --depth 1 origin "$ref" && git checkout "$ref")
           }
-          checkout_ref "${REPO_NODE}"      "${{ steps.manifest.outputs.miden_node_ref }}"      vendor/miden-node
+          checkout_ref "${REPO_NODE}"      "${{ steps.manifest.outputs.miden_node_ref }}"      vendor/node
           checkout_ref "${REPO_VM}"        "${{ steps.manifest.outputs.miden_vm_ref }}"        vendor/miden-vm
-          checkout_ref "${REPO_BASE}"      "${{ steps.manifest.outputs.miden_base_ref }}"      vendor/miden-base
+          checkout_ref "${REPO_BASE}"      "${{ steps.manifest.outputs.miden_base_ref }}"      vendor/protocol
           checkout_ref "${REPO_CLIENT}"    "${{ steps.manifest.outputs.miden_client_ref }}"    vendor/miden-client
           checkout_ref "${REPO_COMPILER}"  "${{ steps.manifest.outputs.compiler_ref }}"  vendor/compiler
-          checkout_ref "${REPO_TUTORIALS}" "${{ steps.manifest.outputs.miden_tutorials_ref }}" vendor/miden-tutorials
+          checkout_ref "${REPO_TUTORIALS}" "${{ steps.manifest.outputs.miden_tutorials_ref }}" vendor/tutorials
 
       # ============================================================
       # v0.4 IA: Aggregate into nested structure (TEMPORARY)
@@ -150,15 +150,15 @@ jobs:
           echo "Aggregating vendor docs into v0.4 IA structure..."
 
           # Clean directories that will be re-synced (v0.4 nested paths)
-          rm -rf docs/core-concepts/miden-base docs/core-concepts/miden-vm docs/core-concepts/miden-node docs/core-concepts/compiler
+          rm -rf docs/core-concepts/protocol docs/core-concepts/miden-vm docs/core-concepts/node docs/core-concepts/compiler
           rm -rf docs/builder/tools/client
           # Note: docs/builder/tutorials is NOT fully cleaned to preserve local tutorials (e.g. miden-bank)
 
           # Core Concepts docs → docs/core-concepts/*
-          if [ -d "vendor/miden-base/docs/src" ]; then
-            mkdir -p docs/core-concepts/miden-base
-            cp -r vendor/miden-base/docs/src/* docs/core-concepts/miden-base/
-            echo "Synced miden-base → docs/core-concepts/miden-base"
+          if [ -d "vendor/protocol/docs/src" ]; then
+            mkdir -p docs/core-concepts/protocol
+            cp -r vendor/protocol/docs/src/* docs/core-concepts/protocol/
+            echo "Synced protocol → docs/core-concepts/protocol"
           fi
 
           if [ -d "vendor/miden-vm/docs/src" ]; then
@@ -167,10 +167,10 @@ jobs:
             echo "Synced miden-vm → docs/core-concepts/miden-vm"
           fi
 
-          if [ -d "vendor/miden-node/docs/external/src" ]; then
-            mkdir -p docs/core-concepts/miden-node
-            cp -r vendor/miden-node/docs/external/src/* docs/core-concepts/miden-node/
-            echo "Synced miden-node → docs/core-concepts/miden-node"
+          if [ -d "vendor/node/docs/external/src" ]; then
+            mkdir -p docs/core-concepts/node
+            cp -r vendor/node/docs/external/src/* docs/core-concepts/node/
+            echo "Synced node → docs/core-concepts/node"
           fi
 
           if [ -d "vendor/compiler/docs/external/src" ]; then
@@ -180,11 +180,11 @@ jobs:
           fi
 
           # Builder docs → docs/builder/*
-          # Sync miden-tutorials into tutorials (local tutorials are preserved)
-          if [ -d "vendor/miden-tutorials/docs/src" ]; then
+          # Sync tutorials into tutorials (local tutorials are preserved)
+          if [ -d "vendor/tutorials/docs/src" ]; then
             mkdir -p docs/builder/tutorials
-            cp -r vendor/miden-tutorials/docs/src/* docs/builder/tutorials/
-            echo "Synced miden-tutorials → docs/builder/tutorials"
+            cp -r vendor/tutorials/docs/src/* docs/builder/tutorials/
+            echo "Synced tutorials → docs/builder/tutorials"
           fi
 
           if [ -d "vendor/miden-client/docs/external/src" ]; then
@@ -215,9 +215,9 @@ jobs:
         run: |
           rm -rf vendor
           # Clean v0.4 nested paths
-          rm -rf docs/core-concepts/miden-base
+          rm -rf docs/core-concepts/protocol
           rm -rf docs/core-concepts/miden-vm
-          rm -rf docs/core-concepts/miden-node
+          rm -rf docs/core-concepts/node
           rm -rf docs/core-concepts/compiler
           rm -rf docs/builder/tools/client
           # Note: tutorials live in docs/builder/tutorials/ (authored content, not cleaned)

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -7,16 +7,16 @@ on:
     inputs:
       # optional per-repo overrides (branch/ref/SHA); leave empty to use defaults
       miden_base_ref:
-        description: "Ref for 0xMiden/miden-base"
+        description: "Ref for 0xMiden/protocol"
         required: false
       miden_tutorials_ref:
-        description: "Ref for 0xMiden/miden-tutorials"
+        description: "Ref for 0xMiden/tutorials"
         required: false
       miden_client_ref:
         description: "Ref for 0xMiden/miden-client"
         required: false
       miden_node_ref:
-        description: "Ref for 0xMiden/miden-node"
+        description: "Ref for 0xMiden/node"
         required: false
       miden_vm_ref:
         description: "Ref for 0xMiden/miden-vm"
@@ -86,27 +86,27 @@ jobs:
           echo "COMPILER_REF=$compiler_ref" >> $GITHUB_OUTPUT
 
           echo "Resolved refs:"
-          echo "  miden-base:       $base_ref"
-          echo "  miden-tutorials:  $tutorials_ref"
-          echo "  miden-client:     $client_ref"
-          echo "  miden-node:       $node_ref"
+          echo "  protocol:          $base_ref"
+          echo "  tutorials:         $tutorials_ref"
+          echo "  miden-client:      $client_ref"
+          echo "  node:              $node_ref"
           echo "  miden-vm:         $vm_ref"
           echo "  compiler:         $compiler_ref"
 
       # Check out each source repo into vendor/*
-      - name: Checkout 0xMiden/miden-base
+      - name: Checkout 0xMiden/protocol
         uses: actions/checkout@v4
         with:
-          repository: 0xMiden/miden-base
+          repository: 0xMiden/protocol
           ref: ${{ steps.refs.outputs.MIDEN_BASE_REF }}
-          path: vendor/miden-base
+          path: vendor/protocol
 
-      - name: Checkout 0xMiden/miden-tutorials
+      - name: Checkout 0xMiden/tutorials
         uses: actions/checkout@v4
         with:
-          repository: 0xMiden/miden-tutorials
+          repository: 0xMiden/tutorials
           ref: ${{ steps.refs.outputs.MIDEN_TUTORIALS_REF }}
-          path: vendor/miden-tutorials
+          path: vendor/tutorials
 
       - name: Checkout 0xMiden/miden-client
         uses: actions/checkout@v4
@@ -115,12 +115,12 @@ jobs:
           ref: ${{ steps.refs.outputs.MIDEN_CLIENT_REF }}
           path: vendor/miden-client
 
-      - name: Checkout 0xMiden/miden-node
+      - name: Checkout 0xMiden/node
         uses: actions/checkout@v4
         with:
-          repository: 0xMiden/miden-node
+          repository: 0xMiden/node
           ref: ${{ steps.refs.outputs.MIDEN_NODE_REF }}
-          path: vendor/miden-node
+          path: vendor/node
 
       - name: Checkout 0xMiden/miden-vm
         uses: actions/checkout@v4
@@ -138,23 +138,23 @@ jobs:
 
       # ============================================================
       # v0.4 IA: Aggregate into nested structure
-      #   - Core Concepts docs (miden-base, miden-vm, compiler, miden-node) → docs/core-concepts/
-      #   - Builder docs (miden-tutorials, miden-client) → docs/builder/
+      #   - Core Concepts docs (protocol, miden-vm, compiler, node) → docs/core-concepts/
+      #   - Builder docs (tutorials, miden-client) → docs/builder/
       # ============================================================
       - name: Aggregate docs into single docs tree
         run: |
           echo "Aggregating vendor docs into v0.4 IA structure..."
 
           # Clean directories that will be re-synced (v0.4 nested paths)
-          rm -rf docs/core-concepts/miden-base docs/core-concepts/miden-vm docs/core-concepts/miden-node docs/core-concepts/compiler
+          rm -rf docs/core-concepts/protocol docs/core-concepts/miden-vm docs/core-concepts/node docs/core-concepts/compiler
           rm -rf docs/builder/tools/client
           # Note: docs/builder/tutorials is NOT fully cleaned to preserve local tutorials (e.g. miden-bank)
 
           # Core Concepts docs → docs/core-concepts/*
-          if [ -d "vendor/miden-base/docs/src" ]; then
-            mkdir -p docs/core-concepts/miden-base
-            cp -r vendor/miden-base/docs/src/* docs/core-concepts/miden-base/
-            echo "Synced miden-base → docs/core-concepts/miden-base"
+          if [ -d "vendor/protocol/docs/src" ]; then
+            mkdir -p docs/core-concepts/protocol
+            cp -r vendor/protocol/docs/src/* docs/core-concepts/protocol/
+            echo "Synced protocol → docs/core-concepts/protocol"
           fi
 
           if [ -d "vendor/miden-vm/docs/src" ]; then
@@ -163,10 +163,10 @@ jobs:
             echo "Synced miden-vm → docs/core-concepts/miden-vm"
           fi
 
-          if [ -d "vendor/miden-node/docs/external/src" ]; then
-            mkdir -p docs/core-concepts/miden-node
-            cp -r vendor/miden-node/docs/external/src/* docs/core-concepts/miden-node/
-            echo "Synced miden-node → docs/core-concepts/miden-node"
+          if [ -d "vendor/node/docs/external/src" ]; then
+            mkdir -p docs/core-concepts/node
+            cp -r vendor/node/docs/external/src/* docs/core-concepts/node/
+            echo "Synced node → docs/core-concepts/node"
           fi
 
           if [ -d "vendor/compiler/docs/external/src" ]; then
@@ -176,11 +176,11 @@ jobs:
           fi
 
           # Builder docs → docs/builder/*
-          # Sync miden-tutorials into tutorials (local tutorials are preserved)
-          if [ -d "vendor/miden-tutorials/docs/src" ]; then
+          # Sync tutorials into tutorials (local tutorials are preserved)
+          if [ -d "vendor/tutorials/docs/src" ]; then
             mkdir -p docs/builder/tutorials
-            cp -r vendor/miden-tutorials/docs/src/* docs/builder/tutorials/
-            echo "Synced miden-tutorials → docs/builder/tutorials"
+            cp -r vendor/tutorials/docs/src/* docs/builder/tutorials/
+            echo "Synced tutorials → docs/builder/tutorials"
           fi
 
           if [ -d "vendor/miden-client/docs/external/src" ]; then

--- a/.release/release-manifest.yml
+++ b/.release/release-manifest.yml
@@ -1,9 +1,9 @@
 version: "0.13" # the label to snapshot (used if no manual override)
 refs: # exact, immutable refs per source repo (tags or release branches)
-  miden-base: "refs/tags/v0.13.3"
-  miden-node: "refs/tags/v0.13.4"
+  protocol: "refs/tags/v0.13.3"
+  node: "refs/tags/v0.13.4"
   miden-client: "refs/tags/v0.13.0"
-  miden-tutorials: "refs/heads/main"
+  tutorials: "refs/heads/main"
   miden-vm: "refs/tags/v0.20.6"
   compiler: "refs/tags/0.7.0"
 next_version: "0.14"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# miden-docs
+# docs
 
 Consolidated documentation for the Miden rollup
 
@@ -12,7 +12,7 @@ This documentation site combines content **authored in this repo** with content 
 
 ```mermaid
 flowchart TD
-    subgraph ThisRepo["0xMiden/miden-docs"]
+    subgraph ThisRepo["0xMiden/docs"]
         subgraph DocsDir["docs/ (authored here)"]
             BuilderDir["builder/"]
             BuilderQS["builder/get-started/"]
@@ -48,12 +48,12 @@ flowchart TD
     end
 
     subgraph ExternalRepos["External Repositories (canonical sources)"]
-        MidenBase["0xMiden/miden-base"]
+        MidenBase["0xMiden/protocol"]
         MidenVM["0xMiden/miden-vm"]
-        MidenNode["0xMiden/miden-node"]
+        MidenNode["0xMiden/node"]
         Compiler["0xMiden/compiler"]
         MidenClient["0xMiden/miden-client"]
-        MidenTutorials["0xMiden/miden-tutorials"]
+        MidenTutorials["0xMiden/tutorials"]
     end
 
     CutVersions["CICD cut-versions.yml<br/>(ingest + snapshot)"]
@@ -88,7 +88,7 @@ flowchart TD
 | Category | Location | Source | Example |
 |----------|----------|--------|---------|
 | **Authored** | `docs/builder/` | Written in this repo | `docs/builder/get-started/`, `docs/builder/faq.md` |
-| **Ingested (live)** | `docs/core-concepts/`, `docs/builder/` | External repos @ next | `docs/core-concepts/miden-base/`, `docs/builder/tutorials/` |
+| **Ingested (live)** | `docs/core-concepts/`, `docs/builder/` | External repos @ next | `docs/core-concepts/protocol/`, `docs/builder/tutorials/` |
 | **Ingested (versioned)** | `versioned_docs/` | External repos @ release tags | `versioned_docs/version-0.12/miden-base/` |
 | **Snapshots** | `versioned_docs/` | Frozen via `docs:version` | All versioned content |
 
@@ -142,12 +142,12 @@ Edit `.release/release-manifest.yml`:
 version: "0.13"  # New version label
 
 refs:
-  miden-base: v0.13.0      # Pin to release tag
+  protocol: v0.13.0        # Pin to release tag
   miden-vm: v0.20.0
-  miden-node: v0.13.0
+  node: v0.13.0
   compiler: 0.6.0
   miden-client: v0.13.0
-  miden-tutorials: main    # Or specific commit/tag
+  tutorials: main          # Or specific commit/tag
 ```
 
 #### 2. Run the Version Cut Workflow
@@ -160,7 +160,7 @@ Trigger `.github/workflows/cut-versions.yml` on a branch (manually via `workflow
 
 The workflow executes these steps:
 1. **Checkout external repos** at pinned refs
-2. **Aggregate docs temporarily** into `docs/` (miden-base/, miden-vm/, etc.)
+2. **Aggregate docs temporarily** into `docs/` (protocol/, miden-vm/, etc.)
 3. **Run `docusaurus docs:version X.Y`** to snapshot everything
 4. **Clean up `docs/`** — remove aggregated external content
 5. **Commit `versioned_docs/version-X.Y/`** to the repository
@@ -181,7 +181,7 @@ Deployment is **automatic** on push to `main`.
 The `.github/workflows/deploy-docs.yml` workflow:
 1. Checks out this repository and all external source repos
 2. Ingests external docs into v0.4 IA structure:
-   - Core Concepts docs → `docs/core-concepts/miden-base/`, `miden-vm/`, `compiler/`, `miden-node/`
+   - Core Concepts docs → `docs/core-concepts/protocol/`, `miden-vm/`, `compiler/`, `node/`
    - Builder docs → `docs/builder/tutorials/`, `docs/builder/tools/client/`
 3. Runs `npm run build` to generate the static site
 4. Deploys to GitHub Pages at `docs.miden.xyz`
@@ -209,7 +209,7 @@ The build uses:
 ### ❌ DON'T
 
 - **Never** manually copy external content into `docs/` (use CI/CD ingestion)
-- **Never** create root-level `docs/miden-base/`, `docs/miden-vm/`, etc. (use nested paths in `docs/core-concepts/`)
+- **Never** create root-level `docs/protocol/`, `docs/miden-vm/`, etc. (use nested paths in `docs/core-concepts/`)
 - **Never** edit `versioned_docs/` directly (snapshots are immutable)
 - **Never** create a root-level `docs/quick-start/` (Get Started lives in `docs/builder/`)
 
@@ -219,9 +219,9 @@ The build uses:
 |------|--------|
 | Edit Get Started | `docs/builder/get-started/` |
 | Edit FAQ/Glossary | `docs/builder/faq.md`, `docs/builder/glossary.md` |
-| Edit Protocol docs | `0xMiden/miden-base` repo → cut new version |
+| Edit Protocol docs | `0xMiden/protocol` repo → cut new version |
 | Edit VM docs | `0xMiden/miden-vm` repo → cut new version |
-| Edit Tutorials | `0xMiden/miden-tutorials` repo → cut new version |
+| Edit Tutorials | `0xMiden/tutorials` repo → cut new version |
 | Edit Client docs | `0xMiden/miden-client` repo → cut new version |
 | Create new release | Update `.release/release-manifest.yml` → run `cut-versions.yml` |
 

--- a/docs/builder/get-started/your-first-smart-contract/create.md
+++ b/docs/builder/get-started/your-first-smart-contract/create.md
@@ -228,7 +228,7 @@ impl IncrementNote {
 
 The struct definition (`IncrementNote`) provides a named type for the note script. Unlike account contracts, note scripts don't store persistent data — the struct serves as the entry point container.
 
-Learn more about [note scripts in the Miden documentation](/core-concepts/miden-base/note/).
+Learn more about [note scripts in the Miden documentation](/core-concepts/protocol/note/).
 
 #### The Note Script Function
 

--- a/docs/builder/get-started/your-first-smart-contract/deploy.md
+++ b/docs/builder/get-started/your-first-smart-contract/deploy.md
@@ -42,7 +42,7 @@ The integration folder serves two essential functions in Miden development:
 Think of the scripts in `src/bin/` as Miden's equivalent to [**Foundry scripts**](https://getfoundry.sh/guides/scripting-with-solidity). These are executable Rust binaries that handle all your contract interactions:
 
 - **Contract Deployment**: Scripts that create and deploy accounts to the network
-- **Function/Procedure Calls**: Scripts that interact with deployed contracts through notes or [transaction scripts](/core-concepts/miden-base/transaction#transaction-lifecycle)
+- **Function/Procedure Calls**: Scripts that interact with deployed contracts through notes or [transaction scripts](/core-concepts/protocol/transaction#transaction-lifecycle)
 - **State Queries**: Scripts that read contract state from the network
 - **Operations**: Scripts for contract upgrades, configuration changes, etc.
 

--- a/docs/builder/smart-contracts/accounts/introduction.md
+++ b/docs/builder/smart-contracts/accounts/introduction.md
@@ -21,7 +21,7 @@ Every account has four parts:
 | **Vault** | The fungible and non-fungible assets the account holds |
 | **Nonce** | A counter that increments exactly once per state change, providing replay protection |
 
-The network doesn't store the full account state. Instead, it stores cryptographic commitments — hashes of the code, storage, and vault (see [account design](/core-concepts/miden-base/account/)). Only the account owner (or a public account's observers) sees the actual data.
+The network doesn't store the full account state. Instead, it stores cryptographic commitments — hashes of the code, storage, and vault (see [account design](/core-concepts/protocol/account/)). Only the account owner (or a public account's observers) sees the actual data.
 
 ## Components, not contracts
 

--- a/docs/builder/smart-contracts/notes/introduction.md
+++ b/docs/builder/smart-contracts/notes/introduction.md
@@ -48,7 +48,7 @@ Transaction 1 (Sender)                Transaction 2 (Recipient)
 
 **Transaction 1**: The sender's account creates an output note, attaches assets to it, and the note is published (either on-chain or kept private).
 
-**Transaction 2**: The recipient discovers the note, consumes it in their own transaction, the note script runs and verifies the consumer is authorized, and assets transfer into the recipient's vault. A **nullifier** is recorded to prevent the same note from being consumed again (see [note design](/core-concepts/miden-base/note)).
+**Transaction 2**: The recipient discovers the note, consumes it in their own transaction, the note script runs and verifies the consumer is authorized, and assets transfer into the recipient's vault. A **nullifier** is recorded to prevent the same note from being consumed again (see [note design](/core-concepts/protocol/note)).
 
 This separation is what enables privacy and parallelism — the two transactions are independent and unlinkable from the network's perspective.
 

--- a/docs/builder/smart-contracts/transactions/introduction.md
+++ b/docs/builder/smart-contracts/transactions/introduction.md
@@ -8,7 +8,7 @@ description: "Transactions are Miden's execution unit — they consume input not
 
 Transactions are the execution unit in Miden. Every state change — transferring assets, updating storage, minting tokens — happens inside a transaction. Each transaction runs against a single account, consumes zero or more input notes, and produces zero or more output notes.
 
-The critical difference from other blockchains: transactions execute locally on the user's machine, not on a shared VM. After execution, the Miden VM generates a zero-knowledge proof that the transaction was valid (see [transaction design](/core-concepts/miden-base/transaction)). Only this proof and the resulting state commitments are submitted to the network. The network never sees the transaction inputs, the account's private state, or the logic that ran.
+The critical difference from other blockchains: transactions execute locally on the user's machine, not on a shared VM. After execution, the Miden VM generates a zero-knowledge proof that the transaction was valid (see [transaction design](/core-concepts/protocol/transaction)). Only this proof and the resulting state commitments are submitted to the network. The network never sees the transaction inputs, the account's private state, or the logic that ran.
 
 ## Anatomy of a transaction
 

--- a/docs/core-concepts/index.md
+++ b/docs/core-concepts/index.md
@@ -40,7 +40,7 @@ Miden is a zero-knowledge rollup that fundamentally rethinks blockchain architec
 
 ---
 
-## Protocol (miden-base)
+## Protocol
 
 The protocol layer defines Miden's data structures, state model, and transaction semantics.
 
@@ -157,7 +157,7 @@ The compiler supports:
 
 ---
 
-## Node (miden-node)
+## Node
 
 The node is the network infrastructure that receives transactions and produces blocks.
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -20,7 +20,7 @@ const config: Config = {
   baseUrl: "",
 
   organizationName: "0xMiden",
-  projectName: "miden-docs",
+  projectName: "docs",
 
   onBrokenLinks: "warn",
   onBrokenMarkdownLinks: "warn",
@@ -118,8 +118,9 @@ const config: Config = {
           }
 
           // Core Concepts section: redirect old root-level paths to new /core-concepts/ paths
-          if (existingPath.startsWith("/core-concepts/miden-base")) {
-            redirects.push(existingPath.replace("/core-concepts/miden-base", "/miden-base"));
+          if (existingPath.startsWith("/core-concepts/protocol")) {
+            redirects.push(existingPath.replace("/core-concepts/protocol", "/miden-base"));
+            redirects.push(existingPath.replace("/core-concepts/protocol", "/core-concepts/miden-base"));
           }
           if (existingPath.startsWith("/core-concepts/miden-vm")) {
             redirects.push(existingPath.replace("/core-concepts/miden-vm", "/miden-vm"));
@@ -127,8 +128,9 @@ const config: Config = {
           if (existingPath.startsWith("/core-concepts/compiler")) {
             redirects.push(existingPath.replace("/core-concepts/compiler", "/compiler"));
           }
-          if (existingPath.startsWith("/core-concepts/miden-node")) {
-            redirects.push(existingPath.replace("/core-concepts/miden-node", "/miden-node"));
+          if (existingPath.startsWith("/core-concepts/node")) {
+            redirects.push(existingPath.replace("/core-concepts/node", "/miden-node"));
+            redirects.push(existingPath.replace("/core-concepts/node", "/core-concepts/miden-node"));
           }
 
           // Redirect old /design/ paths to /core-concepts/

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -9,7 +9,7 @@ import type { SidebarsConfig } from "@docusaurus/plugin-content-docs";
  *
  * - coreConceptsSidebar: Architecture/internals (protocol, VM, proving)
  *   Canonical source: Landing page in docs/core-concepts/index.md
- *   Ingested content: docs/core-concepts/miden-base/, miden-vm/, compiler/, miden-node/
+ *   Ingested content: docs/core-concepts/protocol/, miden-vm/, compiler/, node/
  *
  * ARCHITECTURE NOTE:
  * External docs are ingested at build time via deploy-docs.yml into:

--- a/static/skill.md
+++ b/static/skill.md
@@ -2,8 +2,8 @@
 name: miden-architecture
 description: >
   Miden protocol architecture and ecosystem knowledge. Use when working on any
-  Miden repository (miden-base, miden-client, miden-node, miden-vm, compiler,
-  miden-docs). Covers the stack machine, transaction model, note system, state
+  Miden repository (protocol, miden-client, node, miden-vm, compiler,
+  docs). Covers the stack machine, transaction model, note system, state
   management, and Rust SDK programming model.
 compatibility: Designed for Claude Code and similar AI coding assistants.
 metadata:
@@ -73,4 +73,4 @@ Privacy is the default.
 - Full docs for LLMs: https://docs.miden.xyz/llms.txt
 - SDK API: https://docs.rs/miden/latest/miden/
 - GitHub: https://github.com/0xMiden
-- Core repos: miden-base (protocol), miden-vm (VM), miden-client (client), compiler (Rust->MASM)
+- Core repos: protocol, miden-vm (VM), miden-client (client), compiler (Rust->MASM)


### PR DESCRIPTION
## Summary

- Update `deploy-docs.yml` and `cut-versions.yml` repo URLs, vendor paths, and aggregation targets
- Rename release manifest keys (`miden-base`→`protocol`, `miden-node`→`node`, `miden-tutorials`→`tutorials`)
- Update `docusaurus.config.ts` project name and add redirects for old `/core-concepts/miden-base/` and `/core-concepts/miden-node/` paths
- Fix internal doc links from `/core-concepts/miden-base/` to `/core-concepts/protocol/`
- v0.11–v0.13 versioned docs left untouched (historical snapshots)

Closes #201

## Test plan

- [x] `npm run build` passes locally with aggregated vendor content
- [x] `act` run of `deploy-docs.yml` — all workflow steps pass (checkout, aggregation, deps)
- [x] `act` run of `cut-versions.yml` — all workflow steps pass through aggregation
- [x] Release manifest parses correctly with new keys
- [x] Redirect HTML generated for old paths