### PR TITLE
docs(builder): fix Miden Bank tutorial links in smart contract docs

### DIFF
--- a/docs/builder/smart-contracts/overview.md
+++ b/docs/builder/smart-contracts/overview.md
@@ -148,4 +148,4 @@ Miden supports several account types, configured in `Cargo.toml`:
 | [Cross-Component Calls](./cross-component-calls) | Inter-component communication | WIT bindings, `generate!()` |
 | [Types](./types) | Felt, Word, Asset — the VM's native types | Field arithmetic |
 
-Ready to start building? Follow the [Miden Bank Tutorial](../tutorials/miden-bank/) for a hands-on walkthrough.
+Ready to start building? Follow the [Miden Bank Tutorial](../tutorials/rust-compiler/miden-bank/) for a hands-on walkthrough.

--- a/docs/builder/smart-contracts/overview.md
+++ b/docs/builder/smart-contracts/overview.md
@@ -6,7 +6,7 @@ description: "Miden's execution model, account structure, note system, and trans
 
 # What is a Miden Smart Contract
 
-Miden is a ZK rollup where transactions execute on the client and only a cryptographic proof is submitted to the network. Every entity — wallets, contracts, faucets — is an account with code, storage, a vault, and a nonce. Assets move between accounts through notes, which act as programmable UTXOs. This page describes the execution model, account structure, note system, and transaction lifecycle. For a hands-on walkthrough, see the [Miden Bank Tutorial](../tutorials/miden-bank/).
+Miden is a ZK rollup where transactions execute on the client and only a cryptographic proof is submitted to the network. Every entity — wallets, contracts, faucets — is an account with code, storage, a vault, and a nonce. Assets move between accounts through notes, which act as programmable UTXOs. This page describes the execution model, account structure, note system, and transaction lifecycle. For a hands-on walkthrough, see the [Miden Bank Tutorial](../tutorials/rust-compiler/miden-bank/).
 
 ## What makes Miden different
 

--- a/docs/builder/smart-contracts/patterns.md
+++ b/docs/builder/smart-contracts/patterns.md
@@ -6,7 +6,7 @@ description: "Common patterns and security considerations for Miden smart contra
 
 # Patterns
 
-Security considerations and common patterns for Miden smart contracts. For runnable examples, see the [compiler examples directory](https://github.com/0xMiden/compiler/tree/next/examples) and the [Miden Bank Tutorial](../tutorials/miden-bank/).
+Security considerations and common patterns for Miden smart contracts. For runnable examples, see the [compiler examples directory](https://github.com/0xMiden/compiler/tree/next/examples) and the [Miden Bank Tutorial](../tutorials/rust-compiler/miden-bank/).
 
 ## Access control
 


### PR DESCRIPTION
## Current behavior

The builder smart contract docs reference the Miden Bank Tutorial via `../tutorials/miden-bank/`, but that path does not match the current tutorials structure used by the docs site.

As a result, the tutorial links in `patterns.md` and `overview.md` are broken or resolve incorrectly.

## New behavior

The Miden Bank Tutorial links now point to `../tutorials/rust-compiler/miden-bank/`, which matches the current builder tutorials structure.

Updated:
- `docs/builder/smart-contracts/patterns.md`
- `docs/builder/smart-contracts/overview.md`

## Breaking changes

None.

## Other info

Documentation-only update.
This change also aligns the current docs with the already-correct path used in the versioned docs.

Closes #234