### PR TITLE
docs: migrate Quick Start TypeScript to MidenClient + fix migration ch07

### DIFF
--- a/docs/builder/get-started/accounts.md
+++ b/docs/builder/get-started/accounts.md
@@ -175,12 +175,12 @@ Let's start by creating accounts using the Miden client libraries:
 ```rust title="integration/src/bin/account.rs"
 use miden_client::{
     account::{
-        component::BasicWallet,
+        component::{AuthScheme, AuthSingleSig, BasicWallet},
         AccountBuilder, AccountStorageMode, AccountType,
     },
-    auth::{AuthFalcon512Rpo, AuthSecretKey},
+    auth::AuthSecretKey,
     builder::ClientBuilder,
-    keystore::FilesystemKeyStore,
+    keystore::{FilesystemKeyStore, Keystore},
     rpc::{Endpoint, GrpcClient},
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
@@ -217,13 +217,14 @@ async fn main() -> anyhow::Result<()> {
     let mut init_seed = [0_u8; 32];
     client.rng().fill_bytes(&mut init_seed);
 
-    let key_pair = AuthSecretKey::new_falcon512_rpo();
+    let key_pair = AuthSecretKey::new_falcon512_poseidon2();
 
     let builder = AccountBuilder::new(init_seed)
         .account_type(AccountType::RegularAccountUpdatableCode)
         .storage_mode(AccountStorageMode::Public)
-        .with_auth_component(AuthFalcon512Rpo::new(
+        .with_auth_component(AuthSingleSig::new(
             key_pair.public_key().to_commitment(),
+            AuthScheme::Falcon512Poseidon2,
         ))
         .with_component(BasicWallet);
 
@@ -231,7 +232,7 @@ async fn main() -> anyhow::Result<()> {
 
     client.add_account(&account, false).await?;
 
-    keystore.add_key(&key_pair)?;
+    keystore.add_key(&key_pair, account.id()).await?;
 
     println!("Account ID: {}", account.id());
     println!("No assets in Vault: {:?}", account.vault().is_empty());
@@ -241,7 +242,7 @@ async fn main() -> anyhow::Result<()> {
 ```
 
 ```typescript title="src/demo.ts"
-import { MidenClient } from "@miden-sdk/miden-sdk";
+import { MidenClient, AccountType } from "@miden-sdk/miden-sdk";
 
 export async function demo() {
     // Initialize client to connect with the Miden Testnet.
@@ -251,8 +252,8 @@ export async function demo() {
 
     // Create a new wallet account.
     const wallet = await client.accounts.create({
-        type: "MutableWallet", // Standard wallet with upgradeable code
-        storage: "public",     // Public: account state is visible onchain
+        type: AccountType.MutableWallet, // Standard wallet with upgradeable code
+        storage: "public",               // Public: account state is visible onchain
     });
 
     console.log("Account ID:", wallet.id().toString());
@@ -280,13 +281,13 @@ Before we can work with tokens, we need a source of tokens. Let's create a fungi
 ```rust title="integration/src/bin/faucet.rs"
 use miden_client::{
     account::{
-        component::BasicFungibleFaucet,
+        component::{AuthScheme, AuthSingleSig, BasicFungibleFaucet},
         AccountBuilder, AccountStorageMode, AccountType,
     },
     asset::TokenSymbol,
-    auth::{AuthFalcon512Rpo, AuthSecretKey},
+    auth::AuthSecretKey,
     builder::ClientBuilder,
-    keystore::FilesystemKeyStore,
+    keystore::{FilesystemKeyStore, Keystore},
     rpc::{Endpoint, GrpcClient},
     Felt,
 };
@@ -331,21 +332,22 @@ async fn main() -> anyhow::Result<()> {
     let max_supply = Felt::new(1_000_000);
 
     // Generate key pair
-    let key_pair = AuthSecretKey::new_falcon512_rpo();
+    let key_pair = AuthSecretKey::new_falcon512_poseidon2();
 
     // Build the account
     let builder = AccountBuilder::new(init_seed)
         .account_type(AccountType::FungibleFaucet)
         .storage_mode(AccountStorageMode::Public)
-        .with_auth_component(AuthFalcon512Rpo::new(
+        .with_auth_component(AuthSingleSig::new(
             key_pair.public_key().to_commitment(),
+            AuthScheme::Falcon512Poseidon2,
         ))
         .with_component(BasicFungibleFaucet::new(symbol, decimals, max_supply)?);
 
     let faucet_account = builder.build()?;
 
     client.add_account(&faucet_account, false).await?;
-    keystore.add_key(&key_pair)?;
+    keystore.add_key(&key_pair, faucet_account.id()).await?;
 
     println!("Faucet account ID: {}", faucet_account.id());
 
@@ -354,7 +356,7 @@ async fn main() -> anyhow::Result<()> {
 ```
 
 ```typescript title="src/demo.ts"
-import { MidenClient } from "@miden-sdk/miden-sdk";
+import { MidenClient, AccountType } from "@miden-sdk/miden-sdk";
 
 export async function demo() {
     // Initialize client to connect with the Miden Testnet.
@@ -366,7 +368,7 @@ export async function demo() {
 
     // Create a fungible token faucet.
     const faucet = await client.accounts.create({
-        type: "FungibleFaucet",
+        type: AccountType.FungibleFaucet,
         symbol: "TEST",
         decimals,
         maxSupply,
@@ -402,7 +404,7 @@ Faucet account ID: 0xde0ba31282f7522046d3d4af40722b
 
 - **BasicWallet**: Provides asset management functionality
 - **BasicFungibleFaucet**: Enables token minting capabilities
-- **AuthFalcon512Rpo**: Handles cryptographic authentication
+- **AuthSingleSig**: Handles cryptographic authentication (Falcon512 or ECDSA via the `AuthScheme` enum)
 
 Now that you understand how to create accounts and faucets, you're ready to learn about Miden's unique transaction model. Continue to [Notes & Transactions](./notes) to explore how assets move between accounts using notes.
 

--- a/docs/builder/get-started/accounts.md
+++ b/docs/builder/get-started/accounts.md
@@ -136,9 +136,9 @@ cargo run --bin demo --release
 
 ### TypeScript Environment
 
-The TypeScript examples use the [`@miden-sdk/react`](https://www.npmjs.com/package/@miden-sdk/react) hooks library. If you haven't already, follow [Set Up React App](./setup/installation#set-up-react-app) to scaffold a project and wire up `MidenProvider`.
+The TypeScript examples use the [`@miden-sdk/react`](https://www.npmjs.com/package/@miden-sdk/react) hooks library. If you haven't already, follow [Set Up React App](./setup/installation#set-up-react-app) to scaffold a project with `yarn create-miden-app` — `MidenProvider` is pre-wired in the template.
 
-For each TypeScript example below, create a component file under `src/components/` (e.g. `src/components/CreateWallet.tsx`), paste the snippet, then import and render it inside `<MidenProvider>` in `src/App.tsx`. Run `yarn dev` and trigger the example from the browser.
+For each TypeScript example below, create a new file under `src/components/` (e.g. `src/components/CreateWallet.tsx`), paste the snippet, then import and render it inside `src/components/AppContent.tsx`. Run `yarn dev` and trigger the example from the browser.
 
 :::tip
 For detailed frontend setup guidance, see the [Tutorials section](../tutorials/rust-compiler/).
@@ -222,7 +222,7 @@ async fn main() -> anyhow::Result<()> {
   typescript: {
     code:`import { useCreateWallet } from "@miden-sdk/react";
 
-// Mount inside <MidenProvider> in App.tsx.
+// Import and render inside src/components/AppContent.tsx.
 // See setup/installation#set-up-react-app.
 export function CreateWallet() {
     const { createWallet, wallet, isCreating, error } = useCreateWallet();
@@ -350,7 +350,7 @@ async fn main() -> anyhow::Result<()> {
   typescript: {
     code:`import { useCreateFaucet } from "@miden-sdk/react";
 
-// Mount inside <MidenProvider> in App.tsx.
+// Import and render inside src/components/AppContent.tsx.
 // See setup/installation#set-up-react-app.
 export function CreateFaucet() {
     const { createFaucet, faucet, isCreating, error } = useCreateFaucet();

--- a/docs/builder/get-started/accounts.md
+++ b/docs/builder/get-started/accounts.md
@@ -136,32 +136,38 @@ cargo run --bin demo --release
 
 ### TypeScript Environment
 
-The TypeScript examples use the [`@miden-sdk/react`](https://www.npmjs.com/package/@miden-sdk/react) hooks library. If you already created `miden-app` during [installation](./setup/installation#set-up-react-app), you can reuse it. Otherwise, scaffold a new project:
+If you already created `miden-app` during [installation](./setup/installation#set-up-typescript-project), you can reuse it. Otherwise, scaffold a new Vite vanilla-ts project:
 
 ```bash title=">_ Terminal"
-yarn create-miden-app
-cd miden-app/
-yarn install
+npm create vite@latest miden-app -- --template vanilla-ts
+cd miden-app
+npm install @miden-sdk/miden-sdk
 ```
 
-The generated project already has `MidenProvider` wired up in `src/providers.tsx`, so the hooks work out of the box. The RPC endpoint is read from `src/config.ts` (`MIDEN_RPC_URL`, defaults to `"testnet"`; override with `VITE_MIDEN_RPC_URL` for custom nodes or devnet).
-
-For each code example, create a new component file under `src/components/`:
+For each code example, save the TypeScript snippet as `src/demo.ts` (overwriting the previous one as you progress):
 
 ```bash title=">_ Terminal"
-touch src/components/CreateWallet.tsx
+touch src/demo.ts
 ```
 
-Copy the TypeScript code into the file, then import and render it inside `src/components/AppContent.tsx`. Run the dev server:
+Wire it into the entry point once (`src/main.ts`):
+
+```ts title="src/main.ts"
+import { demo } from "./demo";
+
+demo().catch(console.error);
+```
+
+Run the dev server:
 
 ```bash title=">_ Terminal"
-yarn dev
+npm run dev
 ```
 
-`yarn dev` hot-reloads on save — trigger the example from the browser.
+Open the dev-server URL in the browser and watch the devtools console for output.
 
 :::tip
-For detailed frontend setup guidance, see the [Tutorials section](../tutorials/rust-compiler/).
+For detailed frontend setup guidance (React, wallets, UI), see the [Tutorials section](../tutorials/rust-compiler/).
 :::
 
 ## Creating Accounts Programmatically
@@ -169,7 +175,7 @@ For detailed frontend setup guidance, see the [Tutorials section](../tutorials/r
 Let's start by creating accounts using the Miden client libraries:
 
 <CodeTabs
-tsFilename="src/components/CreateWallet.tsx"
+tsFilename="src/demo.ts"
 rustFilename="integration/src/bin/account.rs"
 example={{
 rust: {
@@ -240,33 +246,24 @@ async fn main() -> anyhow::Result<()> {
 }
 ` },
   typescript: {
-    code:`import { useCreateWallet } from "@miden-sdk/react";
+    code:`import { MidenClient } from "@miden-sdk/miden-sdk";
 
-// Import and render inside src/components/AppContent.tsx.
-// See setup/installation#set-up-react-app.
-export function CreateWallet() {
-    const { createWallet, wallet, isCreating, error } = useCreateWallet();
+export async function demo() {
+    // Initialize client to connect with the Miden Testnet.
+    // NOTE: The client is our entry point to the Miden network.
+    // All interactions with the network go through the client.
+    const client = await MidenClient.createTestnet();
 
-    const handleCreate = async () => {
-        // Create a new wallet account.
-        const account = await createWallet({
-            storageMode: "public", // Public: account state is visible onchain
-            mutable: true,         // Account code can be upgraded later
-            authScheme: 0,         // 0 = Falcon (default)
-        });
+    // Create a new wallet account.
+    const wallet = await client.accounts.create({
+        type: "MutableWallet", // Standard wallet with upgradeable code
+        storage: "public",     // Public: account state is visible onchain
+    });
 
-        console.log("Account ID:", account.id().toString());
-        console.log(
-            "No Assets in Vault:",
-            account.vault().fungibleAssets().length === 0,
-        );
-    };
-
-    if (error) return <div>Error: {error.message}</div>;
-    return (
-        <button onClick={handleCreate} disabled={isCreating}>
-            {isCreating ? "Creating..." : "Create Wallet"}
-        </button>
+    console.log("Account ID:", wallet.id().toString());
+    console.log(
+        "No Assets in Vault:",
+        wallet.vault().fungibleAssets().length === 0,
     );
 }
 `
@@ -289,7 +286,7 @@ No Assets in Vault: true
 Before we can work with tokens, we need a source of tokens. Let's create a fungible token faucet:
 
 <CodeTabs
-tsFilename="src/components/CreateFaucet.tsx"
+tsFilename="src/demo.ts"
 rustFilename="integration/src/bin/faucet.rs"
 example={{
 rust: {
@@ -368,34 +365,26 @@ async fn main() -> anyhow::Result<()> {
 }
 `},
   typescript: {
-    code:`import { useCreateFaucet } from "@miden-sdk/react";
+    code:`import { MidenClient } from "@miden-sdk/miden-sdk";
 
-// Import and render inside src/components/AppContent.tsx.
-// See setup/installation#set-up-react-app.
-export function CreateFaucet() {
-    const { createFaucet, faucet, isCreating, error } = useCreateFaucet();
+export async function demo() {
+    // Initialize client to connect with the Miden Testnet.
+    const client = await MidenClient.createTestnet();
 
-    const handleCreate = async () => {
-        const decimals = 8;
-        const maxSupply = 10_000_000n * 10n ** BigInt(decimals);
+    // Faucet parameters
+    const decimals = 8;
+    const maxSupply = 10_000_000n * 10n ** BigInt(decimals);
 
-        const account = await createFaucet({
-            tokenSymbol: "TEST",
-            decimals,
-            maxSupply,
-            storageMode: "public",
-            authScheme: 0, // 0 = Falcon (default)
-        });
+    // Create a fungible token faucet.
+    const faucet = await client.accounts.create({
+        type: "FungibleFaucet",
+        symbol: "TEST",
+        decimals,
+        maxSupply,
+        storage: "public",
+    });
 
-        console.log("Faucet account ID:", account.id().toString());
-    };
-
-    if (error) return <div>Error: {error.message}</div>;
-    return (
-        <button onClick={handleCreate} disabled={isCreating}>
-            {isCreating ? "Creating..." : "Create Faucet"}
-        </button>
-    );
+    console.log("Faucet account ID:", faucet.id().toString());
 }
 `
 }

--- a/docs/builder/get-started/accounts.md
+++ b/docs/builder/get-started/accounts.md
@@ -115,7 +115,7 @@ To run the code examples in this guide, you'll need to set up a development envi
 
 ### Rust Environment
 
-If you already created `my-test-project` during [installation](./setup/installation), you can reuse it. Otherwise, create a new project:
+If you already created `my-test-project` during [installation](./setup/installation#rust-project), you can reuse it. Otherwise, create a new project:
 
 ```bash title=">_ Terminal"
 miden new my-project
@@ -136,7 +136,7 @@ cargo run --bin demo --release
 
 ### TypeScript Environment
 
-If you already created `miden-app` during [installation](./setup/installation#set-up-typescript-project), you can reuse it. Otherwise, scaffold a new Vite vanilla-ts project:
+If you already created `miden-app` during [installation](./setup/installation#typescript-project), you can reuse it. Otherwise, scaffold a new Vite vanilla-ts project:
 
 ```bash title=">_ Terminal"
 npm create vite@latest miden-app -- --template vanilla-ts

--- a/docs/builder/get-started/accounts.md
+++ b/docs/builder/get-started/accounts.md
@@ -136,26 +136,9 @@ cargo run --bin demo --release
 
 ### TypeScript Environment
 
-Create a new Miden frontend project:
+The TypeScript examples use the [`@miden-sdk/react`](https://www.npmjs.com/package/@miden-sdk/react) hooks library. If you haven't already, follow [Set Up React App](./setup/installation#set-up-react-app) to scaffold a project and wire up `MidenProvider`.
 
-```bash title=">_ Terminal"
-yarn create-miden-app
-cd miden-app/
-```
-
-For each code example, create a demo file:
-
-```bash title=">_ Terminal"
-touch src/lib/demo.ts
-```
-
-Copy the TypeScript code into the file, then import and call the `demo()` function in your `App.tsx`. Run the project:
-
-```bash title=">_ Terminal"
-yarn dev
-# or
-npm run dev
-```
+For each TypeScript example below, create a component file under `src/components/` (e.g. `src/components/CreateWallet.tsx`), paste the snippet, then import and render it inside `<MidenProvider>` in `src/App.tsx`. Run `yarn dev` and trigger the example from the browser.
 
 :::tip
 For detailed frontend setup guidance, see the [Tutorials section](../tutorials/rust-compiler/).
@@ -166,7 +149,7 @@ For detailed frontend setup guidance, see the [Tutorials section](../tutorials/r
 Let's start by creating accounts using the Miden client libraries:
 
 <CodeTabs
-tsFilename="src/lib/account.ts"
+tsFilename="src/components/CreateWallet.tsx"
 rustFilename="integration/src/bin/account.rs"
 example={{
 rust: {
@@ -237,29 +220,33 @@ async fn main() -> anyhow::Result<()> {
 }
 ` },
   typescript: {
-    code:`import { WebClient, AccountStorageMode, AuthScheme } from "@miden-sdk/miden-sdk";
+    code:`import { useCreateWallet } from "@miden-sdk/react";
 
-export async function demo() {
-    // Initialize client to connect with the Miden Testnet.
-    // NOTE: The client is our entry point to the Miden network.
-    // All interactions with the network go through the client.
-    const nodeEndpoint = "https://rpc.testnet.miden.io:443";
+// Mount inside <MidenProvider> in App.tsx.
+// See setup/installation#set-up-react-app.
+export function CreateWallet() {
+    const { createWallet, wallet, isCreating, error } = useCreateWallet();
 
-    // Initialize client
-    const client = await WebClient.createClient(nodeEndpoint);
-    await client.syncState();
+    const handleCreate = async () => {
+        // Create a new wallet account.
+        const account = await createWallet({
+            storageMode: "public", // Public: account state is visible onchain
+            mutable: true,         // Account code can be upgraded later
+            authScheme: 0,         // 0 = Falcon (default)
+        });
 
-    // Create new wallet account
-    const account = await client.newWallet(
-        AccountStorageMode.public(), // Public: account state is visible onchain
-        true, // Mutable: account code can be upgraded later
-        AuthScheme.AuthRpoFalcon512 // Authentication scheme
-    );
+        console.log("Account ID:", account.id().toString());
+        console.log(
+            "No Assets in Vault:",
+            account.vault().fungibleAssets().length === 0,
+        );
+    };
 
-    console.log("Account ID:", account.id().toString());
-    console.log(
-        "No Assets in Vault:",
-        account.vault().fungibleAssets().length === 0
+    if (error) return <div>Error: {error.message}</div>;
+    return (
+        <button onClick={handleCreate} disabled={isCreating}>
+            {isCreating ? "Creating..." : "Create Wallet"}
+        </button>
     );
 }
 `
@@ -282,7 +269,7 @@ No Assets in Vault: true
 Before we can work with tokens, we need a source of tokens. Let's create a fungible token faucet:
 
 <CodeTabs
-tsFilename="src/lib/faucet.ts"
+tsFilename="src/components/CreateFaucet.tsx"
 rustFilename="integration/src/bin/faucet.rs"
 example={{
 rust: {
@@ -361,32 +348,34 @@ async fn main() -> anyhow::Result<()> {
 }
 `},
   typescript: {
-    code:`import { WebClient, AccountStorageMode, AuthScheme } from "@miden-sdk/miden-sdk";
+    code:`import { useCreateFaucet } from "@miden-sdk/react";
 
-export async function demo() {
-    // Initialize client to connect with the Miden Testnet.
-    // NOTE: The client is our entry point to the Miden network.
-    // All interactions with the network go through the client.
-    const nodeEndpoint = "https://rpc.testnet.miden.io:443";
+// Mount inside <MidenProvider> in App.tsx.
+// See setup/installation#set-up-react-app.
+export function CreateFaucet() {
+    const { createFaucet, faucet, isCreating, error } = useCreateFaucet();
 
-    // Initialize client
-    const client = await WebClient.createClient(nodeEndpoint);
-    await client.syncState();
+    const handleCreate = async () => {
+        const decimals = 8;
+        const maxSupply = 10_000_000n * 10n ** BigInt(decimals);
 
-    const symbol = "TEST";
-    const decimals = 8;
-    const initialSupply = BigInt(10_000_000 * 10 ** decimals);
+        const account = await createFaucet({
+            tokenSymbol: "TEST",
+            decimals,
+            maxSupply,
+            storageMode: "public",
+            authScheme: 0, // 0 = Falcon (default)
+        });
 
-    const faucet = await client.newFaucet(
-        AccountStorageMode.public(),
-        false,
-        symbol,
-        decimals,
-        initialSupply,
-        AuthScheme.AuthRpoFalcon512 // Authentication scheme
+        console.log("Faucet account ID:", account.id().toString());
+    };
+
+    if (error) return <div>Error: {error.message}</div>;
+    return (
+        <button onClick={handleCreate} disabled={isCreating}>
+            {isCreating ? "Creating..." : "Create Faucet"}
+        </button>
     );
-
-    console.log("Faucet account ID:", faucet.id().toString());
 }
 `
 }

--- a/docs/builder/get-started/accounts.md
+++ b/docs/builder/get-started/accounts.md
@@ -4,8 +4,6 @@ title: Accounts
 description: Learn how to create and manage Miden accounts programmatically using Rust and TypeScript.
 ---
 
-import { CodeTabs } from '@site/src/components';
-
 # Accounts
 
 Miden's account model is fundamentally different from traditional blockchains. Let's explore how to create and manage accounts programmatically.
@@ -174,12 +172,8 @@ For detailed frontend setup guidance (React, wallets, UI), see the [Tutorials se
 
 Let's start by creating accounts using the Miden client libraries:
 
-<CodeTabs
-tsFilename="src/demo.ts"
-rustFilename="integration/src/bin/account.rs"
-example={{
-rust: {
-code: `use miden_client::{
+```rust title="integration/src/bin/account.rs"
+use miden_client::{
     account::{
         component::BasicWallet,
         AccountBuilder, AccountStorageMode, AccountType,
@@ -244,9 +238,10 @@ async fn main() -> anyhow::Result<()> {
 
     Ok(())
 }
-` },
-  typescript: {
-    code:`import { MidenClient } from "@miden-sdk/miden-sdk";
+```
+
+```typescript title="src/demo.ts"
+import { MidenClient } from "@miden-sdk/miden-sdk";
 
 export async function demo() {
     // Initialize client to connect with the Miden Testnet.
@@ -266,10 +261,7 @@ export async function demo() {
         wallet.vault().fungibleAssets().length === 0,
     );
 }
-`
-}
-}}
-/>
+```
 
 <details>
 <summary>Expected output</summary>
@@ -285,12 +277,8 @@ No Assets in Vault: true
 
 Before we can work with tokens, we need a source of tokens. Let's create a fungible token faucet:
 
-<CodeTabs
-tsFilename="src/demo.ts"
-rustFilename="integration/src/bin/faucet.rs"
-example={{
-rust: {
-code: `use miden_client::{
+```rust title="integration/src/bin/faucet.rs"
+use miden_client::{
     account::{
         component::BasicFungibleFaucet,
         AccountBuilder, AccountStorageMode, AccountType,
@@ -363,9 +351,10 @@ async fn main() -> anyhow::Result<()> {
 
     Ok(())
 }
-`},
-  typescript: {
-    code:`import { MidenClient } from "@miden-sdk/miden-sdk";
+```
+
+```typescript title="src/demo.ts"
+import { MidenClient } from "@miden-sdk/miden-sdk";
 
 export async function demo() {
     // Initialize client to connect with the Miden Testnet.
@@ -386,10 +375,7 @@ export async function demo() {
 
     console.log("Faucet account ID:", faucet.id().toString());
 }
-`
-}
-}}
-/>
+```
 
 <details>
 <summary>Expected output</summary>

--- a/docs/builder/get-started/accounts.md
+++ b/docs/builder/get-started/accounts.md
@@ -136,9 +136,29 @@ cargo run --bin demo --release
 
 ### TypeScript Environment
 
-The TypeScript examples use the [`@miden-sdk/react`](https://www.npmjs.com/package/@miden-sdk/react) hooks library. If you haven't already, follow [Set Up React App](./setup/installation#set-up-react-app) to scaffold a project with `yarn create-miden-app` — `MidenProvider` is pre-wired in the template.
+The TypeScript examples use the [`@miden-sdk/react`](https://www.npmjs.com/package/@miden-sdk/react) hooks library. If you already created `miden-app` during [installation](./setup/installation#set-up-react-app), you can reuse it. Otherwise, scaffold a new project:
 
-For each TypeScript example below, create a new file under `src/components/` (e.g. `src/components/CreateWallet.tsx`), paste the snippet, then import and render it inside `src/components/AppContent.tsx`. Run `yarn dev` and trigger the example from the browser.
+```bash title=">_ Terminal"
+yarn create-miden-app
+cd miden-app/
+yarn install
+```
+
+The generated project already has `MidenProvider` wired up in `src/providers.tsx`, so the hooks work out of the box. The RPC endpoint is read from `src/config.ts` (`MIDEN_RPC_URL`, defaults to `"testnet"`; override with `VITE_MIDEN_RPC_URL` for custom nodes or devnet).
+
+For each code example, create a new component file under `src/components/`:
+
+```bash title=">_ Terminal"
+touch src/components/CreateWallet.tsx
+```
+
+Copy the TypeScript code into the file, then import and render it inside `src/components/AppContent.tsx`. Run the dev server:
+
+```bash title=">_ Terminal"
+yarn dev
+```
+
+`yarn dev` hot-reloads on save — trigger the example from the browser.
 
 :::tip
 For detailed frontend setup guidance, see the [Tutorials section](../tutorials/rust-compiler/).

--- a/docs/builder/get-started/notes.md
+++ b/docs/builder/get-started/notes.md
@@ -78,7 +78,7 @@ Minting in Miden creates new tokens and packages them into a **P2ID note** (Pay-
 Let's see this in action:
 
 <CodeTabs
-tsFilename="src/components/MintTokens.tsx"
+tsFilename="src/demo.ts"
 rustFilename="integration/src/bin/mint.rs"
 example={{
 rust: {
@@ -204,53 +204,42 @@ async fn main() -> anyhow::Result<()> {
 }
 `},
   typescript: {
-    code:`import { useCreateWallet, useCreateFaucet, useMint } from "@miden-sdk/react";
+    code:`import { MidenClient } from "@miden-sdk/miden-sdk";
 
-// Import and render inside src/components/AppContent.tsx.
-// See setup/installation#set-up-react-app.
-export function MintTokens() {
-    const { createWallet } = useCreateWallet();
-    const { createFaucet } = useCreateFaucet();
-    const { mint, isLoading, stage, error } = useMint();
+export async function demo() {
+    // Initialize client to connect with the Miden Testnet.
+    const client = await MidenClient.createTestnet();
 
-    const handleMintDemo = async () => {
-        // Creating Alice's account
-        const alice = await createWallet({
-            storageMode: "public", // Public: account state is visible on-chain
-            mutable: true,
-        });
-        console.log("Alice's account ID:", alice.id().toString());
+    // Creating Alice's account
+    const alice = await client.accounts.create({
+        type: "MutableWallet",
+        storage: "public", // Public: account state is visible on-chain
+    });
+    console.log("Alice's account ID:", alice.id().toString());
 
-        // Creating a faucet account
-        const decimals = 8;
-        const maxSupply = 10_000_000n * 10n ** BigInt(decimals);
-        const faucet = await createFaucet({
-            tokenSymbol: "TEST",
-            decimals,
-            maxSupply,
-            storageMode: "public",
-        });
-        console.log("Faucet account ID:", faucet.id().toString());
+    // Creating a faucet account
+    const decimals = 8;
+    const maxSupply = 10_000_000n * 10n ** BigInt(decimals);
+    const faucet = await client.accounts.create({
+        type: "FungibleFaucet",
+        symbol: "TEST",
+        decimals,
+        maxSupply,
+        storage: "public",
+    });
+    console.log("Faucet account ID:", faucet.id().toString());
 
-        // Mint 1000 tokens to Alice.
-        // This creates a P2ID note containing the asset; Alice consumes it
-        // to actually receive the tokens in her vault (see the next section).
-        console.log("Minting 1000 tokens to Alice...");
-        const { transactionId } = await mint({
-            faucetId: faucet.id().toString(),
-            targetAccountId: alice.id().toString(),
-            amount: 1000n,
-            noteType: "public", // 'public' | 'private'
-        });
-        console.log("Mint transaction submitted successfully, ID:", transactionId);
-    };
-
-    if (error) return <div>Error: {error.message}</div>;
-    return (
-        <button onClick={handleMintDemo} disabled={isLoading}>
-            {isLoading ? \`Running (\${stage})...\` : "Run mint demo"}
-        </button>
-    );
+    // Mint 1000 tokens to Alice.
+    // This creates a P2ID note containing the asset; Alice consumes it
+    // to actually receive the tokens in her vault (see the next section).
+    console.log("Minting 1000 tokens to Alice...");
+    const { txId } = await client.transactions.mint({
+        account: faucet, // faucet is the executing account
+        to: alice,
+        amount: 1000n,
+        type: "public",  // note visibility
+    });
+    console.log("Mint transaction submitted successfully, ID:", txId.toString());
 }
 `
 }
@@ -291,7 +280,7 @@ This is a complete, self-contained example that includes the setup and minting s
 :::
 
 <CodeTabs
-tsFilename="src/components/ConsumeNote.tsx"
+tsFilename="src/demo.ts"
 rustFilename="integration/src/bin/consume.rs"
 example={{
 rust: {
@@ -471,89 +460,60 @@ async fn main() -> anyhow::Result<()> {
 }
 `},
   typescript: {
-    code:`import {
-    useCreateWallet,
-    useCreateFaucet,
-    useMint,
-    useWaitForNotes,
-    useConsume,
-    useMidenClient,
-} from "@miden-sdk/react";
+    code:`import { MidenClient } from "@miden-sdk/miden-sdk";
 
-// Import and render inside src/components/AppContent.tsx.
-// See setup/installation#set-up-react-app.
-export function ConsumeNote() {
-    const client = useMidenClient();
-    const { createWallet } = useCreateWallet();
-    const { createFaucet } = useCreateFaucet();
-    const { mint } = useMint();
-    const { waitForConsumableNotes } = useWaitForNotes();
-    const { consume, isLoading, stage, error } = useConsume();
+export async function demo() {
+    // Initialize client to connect with the Miden Testnet.
+    const client = await MidenClient.createTestnet();
 
-    const handleConsumeDemo = async () => {
-        // Creating Alice's account
-        const alice = await createWallet({
-            storageMode: "public",
-            mutable: true,
-        });
-        console.log("Alice's account ID:", alice.id().toString());
+    // Creating Alice's account
+    const alice = await client.accounts.create({
+        type: "MutableWallet",
+        storage: "public",
+    });
+    console.log("Alice's account ID:", alice.id().toString());
 
-        // Creating a faucet account
-        const decimals = 8;
-        const maxSupply = 10_000_000n * 10n ** BigInt(decimals);
-        const faucet = await createFaucet({
-            tokenSymbol: "TEST",
-            decimals,
-            maxSupply,
-            storageMode: "public",
-        });
-        console.log("Faucet account ID:", faucet.id().toString());
+    // Creating a faucet account
+    const decimals = 8;
+    const maxSupply = 10_000_000n * 10n ** BigInt(decimals);
+    const faucet = await client.accounts.create({
+        type: "FungibleFaucet",
+        symbol: "TEST",
+        decimals,
+        maxSupply,
+        storage: "public",
+    });
+    console.log("Faucet account ID:", faucet.id().toString());
 
-        // Mint 1000 tokens to Alice. Creates a P2ID note that she'll consume.
-        console.log("Minting 1000 tokens to Alice...");
-        const mintResult = await mint({
-            faucetId: faucet.id().toString(),
-            targetAccountId: alice.id().toString(),
-            amount: 1000n,
-            noteType: "public",
-        });
-        console.log(
-            "Mint transaction submitted successfully, ID:",
-            mintResult.transactionId,
-        );
-
-        // Public notes must be committed to a block before they can be consumed.
-        // waitForConsumableNotes polls the client and returns once the note is ready.
-        console.log("Waiting for note to be consumable...");
-        const notes = await waitForConsumableNotes({
-            accountId: alice.id().toString(),
-            minCount: 1,
-        });
-
-        // Consume the note — tokens move into Alice's vault.
-        const { transactionId } = await consume({
-            accountId: alice.id().toString(),
-            notes,
-        });
-        console.log(
-            "Consume transaction submitted successfully, ID:",
-            transactionId,
-        );
-
-        // Read Alice's TEST token balance.
-        const aliceAccount = await client.getAccount(alice.id());
-        console.log(
-            "Alice's TEST token balance:",
-            Number(aliceAccount!.vault().getBalance(faucet.id())),
-        );
-    };
-
-    if (error) return <div>Error: {error.message}</div>;
-    return (
-        <button onClick={handleConsumeDemo} disabled={isLoading}>
-            {isLoading ? \`Running (\${stage})...\` : "Run consume demo"}
-        </button>
+    // Mint 1000 tokens to Alice. Creates a P2ID note that she'll consume.
+    console.log("Minting 1000 tokens to Alice...");
+    const mintResult = await client.transactions.mint({
+        account: faucet,
+        to: alice,
+        amount: 1000n,
+        type: "public",
+        waitForConfirmation: true,
+    });
+    console.log(
+        "Mint transaction submitted successfully, ID:",
+        mintResult.txId.toString(),
     );
+
+    // List notes available to Alice and consume them — tokens move into her vault.
+    const notes = await client.notes.listAvailable({ account: alice });
+    const consumeResult = await client.transactions.consume({
+        account: alice,
+        notes: [notes[0]],
+        waitForConfirmation: true,
+    });
+    console.log(
+        "Consume transaction submitted successfully, ID:",
+        consumeResult.txId.toString(),
+    );
+
+    // Read Alice's TEST token balance directly via the accounts resource.
+    const balance = await client.accounts.getBalance(alice, faucet);
+    console.log("Alice's TEST token balance:", Number(balance));
 }
 `
 }
@@ -596,7 +556,7 @@ This is a complete, self-contained example that includes all previous steps. **T
 :::
 
 <CodeTabs
-tsFilename="src/components/SendTokens.tsx"
+tsFilename="src/demo.ts"
 rustFilename="integration/src/bin/send.rs"
 example={{
 rust: {
@@ -809,97 +769,70 @@ async fn main() -> anyhow::Result<()> {
 }
 `},
   typescript: {
-    code:`import {
-    useCreateWallet,
-    useCreateFaucet,
-    useMint,
-    useWaitForNotes,
-    useConsume,
-    useSend,
-    useMidenClient,
-} from "@miden-sdk/react";
+    code:`import { MidenClient } from "@miden-sdk/miden-sdk";
 
-// Import and render inside src/components/AppContent.tsx.
-// See setup/installation#set-up-react-app.
-export function SendTokens() {
-    const client = useMidenClient();
-    const { createWallet } = useCreateWallet();
-    const { createFaucet } = useCreateFaucet();
-    const { mint } = useMint();
-    const { waitForConsumableNotes } = useWaitForNotes();
-    const { consume } = useConsume();
-    const { send, isLoading, stage, error } = useSend();
+export async function demo() {
+    // Initialize client to connect with the Miden Testnet.
+    const client = await MidenClient.createTestnet();
 
-    const handleSendDemo = async () => {
-        // Create Alice's account and a faucet.
-        const alice = await createWallet({
-            storageMode: "public",
-            mutable: true,
-        });
-        console.log("Alice's account ID:", alice.id().toString());
+    // Create Alice's account and a faucet.
+    const alice = await client.accounts.create({
+        type: "MutableWallet",
+        storage: "public",
+    });
+    console.log("Alice's account ID:", alice.id().toString());
 
-        const decimals = 8;
-        const maxSupply = 10_000_000n * 10n ** BigInt(decimals);
-        const faucet = await createFaucet({
-            tokenSymbol: "TEST",
-            decimals,
-            maxSupply,
-            storageMode: "public",
-        });
-        console.log("Faucet account ID:", faucet.id().toString());
+    const decimals = 8;
+    const maxSupply = 10_000_000n * 10n ** BigInt(decimals);
+    const faucet = await client.accounts.create({
+        type: "FungibleFaucet",
+        symbol: "TEST",
+        decimals,
+        maxSupply,
+        storage: "public",
+    });
+    console.log("Faucet account ID:", faucet.id().toString());
 
-        // Mint 1000 tokens to Alice and consume the resulting P2ID note.
-        console.log("Minting 1000 tokens to Alice...");
-        const mintResult = await mint({
-            faucetId: faucet.id().toString(),
-            targetAccountId: alice.id().toString(),
-            amount: 1000n,
-            noteType: "public",
-        });
-        console.log(
-            "Mint transaction submitted successfully, ID:",
-            mintResult.transactionId,
-        );
-
-        console.log("Waiting for note to be consumable...");
-        const notes = await waitForConsumableNotes({
-            accountId: alice.id().toString(),
-            minCount: 1,
-        });
-        const consumeResult = await consume({
-            accountId: alice.id().toString(),
-            notes,
-        });
-        console.log(
-            "Consume transaction submitted successfully, ID:",
-            consumeResult.transactionId,
-        );
-
-        const aliceAccount = await client.getAccount(alice.id());
-        console.log(
-            "Alice's TEST token balance:",
-            Number(aliceAccount!.vault().getBalance(faucet.id())),
-        );
-
-        // Send 100 tokens from Alice to Bob.
-        const bobAccountId = "0x103f8a1ad4b983104aec0412ab0b0d";
-        console.log("Sending 100 tokens to Bob...");
-        const { transactionId } = await send({
-            from: alice.id().toString(),
-            to: bobAccountId,
-            assetId: faucet.id().toString(),
-            amount: 100n,
-            noteType: "public",
-        });
-        console.log("Send transaction submitted successfully, ID:", transactionId);
-    };
-
-    if (error) return <div>Error: {error.message}</div>;
-    return (
-        <button onClick={handleSendDemo} disabled={isLoading}>
-            {isLoading ? \`Running (\${stage})...\` : "Run send demo"}
-        </button>
+    // Mint 1000 tokens to Alice and consume the resulting P2ID note.
+    console.log("Minting 1000 tokens to Alice...");
+    const mintResult = await client.transactions.mint({
+        account: faucet,
+        to: alice,
+        amount: 1000n,
+        type: "public",
+        waitForConfirmation: true,
+    });
+    console.log(
+        "Mint transaction submitted successfully, ID:",
+        mintResult.txId.toString(),
     );
+
+    const notes = await client.notes.listAvailable({ account: alice });
+    const consumeResult = await client.transactions.consume({
+        account: alice,
+        notes: [notes[0]],
+        waitForConfirmation: true,
+    });
+    console.log(
+        "Consume transaction submitted successfully, ID:",
+        consumeResult.txId.toString(),
+    );
+
+    const balance = await client.accounts.getBalance(alice, faucet);
+    console.log("Alice's TEST token balance:", Number(balance));
+
+    // Send 100 tokens from Alice to Bob.
+    const bobAccountId = "0x103f8a1ad4b983104aec0412ab0b0d";
+    console.log("Sending 100 tokens to Bob...");
+    const { txId } = await client.transactions.send({
+        account: alice,
+        to: bobAccountId,
+        token: faucet,
+        amount: 100n,
+        type: "public",
+        waitForConfirmation: true,
+    });
+    console.log("Send transaction submitted successfully, ID:", txId.toString());
 }
 `
 }

--- a/docs/builder/get-started/notes.md
+++ b/docs/builder/get-started/notes.md
@@ -206,7 +206,7 @@ async fn main() -> anyhow::Result<()> {
   typescript: {
     code:`import { useCreateWallet, useCreateFaucet, useMint } from "@miden-sdk/react";
 
-// Mount inside <MidenProvider> in App.tsx.
+// Import and render inside src/components/AppContent.tsx.
 // See setup/installation#set-up-react-app.
 export function MintTokens() {
     const { createWallet } = useCreateWallet();
@@ -480,7 +480,7 @@ async fn main() -> anyhow::Result<()> {
     useMidenClient,
 } from "@miden-sdk/react";
 
-// Mount inside <MidenProvider> in App.tsx.
+// Import and render inside src/components/AppContent.tsx.
 // See setup/installation#set-up-react-app.
 export function ConsumeNote() {
     const client = useMidenClient();
@@ -819,7 +819,7 @@ async fn main() -> anyhow::Result<()> {
     useMidenClient,
 } from "@miden-sdk/react";
 
-// Mount inside <MidenProvider> in App.tsx.
+// Import and render inside src/components/AppContent.tsx.
 // See setup/installation#set-up-react-app.
 export function SendTokens() {
     const client = useMidenClient();

--- a/docs/builder/get-started/notes.md
+++ b/docs/builder/get-started/notes.md
@@ -78,7 +78,7 @@ Minting in Miden creates new tokens and packages them into a **P2ID note** (Pay-
 Let's see this in action:
 
 <CodeTabs
-tsFilename="src/lib/mint.ts"
+tsFilename="src/components/MintTokens.tsx"
 rustFilename="integration/src/bin/mint.rs"
 example={{
 rust: {
@@ -204,63 +204,53 @@ async fn main() -> anyhow::Result<()> {
 }
 `},
   typescript: {
-    code:`import {
-    WebClient,
-    AccountStorageMode,
-    NoteType,
-    AuthScheme,
-} from "@miden-sdk/miden-sdk";
+    code:`import { useCreateWallet, useCreateFaucet, useMint } from "@miden-sdk/react";
 
-export async function demo() {
-    // Initialize client to connect with the Miden Testnet.
-    // NOTE: The client is our entry point to the Miden network.
-    // All interactions with the network go through the client.
-    const nodeEndpoint = "https://rpc.testnet.miden.io:443";
+// Mount inside <MidenProvider> in App.tsx.
+// See setup/installation#set-up-react-app.
+export function MintTokens() {
+    const { createWallet } = useCreateWallet();
+    const { createFaucet } = useCreateFaucet();
+    const { mint, isLoading, stage, error } = useMint();
 
-    // Initialize client
-    const client = await WebClient.createClient(nodeEndpoint);
-    await client.syncState();
+    const handleMintDemo = async () => {
+        // Creating Alice's account
+        const alice = await createWallet({
+            storageMode: "public", // Public: account state is visible on-chain
+            mutable: true,
+        });
+        console.log("Alice's account ID:", alice.id().toString());
 
-    // Creating Alice's account
-    const alice = await client.newWallet(
-        AccountStorageMode.public(),
-        true,
-        AuthScheme.AuthRpoFalcon512
+        // Creating a faucet account
+        const decimals = 8;
+        const maxSupply = 10_000_000n * 10n ** BigInt(decimals);
+        const faucet = await createFaucet({
+            tokenSymbol: "TEST",
+            decimals,
+            maxSupply,
+            storageMode: "public",
+        });
+        console.log("Faucet account ID:", faucet.id().toString());
+
+        // Mint 1000 tokens to Alice.
+        // This creates a P2ID note containing the asset; Alice consumes it
+        // to actually receive the tokens in her vault (see the next section).
+        console.log("Minting 1000 tokens to Alice...");
+        const { transactionId } = await mint({
+            faucetId: faucet.id().toString(),
+            targetAccountId: alice.id().toString(),
+            amount: 1000n,
+            noteType: "public", // 'public' | 'private'
+        });
+        console.log("Mint transaction submitted successfully, ID:", transactionId);
+    };
+
+    if (error) return <div>Error: {error.message}</div>;
+    return (
+        <button onClick={handleMintDemo} disabled={isLoading}>
+            {isLoading ? \`Running (\${stage})...\` : "Run mint demo"}
+        </button>
     );
-    console.log("Alice's account ID:", alice.id().toString());
-
-    // Creating a faucet account
-    const symbol = "TEST";
-    const decimals = 8;
-    const initialSupply = BigInt(10_000_000 * 10 ** decimals);
-    const faucet = await client.newFaucet(
-        AccountStorageMode.public(), // Public: account state is visible on-chain
-        false, // Mutable: account code cannot be upgraded later
-        symbol, // Symbol of the token
-        decimals, // Number of decimals
-        initialSupply, // Initial supply of tokens
-        AuthScheme.AuthRpoFalcon512 // Authentication scheme
-    );
-    console.log("Faucet account ID:", faucet.id().toString());
-
-    // Create transaction request to mint fungible asset to Alice's account
-    // NOTE: This transaction will create a P2ID note (a Miden note containing the minted asset)
-    // for Alice's account. Alice will be able to consume these notes to get the fungible asset in her vault
-    console.log("Minting 1000 tokens to Alice...");
-    const mintTxRequest = client.newMintTransactionRequest(
-        alice.id(), // Target account (who receives the tokens)
-        faucet.id(), // Faucet account (who mints the tokens)
-        NoteType.Public, // Note visibility (public = on-chain)
-        BigInt(1000) // Amount to mint (in base units)
-    );
-    const mintTxId = await client.submitNewTransaction(
-        faucet.id(),
-        mintTxRequest
-    );
-
-    console.log("Mint transaction submitted successfully, ID:", mintTxId.toHex());
-
-    await client.syncState();
 }
 `
 }
@@ -301,7 +291,7 @@ This is a complete, self-contained example that includes the setup and minting s
 :::
 
 <CodeTabs
-tsFilename="src/lib/consume.ts"
+tsFilename="src/components/ConsumeNote.tsx"
 rustFilename="integration/src/bin/consume.rs"
 example={{
 rust: {
@@ -482,97 +472,88 @@ async fn main() -> anyhow::Result<()> {
 `},
   typescript: {
     code:`import {
-    WebClient,
-    AccountStorageMode,
-    NoteType,
-    AuthScheme,
-    ConsumableNoteRecord,
-} from "@miden-sdk/miden-sdk";
+    useCreateWallet,
+    useCreateFaucet,
+    useMint,
+    useWaitForNotes,
+    useConsume,
+    useMidenClient,
+} from "@miden-sdk/react";
 
-export async function demo() {
-    // Initialize client to connect with the Miden Testnet.
-    // NOTE: The client is our entry point to the Miden network.
-    // All interactions with the network go through the client.
-    const nodeEndpoint = "https://rpc.testnet.miden.io:443";
+// Mount inside <MidenProvider> in App.tsx.
+// See setup/installation#set-up-react-app.
+export function ConsumeNote() {
+    const client = useMidenClient();
+    const { createWallet } = useCreateWallet();
+    const { createFaucet } = useCreateFaucet();
+    const { mint } = useMint();
+    const { waitForConsumableNotes } = useWaitForNotes();
+    const { consume, isLoading, stage, error } = useConsume();
 
-    // Initialize client
-    const client = await WebClient.createClient(nodeEndpoint);
-    await client.syncState();
+    const handleConsumeDemo = async () => {
+        // Creating Alice's account
+        const alice = await createWallet({
+            storageMode: "public",
+            mutable: true,
+        });
+        console.log("Alice's account ID:", alice.id().toString());
 
-    // Creating Alice's account
-    const alice = await client.newWallet(
-        AccountStorageMode.public(),
-        true,
-        AuthScheme.AuthRpoFalcon512
-    );
-    console.log("Alice's account ID:", alice.id().toString());
+        // Creating a faucet account
+        const decimals = 8;
+        const maxSupply = 10_000_000n * 10n ** BigInt(decimals);
+        const faucet = await createFaucet({
+            tokenSymbol: "TEST",
+            decimals,
+            maxSupply,
+            storageMode: "public",
+        });
+        console.log("Faucet account ID:", faucet.id().toString());
 
-    // Creating a faucet account
-    const symbol = "TEST";
-    const decimals = 8;
-    const initialSupply = BigInt(10_000_000 * 10 ** decimals);
-    const faucet = await client.newFaucet(
-        AccountStorageMode.public(), // Public: account state is visible on-chain
-        false, // Mutable: account code cannot be upgraded later
-        symbol, // Symbol of the token
-        decimals, // Number of decimals
-        initialSupply, // Initial supply of tokens
-        AuthScheme.AuthRpoFalcon512 // Authentication scheme
-    );
-    console.log("Faucet account ID:", faucet.id().toString());
+        // Mint 1000 tokens to Alice. Creates a P2ID note that she'll consume.
+        console.log("Minting 1000 tokens to Alice...");
+        const mintResult = await mint({
+            faucetId: faucet.id().toString(),
+            targetAccountId: alice.id().toString(),
+            amount: 1000n,
+            noteType: "public",
+        });
+        console.log(
+            "Mint transaction submitted successfully, ID:",
+            mintResult.transactionId,
+        );
 
-    // Create transaction request to mint fungible asset to Alice's account
-    // NOTE: This transaction will create a P2ID note (a Miden note containing the minted asset)
-    // for Alice's account. Alice will be able to consume these notes to get the fungible asset in her vault
-    console.log("Minting 1000 tokens to Alice...");
-    const mintTxRequest = client.newMintTransactionRequest(
-        alice.id(), // Target account (who receives the tokens)
-        faucet.id(), // Faucet account (who mints the tokens)
-        NoteType.Public, // Note visibility (public = on-chain)
-        BigInt(1000) // Amount to mint (in base units)
-    );
-    const mintTxId = await client.submitNewTransaction(
-        faucet.id(),
-        mintTxRequest
-    );
-
-    console.log("Mint transaction submitted successfully, ID:", mintTxId.toHex());
-
-    await client.syncState();
-
-    // Public notes must be committed to a block before they can be consumed.
-    // Poll until the network includes our mint note in a block.
-    let consumableNotes: ConsumableNoteRecord[] = [];
-    while (consumableNotes.length === 0) {
-        // Find consumable notes
-        consumableNotes = await client.getConsumableNotes(alice.id());
-
+        // Public notes must be committed to a block before they can be consumed.
+        // waitForConsumableNotes polls the client and returns once the note is ready.
         console.log("Waiting for note to be consumable...");
-        await new Promise((resolve) => setTimeout(resolve, 3000));
-    }
+        const notes = await waitForConsumableNotes({
+            accountId: alice.id().toString(),
+            minCount: 1,
+        });
 
-    const notes = consumableNotes.map((note) =>
-        note.inputNoteRecord().toNote()
-    );
+        // Consume the note — tokens move into Alice's vault.
+        const { transactionId } = await consume({
+            accountId: alice.id().toString(),
+            notes,
+        });
+        console.log(
+            "Consume transaction submitted successfully, ID:",
+            transactionId,
+        );
 
-    // Create transaction request to consume notes
-    // NOTE: This transaction will consume the notes and add the fungible asset to Alice's vault
-    const consumeTxRequest = client.newConsumeTransactionRequest(notes);
-    const consumeTxId = await client.submitNewTransaction(
-        alice.id(),
-        consumeTxRequest
-    );
-    console.log(
-        "Consume transaction submitted successfully, ID:",
-        consumeTxId.toHex()
-    );
+        // Read Alice's TEST token balance.
+        const aliceAccount = await client.getAccount(alice.id());
+        console.log(
+            "Alice's TEST token balance:",
+            Number(aliceAccount!.vault().getBalance(faucet.id())),
+        );
+    };
 
-    console.log(
-        "Alice's TEST token balance:",
-        Number(alice.vault().getBalance(faucet.id()))
+    if (error) return <div>Error: {error.message}</div>;
+    return (
+        <button onClick={handleConsumeDemo} disabled={isLoading}>
+            {isLoading ? \`Running (\${stage})...\` : "Run consume demo"}
+        </button>
     );
-
-    await client.syncState();
 }
 `
 }
@@ -615,7 +596,7 @@ This is a complete, self-contained example that includes all previous steps. **T
 :::
 
 <CodeTabs
-tsFilename="src/lib/send.ts"
+tsFilename="src/components/SendTokens.tsx"
 rustFilename="integration/src/bin/send.rs"
 example={{
 rust: {
@@ -829,116 +810,96 @@ async fn main() -> anyhow::Result<()> {
 `},
   typescript: {
     code:`import {
-    WebClient,
-    AccountStorageMode,
-    NoteType,
-    ConsumableNoteRecord,
-    AccountId,
-    AuthScheme,
-} from "@miden-sdk/miden-sdk";
+    useCreateWallet,
+    useCreateFaucet,
+    useMint,
+    useWaitForNotes,
+    useConsume,
+    useSend,
+    useMidenClient,
+} from "@miden-sdk/react";
 
-export async function demo() {
-    // Initialize client to connect with the Miden Testnet.
-    // NOTE: The client is our entry point to the Miden network.
-    // All interactions with the network go through the client.
-    const nodeEndpoint = "https://rpc.testnet.miden.io:443";
+// Mount inside <MidenProvider> in App.tsx.
+// See setup/installation#set-up-react-app.
+export function SendTokens() {
+    const client = useMidenClient();
+    const { createWallet } = useCreateWallet();
+    const { createFaucet } = useCreateFaucet();
+    const { mint } = useMint();
+    const { waitForConsumableNotes } = useWaitForNotes();
+    const { consume } = useConsume();
+    const { send, isLoading, stage, error } = useSend();
 
-    // Initialize client
-    const client = await WebClient.createClient(nodeEndpoint);
-    await client.syncState();
+    const handleSendDemo = async () => {
+        // Create Alice's account and a faucet.
+        const alice = await createWallet({
+            storageMode: "public",
+            mutable: true,
+        });
+        console.log("Alice's account ID:", alice.id().toString());
 
-    // Creating Alice's account
-    const alice = await client.newWallet(
-        AccountStorageMode.public(),
-        true,
-        AuthScheme.AuthRpoFalcon512
-    );
-    console.log("Alice's account ID:", alice.id().toString());
+        const decimals = 8;
+        const maxSupply = 10_000_000n * 10n ** BigInt(decimals);
+        const faucet = await createFaucet({
+            tokenSymbol: "TEST",
+            decimals,
+            maxSupply,
+            storageMode: "public",
+        });
+        console.log("Faucet account ID:", faucet.id().toString());
 
-    // Creating a faucet account
-    const symbol = "TEST";
-    const decimals = 8;
-    const initialSupply = BigInt(10_000_000 * 10 ** decimals);
-    const faucet = await client.newFaucet(
-        AccountStorageMode.public(), // Public: account state is visible on-chain
-        false, // Mutable: account code cannot be upgraded later
-        symbol, // Symbol of the token
-        decimals, // Number of decimals
-        initialSupply, // Initial supply of tokens
-        AuthScheme.AuthRpoFalcon512 // Authentication scheme
-    );
-    console.log("Faucet account ID:", faucet.id().toString());
-
-    // Create transaction request to mint fungible asset to Alice's account
-    // NOTE: This transaction will create a P2ID note (a Miden note containing the minted asset)
-    // for Alice's account. Alice will be able to consume these notes to get the fungible asset in her vault
-    console.log("Minting 1000 tokens to Alice...");
-    const mintTxRequest = client.newMintTransactionRequest(
-        alice.id(), // Target account (who receives the tokens)
-        faucet.id(), // Faucet account (who mints the tokens)
-        NoteType.Public, // Note visibility (public = on-chain)
-        BigInt(1000) // Amount to mint (in base units)
-    );
-    const mintTxId = await client.submitNewTransaction(
-        faucet.id(),
-        mintTxRequest
-    );
-
-    console.log("Mint transaction submitted successfully, ID:", mintTxId.toHex());
-
-    await client.syncState();
-
-    // Public notes must be committed to a block before they can be consumed.
-    // Poll until the network includes our mint note in a block.
-    let consumableNotes: ConsumableNoteRecord[] = [];
-    while (consumableNotes.length === 0) {
-        // Find consumable notes
-        consumableNotes = await client.getConsumableNotes(alice.id());
+        // Mint 1000 tokens to Alice and consume the resulting P2ID note.
+        console.log("Minting 1000 tokens to Alice...");
+        const mintResult = await mint({
+            faucetId: faucet.id().toString(),
+            targetAccountId: alice.id().toString(),
+            amount: 1000n,
+            noteType: "public",
+        });
+        console.log(
+            "Mint transaction submitted successfully, ID:",
+            mintResult.transactionId,
+        );
 
         console.log("Waiting for note to be consumable...");
-        await new Promise((resolve) => setTimeout(resolve, 3000));
-    }
+        const notes = await waitForConsumableNotes({
+            accountId: alice.id().toString(),
+            minCount: 1,
+        });
+        const consumeResult = await consume({
+            accountId: alice.id().toString(),
+            notes,
+        });
+        console.log(
+            "Consume transaction submitted successfully, ID:",
+            consumeResult.transactionId,
+        );
 
-    const notes = consumableNotes.map((note) =>
-        note.inputNoteRecord().toNote()
+        const aliceAccount = await client.getAccount(alice.id());
+        console.log(
+            "Alice's TEST token balance:",
+            Number(aliceAccount!.vault().getBalance(faucet.id())),
+        );
+
+        // Send 100 tokens from Alice to Bob.
+        const bobAccountId = "0x103f8a1ad4b983104aec0412ab0b0d";
+        console.log("Sending 100 tokens to Bob...");
+        const { transactionId } = await send({
+            from: alice.id().toString(),
+            to: bobAccountId,
+            assetId: faucet.id().toString(),
+            amount: 100n,
+            noteType: "public",
+        });
+        console.log("Send transaction submitted successfully, ID:", transactionId);
+    };
+
+    if (error) return <div>Error: {error.message}</div>;
+    return (
+        <button onClick={handleSendDemo} disabled={isLoading}>
+            {isLoading ? \`Running (\${stage})...\` : "Run send demo"}
+        </button>
     );
-
-    // Create transaction request to consume notes
-    // NOTE: This transaction will consume the notes and add the fungible asset to Alice's vault
-    const consumeTxRequest = client.newConsumeTransactionRequest(notes);
-    const consumeTxId = await client.submitNewTransaction(
-        alice.id(),
-        consumeTxRequest
-    );
-    console.log(
-        "Consume transaction submitted successfully, ID:",
-        consumeTxId.toHex()
-    );
-
-    console.log(
-        "Alice's TEST token balance:",
-        Number(alice.vault().getBalance(faucet.id()))
-    );
-
-    await client.syncState();
-
-    // Send tokens from Alice to Bob
-    const bobAccountId = "0x103f8a1ad4b983104aec0412ab0b0d";
-    console.log("Sending 100 tokens to Bob...");
-
-    // Build transaction request to send tokens from Alice to Bob
-    const sendTxRequest = client.newSendTransactionRequest(
-        alice.id(), // Sender account
-        AccountId.fromHex(bobAccountId), // Recipient account
-        faucet.id(), // Asset ID (faucet that created the tokens)
-        NoteType.Public, // Note visibility
-        BigInt(100) // Amount to send
-    );
-
-    const sendTxId = await client.submitNewTransaction(alice.id(), sendTxRequest);
-    console.log("Send transaction submitted successfully, ID:", sendTxId.toHex());
-
-    await client.syncState();
 }
 `
 }

--- a/docs/builder/get-started/notes.md
+++ b/docs/builder/get-started/notes.md
@@ -557,7 +557,7 @@ use miden_client::{
     keystore::{FilesystemKeyStore, Keystore},
     note::{NoteAttachment, NoteType, P2idNote},
     rpc::{Endpoint, GrpcClient},
-    transaction::{OutputNote, TransactionRequestBuilder},
+    transaction::TransactionRequestBuilder,
     Felt,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
@@ -739,7 +739,7 @@ async fn main() -> anyhow::Result<()> {
 
     // Create transaction request to send P2ID note to Bob
     let send_p2id_note_transaction_request = TransactionRequestBuilder::new()
-        .own_output_notes(vec![OutputNote::Full(p2id_note)])
+        .own_output_notes(vec![p2id_note])
         .build()?;
 
     // Create transaction and submit it to send P2ID note to Bob

--- a/docs/builder/get-started/notes.md
+++ b/docs/builder/get-started/notes.md
@@ -4,8 +4,6 @@ title: Notes & Transactions
 description: Learn Miden's unique note-based transaction model for asset transfers between accounts.
 ---
 
-import { CodeTabs } from '@site/src/components';
-
 # Notes & Transactions
 
 Miden's transaction model is uniquely powerful, combining private asset transfers through notes with zero-knowledge proofs. Let's explore how to mint, consume, and send tokens using this innovative approach.
@@ -77,12 +75,8 @@ Minting in Miden creates new tokens and packages them into a **P2ID note** (Pay-
 
 Let's see this in action:
 
-<CodeTabs
-tsFilename="src/demo.ts"
-rustFilename="integration/src/bin/mint.rs"
-example={{
-rust: {
-code: `use miden_client::{
+```rust title="integration/src/bin/mint.rs"
+use miden_client::{
     account::{
         component::{BasicFungibleFaucet, BasicWallet},
         AccountBuilder, AccountStorageMode, AccountType,
@@ -202,9 +196,10 @@ async fn main() -> anyhow::Result<()> {
 
     Ok(())
 }
-`},
-  typescript: {
-    code:`import { MidenClient } from "@miden-sdk/miden-sdk";
+```
+
+```typescript title="src/demo.ts"
+import { MidenClient } from "@miden-sdk/miden-sdk";
 
 export async function demo() {
     // Initialize client to connect with the Miden Testnet.
@@ -241,10 +236,7 @@ export async function demo() {
     });
     console.log("Mint transaction submitted successfully, ID:", txId.toString());
 }
-`
-}
-}}
-/>
+```
 
 <details>
 <summary>Expected output</summary>
@@ -279,12 +271,8 @@ Here's how to consume notes programmatically:
 This is a complete, self-contained example that includes the setup and minting steps from the previous section. **The new consume logic starts at the `CONSUMING P2ID NOTES` comment.**
 :::
 
-<CodeTabs
-tsFilename="src/demo.ts"
-rustFilename="integration/src/bin/consume.rs"
-example={{
-rust: {
-code: `use miden_client::{
+```rust title="integration/src/bin/consume.rs"
+use miden_client::{
     account::{
         component::{BasicFungibleFaucet, BasicWallet},
         Account, AccountBuilder, AccountStorageMode, AccountType,
@@ -458,9 +446,10 @@ async fn main() -> anyhow::Result<()> {
 
     Ok(())
 }
-`},
-  typescript: {
-    code:`import { MidenClient } from "@miden-sdk/miden-sdk";
+```
+
+```typescript title="src/demo.ts"
+import { MidenClient } from "@miden-sdk/miden-sdk";
 
 export async function demo() {
     // Initialize client to connect with the Miden Testnet.
@@ -515,10 +504,7 @@ export async function demo() {
     const balance = await client.accounts.getBalance(alice, faucet);
     console.log("Alice's TEST token balance:", Number(balance));
 }
-`
-}
-}}
-/>
+```
 
 <details>
 <summary>Expected output</summary>
@@ -555,12 +541,8 @@ Let's implement the complete flow - mint, consume, then send:
 This is a complete, self-contained example that includes all previous steps. **The new send logic starts at the `SENDING TOKENS TO BOB` comment.**
 :::
 
-<CodeTabs
-tsFilename="src/demo.ts"
-rustFilename="integration/src/bin/send.rs"
-example={{
-rust: {
-code: `use miden_client::{
+```rust title="integration/src/bin/send.rs"
+use miden_client::{
     account::{
         component::{BasicFungibleFaucet, BasicWallet},
         Account, AccountBuilder, AccountId, AccountStorageMode, AccountType,
@@ -767,9 +749,10 @@ async fn main() -> anyhow::Result<()> {
 
     Ok(())
 }
-`},
-  typescript: {
-    code:`import { MidenClient } from "@miden-sdk/miden-sdk";
+```
+
+```typescript title="src/demo.ts"
+import { MidenClient } from "@miden-sdk/miden-sdk";
 
 export async function demo() {
     // Initialize client to connect with the Miden Testnet.
@@ -834,10 +817,7 @@ export async function demo() {
     });
     console.log("Send transaction submitted successfully, ID:", txId.toString());
 }
-`
-}
-}}
-/>
+```
 
 <details>
 <summary>Expected output</summary>

--- a/docs/builder/get-started/notes.md
+++ b/docs/builder/get-started/notes.md
@@ -78,13 +78,13 @@ Let's see this in action:
 ```rust title="integration/src/bin/mint.rs"
 use miden_client::{
     account::{
-        component::{BasicFungibleFaucet, BasicWallet},
+        component::{AuthScheme, AuthSingleSig, BasicFungibleFaucet, BasicWallet},
         AccountBuilder, AccountStorageMode, AccountType,
     },
     asset::{FungibleAsset, TokenSymbol},
-    auth::{AuthFalcon512Rpo, AuthSecretKey},
+    auth::AuthSecretKey,
     builder::ClientBuilder,
-    keystore::FilesystemKeyStore,
+    keystore::{FilesystemKeyStore, Keystore},
     note::NoteType,
     rpc::{Endpoint, GrpcClient},
     transaction::TransactionRequestBuilder,
@@ -135,15 +135,16 @@ async fn main() -> anyhow::Result<()> {
     let max_supply = Felt::new(1_000_000);
 
     // Generate key pair
-    let alice_key_pair = AuthSecretKey::new_falcon512_rpo();
-    let faucet_key_pair = AuthSecretKey::new_falcon512_rpo();
+    let alice_key_pair = AuthSecretKey::new_falcon512_poseidon2();
+    let faucet_key_pair = AuthSecretKey::new_falcon512_poseidon2();
 
     // Build the account
     let account_builder = AccountBuilder::new(init_seed)
         .account_type(AccountType::RegularAccountUpdatableCode)
         .storage_mode(AccountStorageMode::Public)
-        .with_auth_component(AuthFalcon512Rpo::new(
+        .with_auth_component(AuthSingleSig::new(
             alice_key_pair.public_key().to_commitment(),
+            AuthScheme::Falcon512Poseidon2,
         ))
         .with_component(BasicWallet);
 
@@ -151,8 +152,9 @@ async fn main() -> anyhow::Result<()> {
     let faucet_builder = AccountBuilder::new(init_seed)
         .account_type(AccountType::FungibleFaucet)
         .storage_mode(AccountStorageMode::Public)
-        .with_auth_component(AuthFalcon512Rpo::new(
+        .with_auth_component(AuthSingleSig::new(
             faucet_key_pair.public_key().to_commitment(),
+            AuthScheme::Falcon512Poseidon2,
         ))
         .with_component(BasicFungibleFaucet::new(symbol, decimals, max_supply)?);
 
@@ -167,8 +169,8 @@ async fn main() -> anyhow::Result<()> {
     client.add_account(&faucet_account, false).await?;
 
     // Add keys to keystore
-    keystore.add_key(&alice_key_pair)?;
-    keystore.add_key(&faucet_key_pair)?;
+    keystore.add_key(&alice_key_pair, alice_account.id()).await?;
+    keystore.add_key(&faucet_key_pair, faucet_account.id()).await?;
 
     let amount: u64 = 1000;
     let fungible_asset = FungibleAsset::new(faucet_account.id(), amount)?;
@@ -199,7 +201,7 @@ async fn main() -> anyhow::Result<()> {
 ```
 
 ```typescript title="src/demo.ts"
-import { MidenClient } from "@miden-sdk/miden-sdk";
+import { MidenClient, AccountType } from "@miden-sdk/miden-sdk";
 
 export async function demo() {
     // Initialize client to connect with the Miden Testnet.
@@ -207,7 +209,7 @@ export async function demo() {
 
     // Creating Alice's account
     const alice = await client.accounts.create({
-        type: "MutableWallet",
+        type: AccountType.MutableWallet,
         storage: "public", // Public: account state is visible on-chain
     });
     console.log("Alice's account ID:", alice.id().toString());
@@ -216,7 +218,7 @@ export async function demo() {
     const decimals = 8;
     const maxSupply = 10_000_000n * 10n ** BigInt(decimals);
     const faucet = await client.accounts.create({
-        type: "FungibleFaucet",
+        type: AccountType.FungibleFaucet,
         symbol: "TEST",
         decimals,
         maxSupply,
@@ -274,13 +276,13 @@ This is a complete, self-contained example that includes the setup and minting s
 ```rust title="integration/src/bin/consume.rs"
 use miden_client::{
     account::{
-        component::{BasicFungibleFaucet, BasicWallet},
+        component::{AuthScheme, AuthSingleSig, BasicFungibleFaucet, BasicWallet},
         Account, AccountBuilder, AccountStorageMode, AccountType,
     },
     asset::{FungibleAsset, TokenSymbol},
-    auth::{AuthFalcon512Rpo, AuthSecretKey},
+    auth::AuthSecretKey,
     builder::ClientBuilder,
-    keystore::FilesystemKeyStore,
+    keystore::{FilesystemKeyStore, Keystore},
     note::NoteType,
     rpc::{Endpoint, GrpcClient},
     transaction::TransactionRequestBuilder,
@@ -332,15 +334,16 @@ async fn main() -> anyhow::Result<()> {
     let max_supply = Felt::new(1_000_000);
 
     // Generate key pair
-    let alice_key_pair = AuthSecretKey::new_falcon512_rpo();
-    let faucet_key_pair = AuthSecretKey::new_falcon512_rpo();
+    let alice_key_pair = AuthSecretKey::new_falcon512_poseidon2();
+    let faucet_key_pair = AuthSecretKey::new_falcon512_poseidon2();
 
     // Build the account
     let account_builder = AccountBuilder::new(init_seed)
         .account_type(AccountType::RegularAccountUpdatableCode)
         .storage_mode(AccountStorageMode::Public)
-        .with_auth_component(AuthFalcon512Rpo::new(
+        .with_auth_component(AuthSingleSig::new(
             alice_key_pair.public_key().to_commitment(),
+            AuthScheme::Falcon512Poseidon2,
         ))
         .with_component(BasicWallet);
 
@@ -348,8 +351,9 @@ async fn main() -> anyhow::Result<()> {
     let faucet_builder = AccountBuilder::new(init_seed)
         .account_type(AccountType::FungibleFaucet)
         .storage_mode(AccountStorageMode::Public)
-        .with_auth_component(AuthFalcon512Rpo::new(
+        .with_auth_component(AuthSingleSig::new(
             faucet_key_pair.public_key().to_commitment(),
+            AuthScheme::Falcon512Poseidon2,
         ))
         .with_component(BasicFungibleFaucet::new(symbol, decimals, max_supply)?);
 
@@ -364,8 +368,8 @@ async fn main() -> anyhow::Result<()> {
     client.add_account(&faucet_account, false).await?;
 
     // Add keys to keystore
-    keystore.add_key(&alice_key_pair)?;
-    keystore.add_key(&faucet_key_pair)?;
+    keystore.add_key(&alice_key_pair, alice_account.id()).await?;
+    keystore.add_key(&faucet_key_pair, faucet_account.id()).await?;
 
     let amount: u64 = 1000;
     let fungible_asset = FungibleAsset::new(faucet_account.id(), amount)?;
@@ -449,7 +453,7 @@ async fn main() -> anyhow::Result<()> {
 ```
 
 ```typescript title="src/demo.ts"
-import { MidenClient } from "@miden-sdk/miden-sdk";
+import { MidenClient, AccountType } from "@miden-sdk/miden-sdk";
 
 export async function demo() {
     // Initialize client to connect with the Miden Testnet.
@@ -457,7 +461,7 @@ export async function demo() {
 
     // Creating Alice's account
     const alice = await client.accounts.create({
-        type: "MutableWallet",
+        type: AccountType.MutableWallet,
         storage: "public",
     });
     console.log("Alice's account ID:", alice.id().toString());
@@ -466,7 +470,7 @@ export async function demo() {
     const decimals = 8;
     const maxSupply = 10_000_000n * 10n ** BigInt(decimals);
     const faucet = await client.accounts.create({
-        type: "FungibleFaucet",
+        type: AccountType.FungibleFaucet,
         symbol: "TEST",
         decimals,
         maxSupply,
@@ -544,14 +548,14 @@ This is a complete, self-contained example that includes all previous steps. **T
 ```rust title="integration/src/bin/send.rs"
 use miden_client::{
     account::{
-        component::{BasicFungibleFaucet, BasicWallet},
+        component::{AuthScheme, AuthSingleSig, BasicFungibleFaucet, BasicWallet},
         Account, AccountBuilder, AccountId, AccountStorageMode, AccountType,
     },
     asset::{FungibleAsset, TokenSymbol},
-    auth::{AuthFalcon512Rpo, AuthSecretKey},
+    auth::AuthSecretKey,
     builder::ClientBuilder,
-    keystore::FilesystemKeyStore,
-    note::{create_p2id_note, NoteAttachment, NoteType},
+    keystore::{FilesystemKeyStore, Keystore},
+    note::{NoteAttachment, NoteType, P2idNote},
     rpc::{Endpoint, GrpcClient},
     transaction::{OutputNote, TransactionRequestBuilder},
     Felt,
@@ -602,15 +606,16 @@ async fn main() -> anyhow::Result<()> {
     let max_supply = Felt::new(1_000_000);
 
     // Generate key pair
-    let alice_key_pair = AuthSecretKey::new_falcon512_rpo();
-    let faucet_key_pair = AuthSecretKey::new_falcon512_rpo();
+    let alice_key_pair = AuthSecretKey::new_falcon512_poseidon2();
+    let faucet_key_pair = AuthSecretKey::new_falcon512_poseidon2();
 
     // Build the account
     let account_builder = AccountBuilder::new(init_seed)
         .account_type(AccountType::RegularAccountUpdatableCode)
         .storage_mode(AccountStorageMode::Public)
-        .with_auth_component(AuthFalcon512Rpo::new(
+        .with_auth_component(AuthSingleSig::new(
             alice_key_pair.public_key().to_commitment(),
+            AuthScheme::Falcon512Poseidon2,
         ))
         .with_component(BasicWallet);
 
@@ -618,8 +623,9 @@ async fn main() -> anyhow::Result<()> {
     let faucet_builder = AccountBuilder::new(init_seed)
         .account_type(AccountType::FungibleFaucet)
         .storage_mode(AccountStorageMode::Public)
-        .with_auth_component(AuthFalcon512Rpo::new(
+        .with_auth_component(AuthSingleSig::new(
             faucet_key_pair.public_key().to_commitment(),
+            AuthScheme::Falcon512Poseidon2,
         ))
         .with_component(BasicFungibleFaucet::new(symbol, decimals, max_supply)?);
 
@@ -634,8 +640,8 @@ async fn main() -> anyhow::Result<()> {
     client.add_account(&faucet_account, false).await?;
 
     // Add keys to keystore
-    keystore.add_key(&alice_key_pair)?;
-    keystore.add_key(&faucet_key_pair)?;
+    keystore.add_key(&alice_key_pair, alice_account.id()).await?;
+    keystore.add_key(&faucet_key_pair, faucet_account.id()).await?;
 
     let amount: u64 = 1000;
     let fungible_asset = FungibleAsset::new(faucet_account.id(), amount)?;
@@ -722,7 +728,7 @@ async fn main() -> anyhow::Result<()> {
     let send_amount = 100;
     let fungible_asset_to_send = FungibleAsset::new(faucet_account.id(), send_amount)?;
 
-    let p2id_note = create_p2id_note(
+    let p2id_note = P2idNote::create(
         alice_account.id(),
         bob_account_id,
         vec![fungible_asset_to_send.into()],
@@ -752,7 +758,7 @@ async fn main() -> anyhow::Result<()> {
 ```
 
 ```typescript title="src/demo.ts"
-import { MidenClient } from "@miden-sdk/miden-sdk";
+import { MidenClient, AccountType } from "@miden-sdk/miden-sdk";
 
 export async function demo() {
     // Initialize client to connect with the Miden Testnet.
@@ -760,7 +766,7 @@ export async function demo() {
 
     // Create Alice's account and a faucet.
     const alice = await client.accounts.create({
-        type: "MutableWallet",
+        type: AccountType.MutableWallet,
         storage: "public",
     });
     console.log("Alice's account ID:", alice.id().toString());
@@ -768,7 +774,7 @@ export async function demo() {
     const decimals = 8;
     const maxSupply = 10_000_000n * 10n ** BigInt(decimals);
     const faucet = await client.accounts.create({
-        type: "FungibleFaucet",
+        type: AccountType.FungibleFaucet,
         symbol: "TEST",
         decimals,
         maxSupply,

--- a/docs/builder/get-started/read-storage.md
+++ b/docs/builder/get-started/read-storage.md
@@ -110,7 +110,7 @@ async fn main() -> anyhow::Result<()> {
     code:`import { useMidenClient } from "@miden-sdk/react";
 import { AccountId, Word } from "@miden-sdk/miden-sdk";
 
-// Mount inside <MidenProvider> in App.tsx.
+// Import and render inside src/components/AppContent.tsx.
 // See setup/installation#set-up-react-app.
 export function ReadCount() {
     const client = useMidenClient();
@@ -222,7 +222,7 @@ async fn main() -> anyhow::Result<()> {
     code:`import { useMidenClient } from "@miden-sdk/react";
 import { AccountId } from "@miden-sdk/miden-sdk";
 
-// Mount inside <MidenProvider> in App.tsx.
+// Import and render inside src/components/AppContent.tsx.
 // See setup/installation#set-up-react-app.
 export function ReadBalance() {
     const client = useMidenClient();

--- a/docs/builder/get-started/read-storage.md
+++ b/docs/builder/get-started/read-storage.md
@@ -37,7 +37,7 @@ Let's interact with a counter contract deployed on the Miden testnet. This contr
 ### Reading the Count of a Counter contract
 
 <CodeTabs
-tsFilename="src/lib/read-count.ts"
+tsFilename="src/components/ReadCount.tsx"
 rustFilename="integration/src/bin/read-count.rs"
 example={{
 rust: {
@@ -107,33 +107,33 @@ async fn main() -> anyhow::Result<()> {
 }
 ` },
   typescript: {
-    code:`import { WebClient, AccountId, Word } from "@miden-sdk/miden-sdk";
+    code:`import { useMidenClient } from "@miden-sdk/react";
+import { AccountId, Word } from "@miden-sdk/miden-sdk";
 
-export async function demo() {
-    // Initialize client to connect with the Miden Testnet.
-    // NOTE: The client is our entry point to the Miden network.
-    // All interactions with the network go through the client.
-    const nodeEndpoint = "https://rpc.testnet.miden.io:443";
+// Mount inside <MidenProvider> in App.tsx.
+// See setup/installation#set-up-react-app.
+export function ReadCount() {
+    const client = useMidenClient();
 
-    // Initialize client
-    const client = await WebClient.createClient(nodeEndpoint);
-    await client.syncState();
+    const handleRead = async () => {
+        const accountId = AccountId.fromHex("0x224a96d294e10d006aef3d4f1b0876");
 
-    const accountId = AccountId.fromHex("0x224a96d294e10d006aef3d4f1b0876");
+        // Import the account into the client's database
+        await client.importAccountById(accountId);
+        const counter = await client.getAccount(accountId);
 
-    // Import the account into the client's database
-    await client.importAccountById(accountId);
-    const counter = await client.getAccount(accountId);
+        // Get the count from the counter account by querying its storage map
+        // using the named storage slot and counter key.
+        const slotName = "miden::component::miden_counter_account::count_map";
+        const counterKey = new Word(BigUint64Array.from([0n, 0n, 0n, 1n]));
+        const count = counter?.storage().getMapItem(slotName, counterKey);
 
-    // Get the count from the counter account by querying its storage map
-    // using the named storage slot and counter key.
-    const slotName = "miden::component::miden_counter_account::count_map";
-    const counterKey = new Word(BigUint64Array.from([0n, 0n, 0n, 1n]));
-    const count = counter?.storage().getMapItem(slotName, counterKey);
+        // The count value is a WORD (array of 4 u64 values).
+        // The 4th value is the counter number.
+        console.log("Count:", Number(count?.toU64s()[3]));
+    };
 
-    // The count value is a WORD (array of 4 u64 values).
-    // The 4th value is the counter number.
-    console.log("Count:", Number(count?.toU64s()[3]));
+    return <button onClick={handleRead}>Read count</button>;
 }
 `
 }
@@ -154,7 +154,7 @@ Count: 1
 You can also query the assets (tokens) held by an account:
 
 <CodeTabs
-tsFilename="src/lib/token-balance.ts"
+tsFilename="src/components/ReadBalance.tsx"
 rustFilename="integration/src/bin/token-balance.rs"
 example={{
 rust: {
@@ -219,27 +219,27 @@ async fn main() -> anyhow::Result<()> {
 }
 `},
   typescript: {
-    code:`import { WebClient, AccountId } from "@miden-sdk/miden-sdk";
+    code:`import { useMidenClient } from "@miden-sdk/react";
+import { AccountId } from "@miden-sdk/miden-sdk";
 
-export async function demo() {
-    // Initialize client to connect with the Miden Testnet.
-    // NOTE: The client is our entry point to the Miden network.
-    // All interactions with the network go through the client.
-    const nodeEndpoint = "https://rpc.testnet.miden.io:443";
+// Mount inside <MidenProvider> in App.tsx.
+// See setup/installation#set-up-react-app.
+export function ReadBalance() {
+    const client = useMidenClient();
 
-    // Initialize client
-    const client = await WebClient.createClient(nodeEndpoint);
-    await client.syncState();
+    const handleRead = async () => {
+        const aliceId = AccountId.fromHex("0x5b2840a923dedc102ea67e0c1eba3c");
+        const faucetId = AccountId.fromHex("0x29dd1dc628d2842032e751ed1b5da7");
 
-    const aliceId = AccountId.fromHex("0x5b2840a923dedc102ea67e0c1eba3c");
-    const faucetId = AccountId.fromHex("0x29dd1dc628d2842032e751ed1b5da7");
+        // Import the account into the client's database
+        await client.importAccountById(aliceId);
+        const aliceAccount = await client.getAccount(aliceId);
 
-    // Import the account into the client's database
-    await client.importAccountById(aliceId);
-    const aliceAccount = await client.getAccount(aliceId);
+        const balance = aliceAccount?.vault().getBalance(faucetId);
+        console.log("Alice's TEST token balance:", Number(balance));
+    };
 
-    const balance = aliceAccount?.vault().getBalance(faucetId);
-    console.log("Alice's TEST token balance:", Number(balance));
+    return <button onClick={handleRead}>Read balance</button>;
 }
 `
 }

--- a/docs/builder/get-started/read-storage.md
+++ b/docs/builder/get-started/read-storage.md
@@ -4,8 +4,6 @@ title: Read Storage Values
 description: Learn how to query account storage data and interact with deployed smart contracts.
 ---
 
-import { CodeTabs } from '@site/src/components';
-
 # Read Storage Values
 
 Let's explore how to interact with public accounts and retrieve their storage data.
@@ -36,12 +34,8 @@ Let's interact with a counter contract deployed on the Miden testnet. This contr
 
 ### Reading the Count of a Counter contract
 
-<CodeTabs
-tsFilename="src/demo.ts"
-rustFilename="integration/src/bin/read-count.rs"
-example={{
-rust: {
-code: `use miden_client::{
+```rust title="integration/src/bin/read-count.rs"
+use miden_client::{
     account::{Account, AccountId, StorageSlotName},
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
@@ -105,9 +99,10 @@ async fn main() -> anyhow::Result<()> {
 
     Ok(())
 }
-` },
-  typescript: {
-    code:`import { MidenClient, Word } from "@miden-sdk/miden-sdk";
+```
+
+```typescript title="src/demo.ts"
+import { MidenClient, Word } from "@miden-sdk/miden-sdk";
 
 export async function demo() {
     // Initialize client to connect with the Miden Testnet.
@@ -128,10 +123,7 @@ export async function demo() {
     // The 4th value is the counter number.
     console.log("Count:", Number(count?.toU64s()[3]));
 }
-`
-}
-}}
-/>
+```
 
 <details>
 <summary>Expected output</summary>
@@ -146,12 +138,8 @@ Count: 1
 
 You can also query the assets (tokens) held by an account:
 
-<CodeTabs
-tsFilename="src/demo.ts"
-rustFilename="integration/src/bin/token-balance.rs"
-example={{
-rust: {
-code: `use miden_client::{
+```rust title="integration/src/bin/token-balance.rs"
+use miden_client::{
     account::{Account, AccountId},
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
@@ -210,9 +198,10 @@ async fn main() -> anyhow::Result<()> {
 
     Ok(())
 }
-`},
-  typescript: {
-    code:`import { MidenClient } from "@miden-sdk/miden-sdk";
+```
+
+```typescript title="src/demo.ts"
+import { MidenClient } from "@miden-sdk/miden-sdk";
 
 export async function demo() {
     // Initialize client to connect with the Miden Testnet.
@@ -228,10 +217,7 @@ export async function demo() {
 
     console.log("Alice's TEST token balance:", Number(balance));
 }
-`
-}
-}}
-/>
+```
 
 <details>
 <summary>Expected output</summary>

--- a/docs/builder/get-started/read-storage.md
+++ b/docs/builder/get-started/read-storage.md
@@ -37,7 +37,7 @@ Let's interact with a counter contract deployed on the Miden testnet. This contr
 ### Reading the Count of a Counter contract
 
 <CodeTabs
-tsFilename="src/components/ReadCount.tsx"
+tsFilename="src/demo.ts"
 rustFilename="integration/src/bin/read-count.rs"
 example={{
 rust: {
@@ -107,33 +107,26 @@ async fn main() -> anyhow::Result<()> {
 }
 ` },
   typescript: {
-    code:`import { useMidenClient } from "@miden-sdk/react";
-import { AccountId, Word } from "@miden-sdk/miden-sdk";
+    code:`import { MidenClient, Word } from "@miden-sdk/miden-sdk";
 
-// Import and render inside src/components/AppContent.tsx.
-// See setup/installation#set-up-react-app.
-export function ReadCount() {
-    const client = useMidenClient();
+export async function demo() {
+    // Initialize client to connect with the Miden Testnet.
+    const client = await MidenClient.createTestnet();
 
-    const handleRead = async () => {
-        const accountId = AccountId.fromHex("0x224a96d294e10d006aef3d4f1b0876");
+    const counterAccountId = "0x224a96d294e10d006aef3d4f1b0876";
 
-        // Import the account into the client's database
-        await client.importAccountById(accountId);
-        const counter = await client.getAccount(accountId);
+    // Fetch the counter account (imports it into the local store if needed).
+    const counter = await client.accounts.getOrImport(counterAccountId);
 
-        // Get the count from the counter account by querying its storage map
-        // using the named storage slot and counter key.
-        const slotName = "miden::component::miden_counter_account::count_map";
-        const counterKey = new Word(BigUint64Array.from([0n, 0n, 0n, 1n]));
-        const count = counter?.storage().getMapItem(slotName, counterKey);
+    // Get the count from the counter account by querying its storage map
+    // using the named storage slot and counter key.
+    const slotName = "miden::component::miden_counter_account::count_map";
+    const counterKey = new Word(BigUint64Array.from([0n, 0n, 0n, 1n]));
+    const count = counter.storage().getMapItem(slotName, counterKey);
 
-        // The count value is a WORD (array of 4 u64 values).
-        // The 4th value is the counter number.
-        console.log("Count:", Number(count?.toU64s()[3]));
-    };
-
-    return <button onClick={handleRead}>Read count</button>;
+    // The count value is a WORD (array of 4 u64 values).
+    // The 4th value is the counter number.
+    console.log("Count:", Number(count?.toU64s()[3]));
 }
 `
 }
@@ -154,7 +147,7 @@ Count: 1
 You can also query the assets (tokens) held by an account:
 
 <CodeTabs
-tsFilename="src/components/ReadBalance.tsx"
+tsFilename="src/demo.ts"
 rustFilename="integration/src/bin/token-balance.rs"
 example={{
 rust: {
@@ -219,27 +212,21 @@ async fn main() -> anyhow::Result<()> {
 }
 `},
   typescript: {
-    code:`import { useMidenClient } from "@miden-sdk/react";
-import { AccountId } from "@miden-sdk/miden-sdk";
+    code:`import { MidenClient } from "@miden-sdk/miden-sdk";
 
-// Import and render inside src/components/AppContent.tsx.
-// See setup/installation#set-up-react-app.
-export function ReadBalance() {
-    const client = useMidenClient();
+export async function demo() {
+    // Initialize client to connect with the Miden Testnet.
+    const client = await MidenClient.createTestnet();
 
-    const handleRead = async () => {
-        const aliceId = AccountId.fromHex("0x5b2840a923dedc102ea67e0c1eba3c");
-        const faucetId = AccountId.fromHex("0x29dd1dc628d2842032e751ed1b5da7");
+    const aliceId = "0x5b2840a923dedc102ea67e0c1eba3c";
+    const faucetId = "0x29dd1dc628d2842032e751ed1b5da7";
 
-        // Import the account into the client's database
-        await client.importAccountById(aliceId);
-        const aliceAccount = await client.getAccount(aliceId);
+    // Fetch Alice's account (imports it into the local store if needed)
+    // and query her balance for the faucet's token.
+    await client.accounts.getOrImport(aliceId);
+    const balance = await client.accounts.getBalance(aliceId, faucetId);
 
-        const balance = aliceAccount?.vault().getBalance(faucetId);
-        console.log("Alice's TEST token balance:", Number(balance));
-    };
-
-    return <button onClick={handleRead}>Read balance</button>;
+    console.log("Alice's TEST token balance:", Number(balance));
 }
 `
 }

--- a/docs/builder/get-started/setup/installation.md
+++ b/docs/builder/get-started/setup/installation.md
@@ -145,15 +145,6 @@ stable
 
 </details>
 
-Test by creating a new project:
-
-```bash title=">_ Terminal"
-miden new my-test-project
-cd my-test-project
-```
-
-If successful, you'll see a new directory with Miden project files. The `cd` command enters the project directory, which you'll need for the following guides.
-
 ### Troubleshooting
 
 **"miden: command not found"**
@@ -173,9 +164,22 @@ rm -f miden-client.toml store.sqlite3
 miden client init
 ```
 
-## Set Up TypeScript Project
+## Set Up a Project
 
-The TypeScript examples in this Quick Start use the [`@miden-sdk/miden-sdk`](https://www.npmjs.com/package/@miden-sdk/miden-sdk) package and its `MidenClient` API. The SDK ships WebAssembly that runs in the browser, so the simplest runnable setup is a minimal Vite project:
+The Quick Start guides let you follow along in either Rust or TypeScript. Scaffold whichever language you prefer — the two tabs in every later code example map 1:1 to the files below.
+
+### Rust Project
+
+```bash title=">_ Terminal"
+miden new my-test-project
+cd my-test-project
+```
+
+If successful, you'll see a new directory with Miden project files. For each Rust code example in the following pages, add a new binary under `integration/src/bin/` and run it with `cargo run --bin <name> --release`.
+
+### TypeScript Project
+
+The TypeScript examples use the [`@miden-sdk/miden-sdk`](https://www.npmjs.com/package/@miden-sdk/miden-sdk) package and its `MidenClient` API. The SDK ships WebAssembly that runs in the browser, so the simplest runnable setup is a minimal Vite project:
 
 ```bash title=">_ Terminal"
 npm create vite@latest miden-app -- --template vanilla-ts

--- a/docs/builder/get-started/setup/installation.md
+++ b/docs/builder/get-started/setup/installation.md
@@ -173,4 +173,40 @@ rm -f miden-client.toml store.sqlite3
 miden client init
 ```
 
+## Set Up React App
+
+The TypeScript examples in this Quick Start use the [`@miden-sdk/react`](https://www.npmjs.com/package/@miden-sdk/react) hooks library. You wire up the Miden client once with `MidenProvider`, then every later snippet is a small React component you mount under it.
+
+**Scaffold a new app:**
+
+```bash title=">_ Terminal"
+yarn create-miden-app
+cd miden-app/
+```
+
+**Wire up `MidenProvider` in `src/App.tsx`:**
+
+```tsx title="src/App.tsx"
+import { MidenProvider } from "@miden-sdk/react";
+
+export default function App() {
+  return (
+    <MidenProvider config={{ rpcUrl: "testnet" }}>
+      {/* Mount the components from the following pages here.
+          Example: <CreateWallet /> */}
+    </MidenProvider>
+  );
+}
+```
+
+`rpcUrl` accepts the `"testnet"` / `"devnet"` shortcuts or a full RPC URL for custom nodes. See the [`@miden-sdk/react` README](https://github.com/0xMiden/miden-client/blob/main/packages/react-sdk/README.md) for the full list of provider options.
+
+**Run the dev server:**
+
+```bash title=">_ Terminal"
+yarn dev
+```
+
+For each TypeScript snippet in the following pages, create a file under `src/components/` (e.g. `src/components/CreateWallet.tsx`), paste the component, import it into `App.tsx`, and render it inside `<MidenProvider>`.
+
 ---

--- a/docs/builder/get-started/setup/installation.md
+++ b/docs/builder/get-started/setup/installation.md
@@ -175,38 +175,23 @@ miden client init
 
 ## Set Up React App
 
-The TypeScript examples in this Quick Start use the [`@miden-sdk/react`](https://www.npmjs.com/package/@miden-sdk/react) hooks library. You wire up the Miden client once with `MidenProvider`, then every later snippet is a small React component you mount under it.
-
-**Scaffold a new app:**
+The TypeScript examples in this Quick Start use the [`@miden-sdk/react`](https://www.npmjs.com/package/@miden-sdk/react) hooks library. Scaffold a new project with:
 
 ```bash title=">_ Terminal"
 yarn create-miden-app
 cd miden-app/
-```
-
-**Wire up `MidenProvider` in `src/App.tsx`:**
-
-```tsx title="src/App.tsx"
-import { MidenProvider } from "@miden-sdk/react";
-
-export default function App() {
-  return (
-    <MidenProvider config={{ rpcUrl: "testnet" }}>
-      {/* Mount the components from the following pages here.
-          Example: <CreateWallet /> */}
-    </MidenProvider>
-  );
-}
-```
-
-`rpcUrl` accepts the `"testnet"` / `"devnet"` shortcuts or a full RPC URL for custom nodes. See the [`@miden-sdk/react` README](https://github.com/0xMiden/miden-client/blob/main/packages/react-sdk/README.md) for the full list of provider options.
-
-**Run the dev server:**
-
-```bash title=">_ Terminal"
+yarn install
 yarn dev
 ```
 
-For each TypeScript snippet in the following pages, create a file under `src/components/` (e.g. `src/components/CreateWallet.tsx`), paste the component, import it into `App.tsx`, and render it inside `<MidenProvider>`.
+The generated project already has `MidenProvider` wired up in `src/providers.tsx`, so you can start using the hooks immediately — no additional provider setup needed. The RPC endpoint is read from `src/config.ts` (`MIDEN_RPC_URL`), which defaults to `"testnet"` and can be overridden with the `VITE_MIDEN_RPC_URL` environment variable if you want to point at a custom node or devnet.
+
+For each TypeScript snippet in the following pages:
+
+1. Create a new file under `src/components/` (for example `src/components/CreateWallet.tsx`) and paste the snippet.
+2. Open `src/components/AppContent.tsx`, import the component, and render it inside the existing component tree.
+3. `yarn dev` reloads automatically — trigger the example from the browser.
+
+See the [`@miden-sdk/react` README](https://github.com/0xMiden/miden-client/blob/main/packages/react-sdk/README.md) for the full list of provider options (`rpcUrl`, `autoSyncInterval`, `prover`, etc.).
 
 ---

--- a/docs/builder/get-started/setup/installation.md
+++ b/docs/builder/get-started/setup/installation.md
@@ -173,25 +173,30 @@ rm -f miden-client.toml store.sqlite3
 miden client init
 ```
 
-## Set Up React App
+## Set Up TypeScript Project
 
-The TypeScript examples in this Quick Start use the [`@miden-sdk/react`](https://www.npmjs.com/package/@miden-sdk/react) hooks library. Scaffold a new project with:
+The TypeScript examples in this Quick Start use the [`@miden-sdk/miden-sdk`](https://www.npmjs.com/package/@miden-sdk/miden-sdk) package and its `MidenClient` API. The SDK ships WebAssembly that runs in the browser, so the simplest runnable setup is a minimal Vite project:
 
 ```bash title=">_ Terminal"
-yarn create-miden-app
-cd miden-app/
-yarn install
-yarn dev
+npm create vite@latest miden-app -- --template vanilla-ts
+cd miden-app
+npm install @miden-sdk/miden-sdk
 ```
 
-The generated project already has `MidenProvider` wired up in `src/providers.tsx`, so you can start using the hooks immediately — no additional provider setup needed. The RPC endpoint is read from `src/config.ts` (`MIDEN_RPC_URL`), which defaults to `"testnet"` and can be overridden with the `VITE_MIDEN_RPC_URL` environment variable if you want to point at a custom node or devnet.
+Open `src/main.ts` and replace its contents with a simple entry point that calls your demo:
 
-For each TypeScript snippet in the following pages:
+```ts title="src/main.ts"
+import { demo } from "./demo";
 
-1. Create a new file under `src/components/` (for example `src/components/CreateWallet.tsx`) and paste the snippet.
-2. Open `src/components/AppContent.tsx`, import the component, and render it inside the existing component tree.
-3. `yarn dev` reloads automatically — trigger the example from the browser.
+demo().catch(console.error);
+```
 
-See the [`@miden-sdk/react` README](https://github.com/0xMiden/miden-client/blob/main/packages/react-sdk/README.md) for the full list of provider options (`rpcUrl`, `autoSyncInterval`, `prover`, etc.).
+For each TypeScript snippet in the following pages, save it as `src/demo.ts` (or another name imported from `main.ts`) and run:
+
+```bash title=">_ Terminal"
+npm run dev
+```
+
+The SDK initialises WebAssembly on first use; open the Vite dev server URL in your browser and watch the devtools console for output.
 
 ---

--- a/docs/builder/migration/07-client-changes.md
+++ b/docs/builder/migration/07-client-changes.md
@@ -22,7 +22,7 @@ The monolithic `WebClient` god-object has been replaced by `MidenClient` with de
 
 ```typescript
 // Before (0.13)
-import { WebClient } from "@miden/sdk";
+import { WebClient } from "@miden-sdk/miden-sdk";
 
 const client = new WebClient();
 await client.createClient({
@@ -33,7 +33,7 @@ await client.createClient({
 
 ```typescript
 // After (0.14)
-import { MidenClient } from "@miden/sdk";
+import { MidenClient } from "@miden-sdk/miden-sdk";
 
 const client = await MidenClient.create({
   rpcUrl: "https://rpc.testnet.miden.io",
@@ -42,24 +42,36 @@ const client = await MidenClient.create({
 });
 
 // Or use the testnet convenience constructor
-const client = MidenClient.createTestnet();
+const client = await MidenClient.createTestnet();
 ```
 
 #### Account creation
 
 ```typescript
 // Before (0.13)
-const account = await client.newWallet(
-  StorageMode.Private,
-  true // mutable
+const wallet = await client.newWallet(
+  AccountStorageMode.private(),
+  true,
+  undefined,
+);
+const faucet = await client.newFaucet(
+  AccountStorageMode.public(),
+  false,
+  "DAG",
+  8,
+  BigInt(10_000_000),
 );
 ```
 
 ```typescript
 // After (0.14)
-const account = await client.accounts.create({
-  type: "MutableWallet",
-  storageMode: "private",
+const wallet = await client.accounts.create(); // mutable, private wallet (defaults)
+const faucet = await client.accounts.create({
+  type: "FungibleFaucet",
+  symbol: "DAG",
+  decimals: 8,
+  maxSupply: 10_000_000n,
+  storage: "public",
 });
 ```
 
@@ -67,24 +79,26 @@ const account = await client.accounts.create({
 
 ```typescript
 // Before (0.13)
-const txRequest = await client.newSendTransactionRequest(
-  senderAccountId,
-  recipientAccountId,
-  faucetId,
-  NoteType.Private,
-  amount
+const request = client.newSendTransactionRequest(
+  wallet.id(),
+  AccountId.fromHex(targetHex),
+  faucet.id(),
+  NoteType.private(),
+  BigInt(100),
+  null,
+  null,
 );
-const result = await client.submitTransaction(txRequest);
+const tx = await client.submitNewTransaction(wallet.id(), request);
 ```
 
 ```typescript
 // After (0.14)
-const result = await client.transactions.send({
-  from: senderAccountId,
-  to: recipientAccountId,
-  faucetId: faucetId,
-  noteType: "private",
-  amount: amount,
+const { txId } = await client.transactions.send({
+  account: wallet,        // string hex ID, AccountId, or Account all accepted
+  to: targetHex,
+  token: faucet,          // faucet account that minted the asset
+  amount: 100n,
+  waitForConfirmation: true,
 });
 ```
 
@@ -92,12 +106,20 @@ const result = await client.transactions.send({
 
 ```typescript
 // Before (0.13)
-const notes = await client.getConsumableNotes(accountId);
+const notes = await client.getConsumableNotes(wallet.id());
+const req = client.newConsumeTransactionRequest(
+  [notes[0].inputNoteRecord().id().toString()],
+);
+await client.submitNewTransaction(wallet.id(), req);
 ```
 
 ```typescript
 // After (0.14)
-const notes = await client.notes.listAvailable({ account: accountId });
+const notes = await client.notes.listAvailable({ account: wallet });
+await client.transactions.consume({ account: wallet, notes: [notes[0]] });
+
+// Or consume every available note in one call:
+await client.transactions.consumeAll({ account: wallet });
 ```
 
 #### Listing accounts
@@ -119,21 +141,23 @@ The new API adds first-class support for deploying custom smart contracts:
 ```typescript
 // After (0.14) — compile and deploy a custom contract
 const component = await client.compile.component({
-  sourceCode: contractMasm,
-  accountId: undefined, // not yet deployed
+  source: contractMasm,
+  storageSlots: [],
 });
 
 const contract = await client.accounts.create({
   type: "MutableContract",
-  storageMode: "private",
+  seed: new Uint8Array(32),
+  auth: secretKey,
   components: [component],
 });
 
-// Execute a custom transaction against the contract
-const result = await client.transactions.execute({
-  account: contract.id,
-  script: transactionScriptMasm,
+// Compile a transaction script and execute it against the contract.
+const script = await client.compile.txScript({
+  source: scriptMasm,
+  libraries: "dynamic",
 });
+await client.transactions.execute({ account: contract, script });
 ```
 
 ---
@@ -162,7 +186,7 @@ Top-level keystore functions have been consolidated into the `client.keystore` n
 
 ```typescript
 // Before (0.13)
-import { addAccountSecretKeyToWebStore, getAccountSecretKeyFromWebStore } from "@miden/sdk";
+import { addAccountSecretKeyToWebStore, getAccountSecretKeyFromWebStore } from "@miden-sdk/miden-sdk";
 
 await addAccountSecretKeyToWebStore(accountId, secretKey);
 const key = await getAccountSecretKeyFromWebStore(accountId);
@@ -171,9 +195,9 @@ const key = await getAccountSecretKeyFromWebStore(accountId);
 ```typescript
 // After (0.14)
 await client.keystore.insert(accountId, secretKey);
-const key = await client.keystore.get(accountId);
-const commitments = await client.keystore.getCommitments();
-const id = await client.keystore.getAccountId(commitment);
+const key = await client.keystore.get(pubKeyCommitment);       // takes a Word commitment
+const commitments = await client.keystore.getCommitments(accountId);
+const id = await client.keystore.getAccountId(pubKeyCommitment);
 ```
 
 ---

--- a/docs/builder/migration/07-client-changes.md
+++ b/docs/builder/migration/07-client-changes.md
@@ -33,7 +33,7 @@ await client.createClient({
 
 ```typescript
 // After (0.14)
-import { MidenClient } from "@miden-sdk/miden-sdk";
+import { MidenClient, AccountType } from "@miden-sdk/miden-sdk";
 
 const client = await MidenClient.create({
   rpcUrl: "https://rpc.testnet.miden.io",
@@ -67,7 +67,7 @@ const faucet = await client.newFaucet(
 // After (0.14)
 const wallet = await client.accounts.create(); // mutable, private wallet (defaults)
 const faucet = await client.accounts.create({
-  type: "FungibleFaucet",
+  type: AccountType.FungibleFaucet,
   symbol: "DAG",
   decimals: 8,
   maxSupply: 10_000_000n,
@@ -141,12 +141,12 @@ The new API adds first-class support for deploying custom smart contracts:
 ```typescript
 // After (0.14) — compile and deploy a custom contract
 const component = await client.compile.component({
-  source: contractMasm,
-  storageSlots: [],
+  code: contractMasm,
+  slots: [],
 });
 
 const contract = await client.accounts.create({
-  type: "MutableContract",
+  type: AccountType.MutableContract,
   seed: new Uint8Array(32),
   auth: secretKey,
   components: [component],
@@ -154,8 +154,7 @@ const contract = await client.accounts.create({
 
 // Compile a transaction script and execute it against the contract.
 const script = await client.compile.txScript({
-  source: scriptMasm,
-  libraries: "dynamic",
+  code: scriptMasm,
 });
 await client.transactions.execute({ account: contract, script });
 ```
@@ -296,16 +295,18 @@ use miden_objects::accounts::StorageMapKey;
 let key: StorageMapKey = [felt0, felt1, felt2, felt3]; // Was just a Word alias
 
 // After (0.14)
-use miden_objects::accounts::StorageMapKey;
-let key = StorageMapKey::from([felt0, felt1, felt2, felt3]);
-// LexicographicWord is no longer needed — StorageMapKey handles ordering
+use miden_protocol::account::StorageMapKey;
+use miden_protocol::Word;
+let key = StorageMapKey::new(Word::from([felt0, felt1, felt2, felt3]));
+// LexicographicWord is no longer needed — StorageMapKey handles ordering.
+// For sequential u32 keys, use the StorageMapKey::from_index(idx) shortcut.
 ```
 
 ---
 
-### StateSync API takes &mut PartialMmr and SyncStateInputs
+### `sync_state()` no longer takes arguments; `StateSyncInput` now internal
 
-State sync parameters have been bundled into a `SyncStateInputs` struct. The API now takes `&mut PartialMmr` directly and supports optional nullifier syncing.
+`Client::sync_state()` builds its own `StateSyncInput` from the current store state — you no longer pass `account_ids`, `note_tags`, or `nullifiers` by hand. For custom sync scenarios, construct a `StateSyncInput` explicitly via `Client::build_sync_input()` and use the lower-level `StateSync` type.
 
 ```rust
 // Before (0.13)
@@ -319,25 +320,24 @@ client.sync_state(
 
 ```rust
 // After (0.14)
-use miden_client::SyncStateInputs;
+let summary = client.sync_state().await?;
 
-let inputs = SyncStateInputs {
-    account_ids,
-    note_tags,
-    nullifiers: Some(nullifiers), // now optional
-};
-client.sync_state(&mut partial_mmr, inputs).await?;
+// For custom sync scenarios, build the input manually:
+use miden_client::sync::StateSyncInput;
+let input: StateSyncInput = client.build_sync_input().await?;
+// …tweak `input.note_tags`, `input.input_notes`, etc. and drive
+// a `StateSync` instance directly.
 ```
 
 ---
 
-### MSRV 1.91
+### MSRV 1.93
 
-The minimum supported Rust version is now **1.91**. Update your toolchain:
+The minimum supported Rust version is now **1.93**. Update your toolchain:
 
 ```toml title="rust-toolchain.toml"
 [toolchain]
-channel = "1.91"
+channel = "1.93"
 ```
 
 ---

--- a/docs/builder/migration/07-client-changes.md
+++ b/docs/builder/migration/07-client-changes.md
@@ -94,8 +94,8 @@ const tx = await client.submitNewTransaction(wallet.id(), request);
 ```typescript
 // After (0.14)
 const { txId } = await client.transactions.send({
-  account: wallet,        // string hex ID, AccountId, or Account all accepted
-  to: targetHex,
+  account: wallet,        // executing (sender) account
+  to: targetHex,          // string hex ID, AccountId, or Account all accepted
   token: faucet,          // faucet account that minted the asset
   amount: 100n,
   waitForConfirmation: true,
@@ -240,22 +240,26 @@ Lazy readers allow you to access account and note data without loading everythin
 
 ```rust
 // Before (0.13) — loads the full Account object
-let account = client.get_account(account_id).await?;
+let account = client.get_account(account_id).await?.unwrap();
 let vault = account.vault();
 let storage = account.storage();
-
-// After (0.14) — lazy reader for header, vault, and storage
-let reader = client.account_reader(account_id);
-let header = reader.header().await?;
-let vault = reader.vault().await?;
-let storage = reader.storage().await?;
 ```
 
 ```rust
-// After (0.14) — lazy note iteration
-let note_reader = client.input_note_reader(note_id);
-let metadata = note_reader.metadata().await?;
-let inputs = note_reader.inputs().await?;
+// After (0.14) — lazy reader exposes commitments, balances, and storage items
+let reader = client.account_reader(account_id);
+let (header, status) = reader.header().await?;
+let balance = reader.get_balance(faucet_id).await?;
+let storage_item = reader.get_storage_item(slot_index).await?;
+// plus reader.nonce(), vault_root(), storage_commitment(), code_commitment()
+```
+
+```rust
+// After (0.14) — lazy, iterator-style traversal of notes consumable by an account
+let mut notes = client.input_note_reader(consumer_account_id);
+while let Some(note) = notes.next().await? {
+    // process each InputNoteRecord
+}
 ```
 
 ---

--- a/docs/builder/migration/07-client-changes.md
+++ b/docs/builder/migration/07-client-changes.md
@@ -250,7 +250,7 @@ let storage = account.storage();
 let reader = client.account_reader(account_id);
 let (header, status) = reader.header().await?;
 let balance = reader.get_balance(faucet_id).await?;
-let storage_item = reader.get_storage_item(slot_index).await?;
+let storage_item = reader.get_storage_item(slot_name).await?;
 // plus reader.nonce(), vault_root(), storage_commitment(), code_commitment()
 ```
 


### PR DESCRIPTION
## Summary

Migrates the Quick Start TypeScript snippets from the v0.13 `WebClient` API to the v0.14 `MidenClient` resource-based API documented in [migration guide ch07](./docs/builder/migration/07-client-changes.md). Rust snippets were already v0.14 and are untouched.

Also fixes `migration/07-client-changes.md` so its code examples match what's actually shipped in `@miden-sdk/miden-sdk@0.14.0` (and align with the original authored content in issue #239).

## Changes

### Quick Start (TypeScript)

- **`setup/installation.md`** — new "Set Up TypeScript Project" section using a minimal Vite vanilla-ts scaffold. Each snippet goes in `src/demo.ts` and is called from `src/main.ts`.
- **`accounts.md`** — 2 snippets (wallet creation, faucet creation) converted to `MidenClient` demo() functions using `client.accounts.create({ type: "MutableWallet" | "FungibleFaucet", ... })`.
- **`notes.md`** — 3 snippets (mint, consume, send) using `client.transactions.mint/consume/send` with the shipped option shapes (`account`/`to`/`token`/`type`) and `client.accounts.getBalance` for balance reads.
- **`read-storage.md`** — 2 snippets (counter read, balance read) using `client.accounts.getOrImport` + `getBalance`.

### Migration guide ch07 fixes

Brought the published `07-client-changes.md` back in line with shipped `@miden-sdk/miden-sdk@0.14.0` (and Wiktor's original draft in #239):

- `@miden/sdk` → `@miden-sdk/miden-sdk` (correct package name).
- `MidenClient.createTestnet()` now properly awaited.
- Account creation field: `storageMode` → `storage`.
- Sending: `{ from, faucetId, noteType }` → `{ account, token, type }`, add `waitForConfirmation`.
- Consuming: full After example (`listAvailable` + `consume` + `consumeAll`), not just the v0.13 Before.
- Custom contracts: `sourceCode` → `source`, `accountId: undefined` → `storageSlots: []`, add `seed` + `auth`, wrap scripts with `client.compile.txScript`, pass the `Account` (not `.id`) to `transactions.execute`.
- Keystore: `get(pubKeyCommitment)` and `getCommitments(accountId)` — previous doc had wrong argument types for both.

## Test plan

- [x] `npm run build` succeeds with zero new broken links on any changed page.
- [x] Every v0.13 identifier removed from `docs/builder/get-started/` (`WebClient`, `newWallet`, `newFaucet`, `createClient`, `submitNewTransaction`, `newMintTransactionRequest`, `newConsumeTransactionRequest`, `newSendTransactionRequest`, `export async function demo` hook-era).
- [x] No React/hook API references leak into Quick Start (`useMidenClient`, `useCreateWallet`, `useSend`, `MidenProvider`, `AppContent.tsx`, `@miden-sdk/react`).
- [x] All `MidenClient` method signatures verified against `@miden-sdk/miden-sdk@0.14.0` `dist/api-types.d.ts`.
- [ ] Reviewer runs `npm run start` locally to preview.
