### PR TITLE
fix: update broken anchor links in core-concepts index

### DIFF
--- a/docs/core-concepts/index.md
+++ b/docs/core-concepts/index.md
@@ -26,7 +26,7 @@ import DocCard from '@theme/DocCard';
     <DocCard
       item={{
         type: 'link',
-        href: '#protocol-miden-base',
+        href: '#protocol',
         label: 'Protocol',
         description: 'Accounts, notes, state model, and transaction semantics.',
       }}
@@ -59,7 +59,7 @@ import DocCard from '@theme/DocCard';
     <DocCard
       item={{
         type: 'link',
-        href: '#node-miden-node',
+        href: '#node',
         label: 'Node',
         description: 'Network infrastructure, gRPC API, and block production.',
       }}


### PR DESCRIPTION
## Summary
- Fix broken anchors `#protocol-miden-base` → `#protocol` and `#node-miden-node` → `#node` in core-concepts DocCards
- Caused by heading renames in #219 that weren't reflected in the DocCards added by a concurrent commit

## Test plan
- [x] `npm run build` passes with no broken anchor warnings