### PR TITLE
docs: restructure client docs under tools/clients and tools/cli

### DIFF
--- a/.github/workflows/cut-versions.yml
+++ b/.github/workflows/cut-versions.yml
@@ -151,7 +151,7 @@ jobs:
 
           # Clean directories that will be re-synced (v0.4 nested paths)
           rm -rf docs/core-concepts/protocol docs/core-concepts/miden-vm docs/core-concepts/node docs/core-concepts/compiler
-          rm -rf docs/builder/tools/client
+          rm -rf docs/builder/tools/clients docs/builder/tools/cli
           rm -rf docs/builder/tutorials/miden-bank docs/builder/tutorials/index.md
           # Note: docs/builder/tutorials/rust-compiler/ is NOT cleaned to preserve local guides (testing, debugging, pitfalls)
 
@@ -189,9 +189,15 @@ jobs:
           fi
 
           if [ -d "vendor/miden-client/docs/external/src" ]; then
-            mkdir -p docs/builder/tools/client
-            cp -r vendor/miden-client/docs/external/src/* docs/builder/tools/client/
-            echo "Synced miden-client → docs/builder/tools/client"
+            mkdir -p docs/builder/tools/clients
+            cp -r vendor/miden-client/docs/external/src/* docs/builder/tools/clients/
+            echo "Synced miden-client → docs/builder/tools/clients"
+
+            # Move CLI to its own section under tools
+            if [ -d "docs/builder/tools/clients/cli" ]; then
+              mv docs/builder/tools/clients/cli docs/builder/tools/cli
+              echo "Moved CLI → docs/builder/tools/cli"
+            fi
           fi
 
           echo "Content aggregation complete. Final docs structure:"
@@ -220,7 +226,7 @@ jobs:
           rm -rf docs/core-concepts/miden-vm
           rm -rf docs/core-concepts/node
           rm -rf docs/core-concepts/compiler
-          rm -rf docs/builder/tools/client
+          rm -rf docs/builder/tools/clients docs/builder/tools/cli
           rm -rf docs/builder/tutorials/miden-bank docs/builder/tutorials/index.md
           # Note: docs/builder/tutorials/rust-compiler/ is authored content (testing, debugging, pitfalls), not cleaned
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -147,7 +147,7 @@ jobs:
 
           # Clean directories that will be re-synced (v0.4 nested paths)
           rm -rf docs/core-concepts/protocol docs/core-concepts/miden-vm docs/core-concepts/node docs/core-concepts/compiler
-          rm -rf docs/builder/tools/client
+          rm -rf docs/builder/tools/clients docs/builder/tools/cli
           rm -rf docs/builder/tutorials/miden-bank docs/builder/tutorials/index.md
           # Note: docs/builder/tutorials/rust-compiler/ is NOT cleaned to preserve local guides (testing, debugging, pitfalls)
 
@@ -185,9 +185,15 @@ jobs:
           fi
 
           if [ -d "vendor/miden-client/docs/external/src" ]; then
-            mkdir -p docs/builder/tools/client
-            cp -r vendor/miden-client/docs/external/src/* docs/builder/tools/client/
-            echo "Synced miden-client → docs/builder/tools/client"
+            mkdir -p docs/builder/tools/clients
+            cp -r vendor/miden-client/docs/external/src/* docs/builder/tools/clients/
+            echo "Synced miden-client → docs/builder/tools/clients"
+
+            # Move CLI to its own section under tools
+            if [ -d "docs/builder/tools/clients/cli" ]; then
+              mv docs/builder/tools/clients/cli docs/builder/tools/cli
+              echo "Moved CLI → docs/builder/tools/cli"
+            fi
           fi
 
           echo "Content aggregation complete. Final docs structure:"

--- a/docs/builder/index.md
+++ b/docs/builder/index.md
@@ -108,7 +108,7 @@ import DocCard from '@theme/DocCard';
         type: 'link',
         href: './tools',
         label: 'Tools',
-        description: 'Miden Client libraries, CLI, and developer tooling.',
+        description: 'Client SDKs, CLI, playground, and block explorer.',
       }}
     />
   </div>

--- a/docs/builder/tools/index.md
+++ b/docs/builder/tools/index.md
@@ -3,29 +3,26 @@ title: Tools
 sidebar_position: 1
 ---
 
-<!--
-ARCHITECTURE NOTE:
-Client documentation is canonical in versioned_docs/version-X.Y/miden-client/.
-This landing page exists only for the "current/next" version.
-Full client docs are available by selecting a released version.
--->
-
 # Tools
 
-:::info Version Note
-Full client documentation (Rust Client, Web Client, CLI reference) is available in **released versions only**. Please select a version from the dropdown (e.g., 0.12, 0.11) to access the complete client documentation.
-:::
+Developer tools for building and interacting with the Miden network.
 
-## Miden Client
+## Clients
 
-The Miden client has three main components:
+SDKs for integrating Miden into your applications:
 
-1. **Miden client library** - A Rust library for integrating with the Miden rollup
-2. **Miden client CLI** - Command-line interface for interacting with the network
-3. **Miden web client** - Browser-based interface for managing accounts and transactions
+- **[Rust SDK](./clients/)** — Full-featured Rust library for Miden rollup integration
+- **[Web SDK](./clients/)** — Browser-based client for managing accounts and transactions
+- **[React SDK](./clients/)** — React hooks and components for Miden dApps
 
-## Additional Tools
+## CLI
 
-- **Playground** - Interactive environment for testing Miden assembly
-- **Explorer** - Block explorer for the Miden network
-- **[Miden Guardian](../miden-guardian/)** - Server and SDKs for backing up, syncing, and coordinating private account state (built by OpenZeppelin)
+The **[Miden CLI](./cli/)** provides command-line tools for interacting with the Miden network — creating accounts, submitting transactions, syncing state, and more.
+
+## Playground
+
+The **[Miden Playground](./playground)** is an interactive browser environment for writing and testing Miden assembly programs.
+
+## Explorer
+
+The **[Miden Explorer](./explorer)** is a block explorer for inspecting accounts, notes, transactions, and blocks on the Miden testnet.

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -120,6 +120,10 @@ const config: Config = {
           if (existingPath.startsWith("/builder/tools")) {
             redirects.push(existingPath.replace("/builder/tools", "/miden-client"));
           }
+          // Redirect old client path to new clients path
+          if (existingPath.startsWith("/builder/tools/clients")) {
+            redirects.push(existingPath.replace("/builder/tools/clients", "/builder/tools/client"));
+          }
 
           // Core Concepts section: redirect old root-level paths to new /core-concepts/ paths
           if (existingPath.startsWith("/core-concepts/protocol")) {


### PR DESCRIPTION
## Summary
- Update CI workflows to sync miden-client docs into `tools/clients/` (instead of `tools/client/`), with CLI split into `tools/cli/`
- Rewrite `tools/index.md` as a hub page linking to Clients, CLI, Playground, and Explorer
- Add redirect from old `tools/client/*` to new `tools/clients/*` path

## Test plan
- [x] `npm run build` passes with no new broken link warnings
- [ ] After CI deploy, verify `tools/clients/` and `tools/cli/` are populated from miden-client repo
- [ ] Verify tools hub page renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)