### PR TITLE
docs: v0.14 verification pass on smart-contracts Rust docs

### DIFF
--- a/docs/builder/smart-contracts/accounts/authentication.md
+++ b/docs/builder/smart-contracts/accounts/authentication.md
@@ -6,93 +6,95 @@ description: "Authentication component pattern and nonce management for Miden ac
 
 # Authentication
 
-Miden uses RPO-Falcon512 digital signatures for transaction authentication. Because transactions execute on the client rather than on-chain validators, the system needs a way to prove that a transaction was authorized by the account owner. Without authentication, anyone could construct a valid proof that transfers assets out of an account. The nonce prevents replay attacks — without it, a valid proof could be resubmitted to execute the same state change twice. For details on the cryptographic primitives, see [Cryptography](./cryptography).
+Miden uses digital signatures for transaction authentication. Because transactions execute on the client rather than on-chain validators, the system needs a way to prove that a transaction was authorized by the account owner. Without authentication, anyone could construct a valid proof that transfers assets out of an account. The nonce prevents replay attacks — without it, a valid proof could be resubmitted to execute the same state change twice. For details on the cryptographic primitives, see [Cryptography](./cryptography).
+
+v0.14 unifies the previous per-scheme components (`AuthFalcon512Rpo`, `AuthEcdsaK256Keccak`, …) into a single scheme-agnostic [`AuthSingleSig`](https://docs.rs/miden-standards/latest/miden_standards/account/auth/struct.AuthSingleSig.html) component that takes an `AuthScheme` enum (`Falcon512Poseidon2` or `EcdsaK256Keccak`). The native hash function is Poseidon2, and the Falcon-512 verifier MASM module is `miden::core::crypto::dsa::falcon512_poseidon2`.
 
 ## How authentication works
 
-An auth component stores the RPO256 hash of the account owner's Falcon512 public key in a dedicated storage slot. During transaction execution, it computes a message digest from the transaction's delta commitment and the incremented nonce, requests the signature from the advice provider via `emit_falcon_sig_to_stack`, and verifies it with `rpo_falcon512_verify`. If verification fails, proof generation fails and the transaction is rejected before reaching the network.
+The standards `AuthSingleSig` component stores two items under well-known names:
 
-The signature itself isn't passed as a function argument — it's provided through the **advice provider**, a special mechanism that supplies auxiliary data to the VM during proof generation.
+| Storage slot | Name | Description |
+|---|---|---|
+| Public key | `miden::standards::auth::singlesig::pub_key` | Commitment to the account owner's public key |
+| Scheme ID | `miden::standards::auth::singlesig::scheme` | Which signature scheme to use (1 = ECDSA K256 Keccak, 2 = Falcon-512 Poseidon2) |
 
-## The advice provider
+During transaction execution the kernel invokes the `@auth_script`-annotated procedure on the account. For `AuthSingleSig`, that procedure loads both slots and delegates to `miden::standards::auth::signature::authenticate_transaction`, which:
 
-The advice provider supplies auxiliary data during proof generation — see [Advice Provider](../transactions/advice-provider) for the full API.
+1. Increments the account nonce (even if the account state did not change — this is required for replay protection).
+2. Computes the transaction summary message: `hash([ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, [0, 0, ref_block_num, final_nonce]])`.
+3. Requests the signature from the advice provider and verifies it with the scheme indicated by the stored scheme ID.
 
-## Auth component implementation
+If verification fails, proof generation fails and the transaction is rejected before reaching the network. The signature itself isn't passed as a function argument — it's provided through the **advice provider**, a mechanism that supplies auxiliary data to the VM during proof generation. See [Advice Provider](../transactions/advice-provider) for the full API.
 
-From the [compiler examples](https://github.com/0xMiden/compiler/tree/next/examples/auth-component-rpo-falcon512):
+## Attaching `AuthSingleSig` to an account
+
+On the client side, attach `AuthSingleSig` via `AccountBuilder::with_auth_component`. `miden-client` re-exports `AuthScheme` as `AuthSchemeId`:
+
+```rust
+use miden_client::{
+    account::{AccountBuilder, AccountStorageMode, AccountType, component::BasicWallet},
+    auth::{AuthSchemeId, AuthSecretKey, AuthSingleSig},
+};
+
+let key_pair = AuthSecretKey::new_falcon512_poseidon2_with_rng(client.rng());
+
+let account = AccountBuilder::new(seed)
+    .account_type(AccountType::RegularAccountUpdatableCode)
+    .storage_mode(AccountStorageMode::Public)
+    .with_auth_component(AuthSingleSig::new(
+        key_pair.public_key().to_commitment(),
+        AuthSchemeId::Falcon512Poseidon2,
+    ))
+    .with_component(BasicWallet)
+    .build()?;
+```
+
+If you import directly from `miden-protocol`, the same enum is called `AuthScheme` (`miden_protocol::account::auth::AuthScheme`) — `miden-client` just re-exports it under a friendlier name.
+
+## Writing a custom auth component
+
+If you need authentication logic beyond `AuthSingleSig` / `AuthMultisig`, you can write a custom auth component in Rust. Mark exactly one procedure per auth component with `#[auth_script]`. If the procedure returns without panicking, the transaction kernel treats authentication as successful. If it panics (for example via `assert!`), authentication fails.
 
 ```rust
 #![no_std]
 #![feature(alloc_error_handler)]
 
-extern crate alloc;
-
-use miden::{
-    Felt, Value, ValueAccess, Word, component, felt, hash_words,
-    intrinsics::advice::adv_insert, native_account, tx,
-};
+use miden::{component, Word};
 
 #[component]
-struct AuthComponent {
-    /// The account owner's public key (RPO-Falcon512 public key hash).
-    #[storage(
-        description = "owner public key",
-        type = "miden::standards::auth::falcon512_rpo::pub_key"
-    )]
-    owner_public_key: Value,
-}
+struct AuthComponent;
 
 #[component]
 impl AuthComponent {
-    pub fn auth_procedure(&mut self, _arg: Word) {
-        let ref_block_num = tx::get_block_number();
-        let final_nonce = self.incr_nonce();
-
-        // Gather tx summary parts
-        let acct_delta_commit = self.compute_delta_commitment();
-        let input_notes_commit = tx::get_input_notes_commitment();
-        let output_notes_commit = tx::get_output_notes_commitment();
-
-        let salt = Word::from([felt!(0), felt!(0), ref_block_num, final_nonce]);
-
-        let mut tx_summary = [acct_delta_commit, input_notes_commit, output_notes_commit, salt];
-        let msg: Word = hash_words(&tx_summary).into();
-        // On the advice stack the words are expected to be in reverse order
-        tx_summary.reverse();
-        // Insert tx summary into advice map under key `msg`
-        adv_insert(msg, &tx_summary);
-
-        let pub_key: Word = self.owner_public_key.read();
-
-        // Emit signature request event to advice stack
-        miden::emit_falcon_sig_to_stack(msg, pub_key);
-
-        // Verify the signature loaded on the advice stack
-        miden::rpo_falcon512_verify(pub_key, msg);
+    #[auth_script]
+    pub fn verify(&self, _arg: Word) {
+        // Custom authentication checks go here.
+        //
+        // Returning normally = authentication succeeded.
+        // Panicking (e.g. `assert!(false)`) = authentication failed and
+        // the transaction will be rejected before proof generation finishes.
+        todo!()
     }
 }
 ```
 
+The kernel also increments the nonce automatically as part of the `@auth_script` contract — you do not need to call `self.incr_nonce()` from inside the procedure for replay protection.
+
 ## Nonce management
 
-The nonce prevents replay attacks — each transaction must use a unique nonce:
+The nonce prevents replay attacks — each transaction must use a unique nonce. For accounts using the standards `AuthSingleSig` (or `AuthMultisig`) component, nonce increment is handled inside `authenticate_transaction`. If you implement a fully custom auth script, you are responsible for incrementing the nonce yourself and for binding it into the signed message.
 
-```rust
-// Increment and return the new nonce
-let new_nonce: Felt = self.incr_nonce();
-```
+The nonce is committed into the transaction proof. If someone tries to replay a transaction, the nonce won't match the account's current nonce and verification will fail.
 
-The nonce is automatically included in the transaction's proof. If someone tries to replay a transaction, the nonce won't match and verification will fail.
-
-Auth components are typically called via [cross-component calls](../cross-component-calls) from note scripts or [transaction scripts](../transactions/transaction-scripts). For access control and security patterns, see [Patterns](../patterns).
+Auth components are invoked automatically by the kernel — you do not call them directly from note scripts or [transaction scripts](../transactions/transaction-scripts). For access control and security patterns, see [Patterns](../patterns).
 
 :::info API Reference
-Full API docs on docs.rs: [`miden`](https://docs.rs/miden/latest/miden/) (`rpo_falcon512_verify`)
+Full API docs on docs.rs: [`miden`](https://docs.rs/miden/latest/miden/), [`AuthSingleSig`](https://docs.rs/miden-standards/latest/miden_standards/account/auth/struct.AuthSingleSig.html), [`AuthScheme`](https://docs.rs/miden-protocol/latest/miden_protocol/account/auth/enum.AuthScheme.html)
 :::
 
 ## Related
 
-- [Cryptography](./cryptography) — RPO-Falcon512 verification and hashing primitives
+- [Cryptography](./cryptography) — Falcon-512 / Poseidon2 verification and hashing primitives
 - [Advice Provider](../transactions/advice-provider) — supplying auxiliary data during proof generation
 - [Patterns](../patterns) — access control, rate limiting, and anti-patterns

--- a/docs/builder/smart-contracts/notes/introduction.md
+++ b/docs/builder/smart-contracts/notes/introduction.md
@@ -20,13 +20,13 @@ Every note has four parts:
 |------|-------------|
 | **Assets** | The fungible or non-fungible tokens the note carries |
 | **Script** | Code that executes when the note is consumed — determines who can claim it and what side effects occur |
-| **Inputs** | Custom data the script can read at consumption time (e.g., a target account ID, an expiration block) |
+| **Storage** | Custom data stored with the note that the script can read at consumption time (e.g., a target account ID, an expiration block) |
 | **Metadata** | Sender ID, note tag (for discovery routing), and auxiliary data |
 
-The **recipient** is a cryptographic hash that encodes who can consume the note. When creating notes programmatically (via [`output_note::create`](./output-notes#create-a-note)), you compute a `Recipient` from the note's serial number, script hash, and inputs:
+The **recipient** is a cryptographic hash that encodes who can consume the note. When creating notes programmatically (via [`output_note::create`](./output-notes#create-a-note)), you compute a `Recipient` from the note's serial number, script root, and storage commitment:
 
 ```
-recipient = hash(hash(hash(serial_num, [0;4]), script_root), inputs_commitment)
+recipient = hash(hash(hash(serial_num, [0;4]), script_root), storage_commitment)
 ```
 
 Only someone who knows these values can construct a valid consumption proof. See [Computing a Recipient](./output-notes#computing-a-recipient) for the SDK API.
@@ -58,7 +58,7 @@ Notes come in two visibility modes:
 
 | Mode | Description |
 |------|-------------|
-| **Public** | The note's full data (assets, script, inputs) is stored by the Miden network and visible on-chain. Anyone can discover and attempt to consume it. |
+| **Public** | The note's full data (assets, script, storage) is stored by the Miden network and visible on-chain. Anyone can discover and attempt to consume it. |
 | **Private** | Only a commitment (hash) is stored on-chain. The actual note data must be communicated off-chain between sender and recipient. |
 
 Private notes provide stronger privacy guarantees — the network can't even see what assets a note carries — but they require the sender and recipient to have a communication channel outside the protocol.

--- a/docs/builder/smart-contracts/notes/note-types.md
+++ b/docs/builder/smart-contracts/notes/note-types.md
@@ -17,25 +17,27 @@ The most common pattern — a note that can only be consumed by a specific accou
 Use P2ID for standard asset transfers where only the intended recipient should be able to consume the note. This is the most common note type.
 
 :::info
-P2ID notes use `create_p2id_note` from the `miden-standards` crate. The script is pre-compiled MASM — use the builder API to create P2ID notes in client code.
+P2ID notes use `P2idNote::create` from the `miden-standards` crate (`miden_standards::note::P2idNote`). The script is pre-compiled MASM — use the builder API to create P2ID notes in client code.
 :::
 
 ### How it works
 
-1. Creator creates a P2ID note containing the assets and the target account ID as a note input
+1. Creator creates a P2ID note containing the assets and the target account ID as a note storage item
 2. Consumer's transaction processes the note — the script verifies the consuming account's ID matches the target
 3. If the IDs match, all assets transfer to the consuming account; otherwise proof generation fails
 
-### Note inputs
+### Note storage
 
-| Input | Type | Description |
-|-------|------|-------------|
+| Item | Type | Description |
+|------|------|-------------|
 | `target_account_id` | `AccountId` | The account allowed to consume this note |
 
 ### Builder API
 
 ```rust
-create_p2id_note(
+use miden_standards::note::P2idNote;
+
+P2idNote::create(
     sender,       // AccountId: who sends the note
     target,       // AccountId: the only account that can consume this note
     assets,       // Vec<Asset>: assets to attach
@@ -63,47 +65,47 @@ P2IDE extends P2ID with a timelock and a reclaim window. The note can't be consu
 Use P2IDE when the sender wants the option to reclaim assets if the recipient doesn't consume the note within a time window.
 
 :::info
-P2IDE notes use `create_p2ide_note` from the `miden-standards` crate. The script is pre-compiled MASM — use the builder API to create P2IDE notes in client code.
+P2IDE notes use `P2ideNote::create` from the `miden-standards` crate (`miden_standards::note::P2ideNote`). The script is pre-compiled MASM — use the builder API to create P2IDE notes in client code.
 :::
 
 ### How it works
 
-1. Creator creates a P2IDE note with the target account ID, a timelock height, and a reclaim height as note inputs
+1. Creator creates a P2IDE note with the target account ID, a timelock height, and a reclaim height as note storage items
 2. **Target consumes after `timelock_height`** — assets transfer to the target account
 3. **Creator reclaims after `reclaim_height`** — assets return to the creator
 4. **Before timelock or between timelock and reclaim by a non-target** — any consumption attempt fails (proof generation fails)
 
-### Note inputs
+### Note storage
 
-| Input | Type | Description |
-|-------|------|-------------|
+| Item | Type | Description |
+|------|------|-------------|
 | `target_account_id_prefix` | `Felt` | Target account ID prefix |
 | `target_account_id_suffix` | `Felt` | Target account ID suffix |
-| `timelock_height` | `Felt` | Block height before which the note can't be consumed |
 | `reclaim_height` | `Felt` | Block height after which the creator can reclaim |
+| `timelock_height` | `Felt` | Block height before which the note can't be consumed |
 
 ### Builder API
 
 ```rust
-create_p2ide_note(
-    sender,           // AccountId: who sends the note
-    target,           // AccountId: the only account that can consume this note
-    assets,           // Vec<Asset>: assets to attach
-    reclaim_height,   // Option<BlockNumber>: None = no reclaim window
-    timelock_height,  // Option<BlockNumber>: None = no timelock
-    note_type,        // NoteType: Public or Private
-    attachment,       // NoteAttachment: auxiliary data
-    rng,              // &mut impl FeltRng
+use miden_standards::note::{P2ideNote, P2ideNoteStorage};
+
+P2ideNote::create(
+    sender,                                               // AccountId: who sends the note
+    P2ideNoteStorage::new(target, reclaim_height, timelock_height),
+    assets,                                               // Vec<Asset>: assets to attach
+    note_type,                                            // NoteType: Public or Private
+    attachment,                                           // NoteAttachment: auxiliary data
+    rng,                                                  // &mut impl FeltRng
 ) -> Result<Note, NoteError>
 ```
 
 | Parameter | Type | Description |
 |-----------|------|-------------|
 | `sender` | `AccountId` | Account sending the note |
-| `target` | `AccountId` | The only account that can consume this note |
+| `target` | `AccountId` | The only account that can consume this note (set on `P2ideNoteStorage`) |
+| `reclaim_height` | `Option<BlockNumber>` | Block height after which sender can reclaim; `None` = no reclaim (set on `P2ideNoteStorage`) |
+| `timelock_height` | `Option<BlockNumber>` | Block height before which note can't be consumed; `None` = no timelock (set on `P2ideNoteStorage`) |
 | `assets` | `Vec<Asset>` | Assets to attach to the note |
-| `reclaim_height` | `Option<BlockNumber>` | Block height after which sender can reclaim; `None` = no reclaim |
-| `timelock_height` | `Option<BlockNumber>` | Block height before which note can't be consumed; `None` = no timelock |
 | `note_type` | `NoteType` | `Public` or `Private` |
 | `attachment` | `NoteAttachment` | Auxiliary data for the note |
 | `rng` | `&mut impl FeltRng` | Random number generator |
@@ -117,7 +119,7 @@ SWAP enables atomic asset exchange. The creator offers one asset; any consumer w
 Use SWAP for trustless atomic exchanges where two parties trade assets without intermediaries.
 
 :::info
-SWAP notes use `create_swap_note` from the `miden-standards` crate. The script is pre-compiled MASM — use the builder API to create SWAP notes in client code.
+SWAP notes use `SwapNote::create` from the `miden-standards` crate (`miden_standards::note::SwapNote`). The script is pre-compiled MASM — use the builder API to create SWAP notes in client code.
 :::
 
 ### How it works
@@ -130,7 +132,9 @@ SWAP notes use `create_swap_note` from the `miden-standards` crate. The script i
 ### Builder API
 
 ```rust
-create_swap_note(
+use miden_standards::note::SwapNote;
+
+SwapNote::create(
     sender,
     offered_asset,
     requested_asset,

--- a/docs/builder/smart-contracts/notes/reading-notes.md
+++ b/docs/builder/smart-contracts/notes/reading-notes.md
@@ -13,27 +13,27 @@ Miden provides two modules for reading note data, each for a different execution
 
 ## `active_note` — the executing note
 
-When a note script runs, `active_note` provides access to the current note's inputs, assets, and metadata:
+When a note script runs, `active_note` provides access to the current note's storage, assets, and metadata:
 
 ```rust
 use miden::active_note;
 ```
 
-### Inputs
+### Storage
 
-Note inputs are custom `Felt` values set by the note creator (e.g., a target account ID, an expiration block height). The recommended way to access inputs is through the `#[note]` struct — fields are automatically deserialized from inputs:
+Note storage is a sequence of `Felt` values set by the note creator (e.g., a target account ID, an expiration block height). The recommended way to access it is through the `#[note]` struct — fields are automatically deserialized from the note's storage:
 
 ```rust
 #[note]
 struct MyNote {
-    target_account_id: AccountId,  // Deserialized from note inputs automatically
+    target_account_id: AccountId,  // Deserialized from note storage automatically
 }
 ```
 
-See [Note Scripts](./note-scripts) for the full `#[note]` pattern. The low-level `active_note::get_inputs()` function is also available for advanced use cases:
+See [Note Scripts](./note-scripts) for the full `#[note]` pattern. The low-level `active_note::get_storage()` function is also available for advanced use cases:
 
 ```rust
-let inputs: Vec<Felt> = active_note::get_inputs();
+let storage: Vec<Felt> = active_note::get_storage();
 ```
 
 ### Assets
@@ -94,17 +94,17 @@ let script_root: Word = input_note::get_script_root(note_idx);
 let serial_num: Word = input_note::get_serial_number(note_idx);
 ```
 
-### Inputs
+### Storage
 
 ```rust
-let inputs_info: InputNoteInputsInfo = input_note::get_inputs_info(note_idx);
+let storage_info: InputNoteStorageInfo = input_note::get_storage_info(note_idx);
 ```
 
 :::note
-Unlike `active_note::get_inputs()` which returns the full `Vec<Felt>` of input values, `input_note` only exposes the inputs commitment and count — not the actual values. The transaction kernel only has commitments for input notes that are not currently executing. To read actual input values, use `active_note::get_inputs()` inside the note script itself.
+Unlike `active_note::get_storage()` which returns the full `Vec<Felt>` of storage values, `input_note` only exposes the storage commitment and count — not the actual values. The transaction kernel only has commitments for input notes that are not currently executing. To read actual storage values, use `active_note::get_storage()` inside the note script itself.
 :::
 
-`InputNoteInputsInfo` contains `commitment: Word` and `num_inputs: Felt`.
+`InputNoteStorageInfo` contains `commitment: Word` and `num_storage_items: Felt`.
 
 ### Note metadata
 
@@ -116,9 +116,9 @@ let metadata: NoteMetadata = input_note::get_metadata(note_idx);
 
 ## Examples
 
-### Reading inputs in a note script
+### Reading storage in a note script
 
-A note script that reads the target account ID from inputs and verifies the consumer:
+A note script that reads the target account ID from storage and verifies the consumer:
 
 ```rust
 use miden::{AccountId, Word, active_note, note};

--- a/docs/builder/smart-contracts/patterns.md
+++ b/docs/builder/smart-contracts/patterns.md
@@ -72,5 +72,5 @@ All Miden contracts run without the standard library:
 | `std::collections::HashMap` | Use `BTreeMap` from `alloc`, or `StorageMap` for persistent account storage |
 | `std::string::String` | Use `alloc::string::String` |
 | `std::vec::Vec` | Use `alloc::vec::Vec` |
-| `println!()` / `eprintln!()` | Use `miden::intrinsics::debug::breakpoint()` |
+| `println!()` / `eprintln!()` | No direct equivalent — run the transaction under the Mockchain and inspect outputs, or use the external debugger |
 | Error strings in `assert!()` | Use `assert!(condition)` without messages |

--- a/docs/builder/smart-contracts/types.md
+++ b/docs/builder/smart-contracts/types.md
@@ -33,15 +33,16 @@ let answer = felt!(42);
 // From u32 (always safe)
 let f = Felt::from_u32(255);
 
-// From u64 without range check (caller ensures value < p)
-let f = Felt::from_u64_unchecked(1_000_000_000);
+// From u64 (infallible — values are reduced into canonical form internally)
+let f = Felt::new(1_000_000_000);
 
-// From u64 with validation (returns Result)
-let f = Felt::new(999).unwrap();
+// Built-in zero / one constants
+let z = Felt::ZERO;
+let o = Felt::ONE;
 ```
 
 :::info `felt!()` range limitation
-The `felt!()` macro currently only accepts values up to `u32::MAX` (4,294,967,295). For larger values, use `Felt::from_u64_unchecked()`. This limitation may be lifted in a future release.
+The `felt!()` macro currently only accepts values up to `u32::MAX` (4,294,967,295). For larger values, use `Felt::new()`. This limitation may be lifted in a future release.
 :::
 
 ### Arithmetic
@@ -67,7 +68,7 @@ x *= felt!(2);          // x is now felt!(12)
 ```
 
 :::note For business logic, prefer u64
-For computing amounts, balances, counters, or any value where overflow/underflow behavior matters, convert to `u64` first, perform the arithmetic, then convert back with `Felt::from_u64_unchecked()`.
+For computing amounts, balances, counters, or any value where overflow/underflow behavior matters, convert to `u64` first, perform the arithmetic, then convert back with `Felt::new()`.
 :::
 
 ### Comparison and conversion
@@ -97,7 +98,7 @@ let a: u64 = felt_a.as_u64();
 let b: u64 = felt_b.as_u64();
 let sum = a.saturating_add(b); // safe addition
 let diff = a.saturating_sub(b); // no underflow
-let result = Felt::from_u64_unchecked(sum);
+let result = Felt::new(sum);
 ```
 :::
 
@@ -116,14 +117,17 @@ let result = f.exp(felt!(3));  // 7^3 mod p = 343
 let power = felt!(10).pow2();  // 2^10 = 1024 (panics if self > 63)
 ```
 
-## Word — Four-element tuples
+## Word — Four field elements
 
-A `Word` is a tuple of four `Felt` values. It's the standard unit for storage, hashing, and data passing in Miden.
+A `Word` holds four `Felt` values. It's the standard unit for storage, hashing, and data passing in Miden.
 
 ```rust
-#[repr(C, align(16))]
+#[repr(C)]
 pub struct Word {
-    pub inner: (Felt, Felt, Felt, Felt),
+    pub a: Felt,
+    pub b: Felt,
+    pub c: Felt,
+    pub d: Felt,
 }
 ```
 
@@ -135,37 +139,29 @@ use miden::{felt, Felt, Word};
 // From an array of 4 Felts
 let w = Word::new([felt!(1), felt!(2), felt!(3), felt!(4)]);
 
-// Shorthand from array (via From trait)
-let w = Word::from([felt!(1), felt!(2), felt!(3), felt!(4)]);
+// Shorthand via `From<[Felt; 4]>`
+let w: Word = [felt!(1), felt!(2), felt!(3), felt!(4)].into();
 
-// From 4 u64 values (unchecked)
-let w = Word::from_u64_unchecked(1, 2, 3, 4);
+// Shorthand via `From<[u32; 4]>` (or [u8; 4] / [u16; 4] / [bool; 4])
+let w = Word::from([1u32, 2, 3, 4]);
 
-// From a single Felt (placed in position [3], positions [0]–[2] zeroed)
-let w = Word::from(felt!(42));  // [felt!(0), felt!(0), felt!(0), felt!(42)]
-
-// From a tuple
-let w = Word::from((felt!(1), felt!(2), felt!(3), felt!(4)));
+// All-zero word
+let z = Word::empty();            // same as Word::default()
 ```
 
 ### Indexing
 
 ```rust
-let w = Word::from([felt!(10), felt!(20), felt!(30), felt!(40)]);
+let w = Word::new([felt!(10), felt!(20), felt!(30), felt!(40)]);
 
-// Read by index
-let first: Felt = w[0];   // felt!(10)
-let last: Felt = w[3];    // felt!(40)
-
-// Mutable indexing
-let mut w = Word::from([felt!(0), felt!(0), felt!(0), felt!(0)]);
-w[0] = felt!(99);
+// Named fields
+let a: Felt = w.a;                // felt!(10)
+let d: Felt = w.d;                // felt!(40)
 
 // Convert to array
-let arr: [Felt; 4] = w.into();
-
-// Convert to tuple
-let tup: (Felt, Felt, Felt, Felt) = w.into();
+let arr: [Felt; 4] = w.into_elements();
+// or via the `From<Word> for [Felt; 4]` impl
+let arr2: [Felt; 4] = w.into();
 ```
 
 ### Packing data into Words
@@ -174,25 +170,26 @@ Since each storage slot holds one `Word`, you'll often pack multiple values:
 
 ```rust
 // Pack two u64 values into a Word
-let config = Word::from([
-    Felt::from_u64_unchecked(max_amount),    // [0]: max amount
-    Felt::from_u64_unchecked(cooldown),      // [1]: cooldown blocks
-    felt!(0),                                 // [2]: unused
-    felt!(0),                                 // [3]: unused
+let config = Word::new([
+    Felt::new(max_amount),    // a: max amount
+    Felt::new(cooldown),      // b: cooldown blocks
+    felt!(0),                 // c: unused
+    felt!(0),                 // d: unused
 ]);
 
-// Unpack
-let max_amount = config[0].as_u64();
-let cooldown = config[1].as_u64();
+// Unpack via named fields
+let max_amount = config.a.as_u64();
+let cooldown = config.b.as_u64();
 ```
 
 ## Asset
 
-`Asset` wraps a `Word` and represents either a fungible or non-fungible asset.
+`Asset` represents either a fungible or non-fungible asset. In v0.14 it is **two words** — a `key` (identifies the asset class) and a `value` (encodes the fungible amount or non-fungible data).
 
 ```rust
 pub struct Asset {
-    pub inner: Word,
+    pub key: Word,
+    pub value: Word,
 }
 ```
 
@@ -200,40 +197,54 @@ pub struct Asset {
 
 **Fungible assets** (tokens):
 
-| Index | Content |
-|-------|---------|
-| `inner[0]` | Amount |
-| `inner[1]` | `0` |
-| `inner[2]` | Faucet ID suffix |
-| `inner[3]` | Faucet ID prefix |
+| Word     | Field | Content |
+|----------|-------|---------|
+| `key`    | `a`   | `0` |
+| `key`    | `b`   | `0` |
+| `key`    | `c`   | Faucet ID suffix |
+| `key`    | `d`   | Faucet ID prefix |
+| `value`  | `a`   | Amount |
+| `value`  | `b`   | `0` |
+| `value`  | `c`   | `0` |
+| `value`  | `d`   | `0` |
 
 **Non-fungible assets** (NFTs):
 
-| Index | Content |
-|-------|---------|
-| `inner[0]` | Data hash element 0 |
-| `inner[1]` | Data hash element 1 |
-| `inner[2]` | Data hash element 2 |
-| `inner[3]` | Faucet ID prefix |
+| Word     | Field | Content |
+|----------|-------|---------|
+| `key`    | `a`   | Data hash element 0 |
+| `key`    | `b`   | Data hash element 1 |
+| `key`    | `c`   | Faucet ID suffix |
+| `key`    | `d`   | Faucet ID prefix |
+| `value`  | `a..d`| Data payload (implementation-defined) |
 
 ### Working with assets
 
 ```rust
-use miden::Asset;
+use miden::{Asset, Word, felt};
 
-// Create from a Word
-let asset = Asset::new([felt!(100), felt!(0), faucet_suffix, faucet_prefix]);
+// Build a fungible asset from key + value words.
+// Fungible key = [0, 0, faucet_suffix, faucet_prefix],
+// fungible value = [amount, 0, 0, 0].
+let asset = Asset::new(
+    Word::from([felt!(0), felt!(0), faucet_suffix, faucet_prefix]),
+    Word::from([felt!(100), felt!(0), felt!(0), felt!(0)]),
+);
 
-// Read the amount (fungible)
-let amount: u64 = asset.inner[0].as_u64();
+// Read the amount (fungible): first limb of `value`.
+let amount: u64 = asset.value.a.as_u64();
 
-// Build a fungible asset from faucet ID and amount
+// Build a fungible asset from faucet ID + amount via the SDK helper.
 use miden::asset;
-let asset = asset::build_fungible_asset(faucet_id, felt!(1000));
+let asset = asset::create_fungible_asset(faucet_id, felt!(1000));
 
-// Build a non-fungible asset
-let nft = asset::build_non_fungible_asset(faucet_id, data_hash);
+// Build a non-fungible asset.
+let nft = asset::create_non_fungible_asset(faucet_id, data_hash);
 ```
+
+:::note Asset on the host side
+On the client / host side, `Asset` is an enum (`Asset::Fungible(_) | Asset::NonFungible(_)`) exposed from `miden-protocol`, with `to_key_word()` / `to_value_word()` / `from_key_value_words()` helpers. Inside a Rust contract the SDK exposes the two-word `Asset` struct shown above.
+:::
 
 ## AccountId
 
@@ -265,16 +276,12 @@ The SDK also provides `NoteIdx`, `Tag`, `NoteType`, `Recipient`, `Digest`, and `
 | From | To | Method |
 |------|----|--------|
 | `u32` | `Felt` | `Felt::from_u32(n)` |
-| `u64` | `Felt` | `Felt::from_u64_unchecked(n)` or `Felt::new(n)?` |
+| `u64` | `Felt` | `Felt::new(n)` |
 | literal | `Felt` | `felt!(n)` |
 | `Felt` | `u64` | `f.as_u64()` |
-| `Felt` | `Word` | `Word::from(f)` — fills position 3, rest zeroed |
-| `Word` | `Felt` | `let f: Felt = w.into()` — extracts position 3 |
-| `[Felt; 4]` | `Word` | `Word::from(arr)` |
-| `Word` | `[Felt; 4]` | `let arr: [Felt; 4] = w.into()` |
-| `(Felt, Felt, Felt, Felt)` | `Word` | `Word::from(tuple)` |
-| `Word` | `Digest` | `Digest::from_word(w)` |
-| `Digest` | `Word` | `let w: Word = d.into()` |
+| `[Felt; 4]` | `Word` | `Word::new(arr)` or `Word::from(arr)` |
+| `[u32; 4]` / `[u16; 4]` / `[u8; 4]` / `[bool; 4]` | `Word` | `Word::from(arr)` |
+| `Word` | `[Felt; 4]` | `w.into_elements()` or `let arr: [Felt; 4] = w.into()` |
 
 Use these types in [component definitions](./accounts/components), store and retrieve Words from [persistent storage](./accounts/storage), or define your own types for public APIs with [`#[export_type]`](./accounts/custom-types).
 


### PR DESCRIPTION
## Summary

Section 7 of the v0.14 docs sweep — re-verify the Rust smart-contracts guides against shipped v0.14 code. Fixes compile-breaking v0.13 residues in five files.

## Bugs fixed

- **`accounts/authentication.md`** — `AuthFalcon512Rpo` → `AuthSingleSig` + `AuthSchemeId::Falcon512Poseidon2` (per #239 auth-consolidation; removed per-scheme auth components).
- **`notes/introduction.md`** — `inputs` → `storage` throughout; recipient hash formula now uses `storage_commitment` (per #239 `NoteInputs` → `NoteStorage` rename).
- **`notes/note-types.md`** — `create_p2id_note(...)` / `create_p2ide_note(...)` / `create_swap_note(...)` free functions → `P2idNote::create(...)` / `P2ideNote::create(...)` / `SwapNote::create(...)` associated methods (per #239 "Note constructors moved to associated methods"). `P2ideNote` now wraps reclaim/timelock into `P2ideNoteStorage::new(target, reclaim_height, timelock_height)`.
- **`patterns.md`** — `println!` no-std replacement suggestion updated: `miden::intrinsics::debug::breakpoint()` was removed (per #239 breakpoint-removed); recommend MockChain output inspection or the external debugger instead.
- **`types.md`** — `Asset` is **two words** in v0.14: `pub struct Asset { pub key: Word, pub value: Word }` (per #239 "Assets are two words, not one"). `Asset::new(key_word, value_word)` takes two args. Field encoding tables split across key + value. Confirmed against Philipp's v14 `miden-bank/contracts/withdraw-request-note` which uses `Asset::new(Word, Word)` verbatim.

## Verification

- **Runtime harness** at `/Users/bs/Develop/Miden/Projects/docs-tests/crates/rust-contracts-demo` exercises 8 API sections (Felt / Word / StorageMapKey / Auth / AccountBuilder / AccountComponentMetadata / P2id+P2ide+Swap / NoteStorage+NoteRecipient) against shipped v0.14 crates. `cargo run -p rust-contracts-demo --release` exits 0.
- **Codex independent audit** flagged two Asset-shape findings on `types.md` (fixed in this commit) and one false-positive on `Word` (shipped `miden-field-0.23.0/src/word/mod.rs:52` confirms `pub struct Word { pub a, b, c, d: Felt }` with a WIT-binding comment — doc is correct, Codex was looking at an out-of-tree version).
- **`npm run build`** passes with no new broken links on any changed page.

## Test plan

- [x] `cargo run -p rust-contracts-demo --release` exits 0 (full output in commit body)
- [x] `npm run build` succeeds
- [x] Every v0.13 identifier removed from the five changed files (grep clean for `AuthFalcon512Rpo`, `create_p2id_note`, `create_p2ide_note`, `create_swap_note`, `Asset { inner`, `inner.a/b/c/d`, `miden::intrinsics::debug::breakpoint`, `note inputs`)
- [x] Codex audit clean after the Asset fixes
- [ ] Reviewer spot-checks rendered diff