### PR TITLE
docs: fix Your First Smart Contract page

### DIFF
--- a/docs/builder/get-started/your-first-smart-contract/create.md
+++ b/docs/builder/get-started/your-first-smart-contract/create.md
@@ -128,6 +128,10 @@ These imports provide:
 - **`StorageMap`**: Key-value storage within account storage slots
 - **`StorageMapAccess`**: Needed for reading storage values (`get_count` function)
 
+:::note[`felt` vs `Felt`]
+`Felt` is the field element type representing values in the Goldilocks prime field (p = 2^64 - 2^32 + 1). `felt!(1)` is a compile-time macro that creates `Felt` values from integer literals with compile-time range validation. Currently `felt!` only accepts values up to 2^32 (compiler limitation); for larger values use `Felt::from_u64_unchecked()`.
+:::
+
 #### Contract Structure Definition
 
 ```rust

--- a/docs/builder/get-started/your-first-smart-contract/deploy.md
+++ b/docs/builder/get-started/your-first-smart-contract/deploy.md
@@ -93,7 +93,7 @@ Account delta: AccountDelta { account_id: V0(AccountIdV0 { prefix: 7255964780328
 
 </details>
 
-Congratulations, you have successfully deployed the Counter Contract to the Miden Testnet, and incremented its count by one! You can view your account on the [Miden Testnet Explorer](https://testnet.midenscan.com).
+Congratulations, you have successfully deployed the Counter Contract to the Miden Testnet, and incremented its count by one! You can verify your transaction on [MidenScan](https://testnet.midenscan.com) by searching for your transaction ID.
 
 ### What Happens During Execution
 
@@ -150,7 +150,7 @@ The `build_project_in_dir()` function:
 
 - Takes the path to your contract's Rust source code
 - Compiles the Rust code into a Miden package (`.masp` file)
-- The package contains the compiled contract bytecode and metadata
+- Generates a package containing the compiled contract bytecode and metadata
 - This is equivalent to manually running `miden build` in each contract directory
 
 These packages contain all the information needed to deploy and interact with your contracts on the Miden network.


### PR DESCRIPTION
## Summary
- Fix "compiles to Miden assembly" → "compiles to a `.masp` package file"
- Add `felt` vs `Felt` note explaining macro vs type
- Fix "Miden component" → "Miden account component"
- Fix storage key strategy wording
- Add trace log explanation note to expected output
- Add MidenScan link for verifying deployment

Fixes #218