### PR TITLE
docs: add v0.14 Web SDK (TypeScript) guide under tools/clients

### DIFF
--- a/.github/workflows/cut-versions.yml
+++ b/.github/workflows/cut-versions.yml
@@ -208,12 +208,6 @@ jobs:
               [ -f "$src" ] && cp "$src" docs/builder/tools/clients/
             done
             echo "Synced miden-client (rust-client, img, theme, common-errors, _category_) → docs/builder/tools/clients"
-
-            # Move CLI to its own section under tools (historical top-level layout)
-            if [ -d "docs/builder/tools/clients/cli" ]; then
-              mv docs/builder/tools/clients/cli docs/builder/tools/cli
-              echo "Moved CLI → docs/builder/tools/cli"
-            fi
           fi
 
           echo "Content aggregation complete. Final docs structure:"

--- a/.github/workflows/cut-versions.yml
+++ b/.github/workflows/cut-versions.yml
@@ -151,7 +151,13 @@ jobs:
 
           # Clean directories that will be re-synced (v0.4 nested paths)
           rm -rf docs/core-concepts/protocol docs/core-concepts/miden-vm docs/core-concepts/node docs/core-concepts/compiler
-          rm -rf docs/builder/tools/clients docs/builder/tools/cli
+          # tools/clients: only clean ingested subdirs; preserve locally-authored web-client/, react-sdk/, index.md
+          rm -rf docs/builder/tools/clients/rust-client
+          rm -rf docs/builder/tools/clients/img
+          rm -rf docs/builder/tools/clients/theme
+          rm -f  docs/builder/tools/clients/common-errors.md
+          rm -f  docs/builder/tools/clients/_category_.yml
+          rm -rf docs/builder/tools/cli
           rm -rf docs/builder/tutorials/miden-bank docs/builder/tutorials/index.md
           # Note: docs/builder/tutorials/rust-compiler/ is NOT cleaned to preserve local guides (testing, debugging, pitfalls)
 
@@ -190,10 +196,20 @@ jobs:
 
           if [ -d "vendor/miden-client/docs/external/src" ]; then
             mkdir -p docs/builder/tools/clients
-            cp -r vendor/miden-client/docs/external/src/* docs/builder/tools/clients/
-            echo "Synced miden-client → docs/builder/tools/clients"
+            # Selective ingestion: only subdirs/files we still auto-sync from miden-client.
+            # web-client/, react-sdk/, and top-level index.md are locally authored in the docs repo
+            # — they are preserved through this clean/ingest cycle.
+            for name in rust-client img theme; do
+              src="vendor/miden-client/docs/external/src/$name"
+              [ -d "$src" ] && cp -r "$src" docs/builder/tools/clients/
+            done
+            for name in common-errors.md _category_.yml; do
+              src="vendor/miden-client/docs/external/src/$name"
+              [ -f "$src" ] && cp "$src" docs/builder/tools/clients/
+            done
+            echo "Synced miden-client (rust-client, img, theme, common-errors, _category_) → docs/builder/tools/clients"
 
-            # Move CLI to its own section under tools
+            # Move CLI to its own section under tools (historical top-level layout)
             if [ -d "docs/builder/tools/clients/cli" ]; then
               mv docs/builder/tools/clients/cli docs/builder/tools/cli
               echo "Moved CLI → docs/builder/tools/cli"
@@ -226,7 +242,13 @@ jobs:
           rm -rf docs/core-concepts/miden-vm
           rm -rf docs/core-concepts/node
           rm -rf docs/core-concepts/compiler
-          rm -rf docs/builder/tools/clients docs/builder/tools/cli
+          # tools/clients: only clean ingested subdirs; preserve locally-authored web-client/, react-sdk/, index.md
+          rm -rf docs/builder/tools/clients/rust-client
+          rm -rf docs/builder/tools/clients/img
+          rm -rf docs/builder/tools/clients/theme
+          rm -f  docs/builder/tools/clients/common-errors.md
+          rm -f  docs/builder/tools/clients/_category_.yml
+          rm -rf docs/builder/tools/cli
           rm -rf docs/builder/tutorials/miden-bank docs/builder/tutorials/index.md
           # Note: docs/builder/tutorials/rust-compiler/ is authored content (testing, debugging, pitfalls), not cleaned
 

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -204,12 +204,6 @@ jobs:
               [ -f "$src" ] && cp "$src" docs/builder/tools/clients/
             done
             echo "Synced miden-client (rust-client, img, theme, common-errors, _category_) → docs/builder/tools/clients"
-
-            # Move CLI to its own section under tools (historical top-level layout)
-            if [ -d "docs/builder/tools/clients/cli" ]; then
-              mv docs/builder/tools/clients/cli docs/builder/tools/cli
-              echo "Moved CLI → docs/builder/tools/cli"
-            fi
           fi
 
           echo "Content aggregation complete. Final docs structure:"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -147,7 +147,13 @@ jobs:
 
           # Clean directories that will be re-synced (v0.4 nested paths)
           rm -rf docs/core-concepts/protocol docs/core-concepts/miden-vm docs/core-concepts/node docs/core-concepts/compiler
-          rm -rf docs/builder/tools/clients docs/builder/tools/cli
+          # tools/clients: only clean ingested subdirs; preserve locally-authored web-client/, react-sdk/, index.md
+          rm -rf docs/builder/tools/clients/rust-client
+          rm -rf docs/builder/tools/clients/img
+          rm -rf docs/builder/tools/clients/theme
+          rm -f  docs/builder/tools/clients/common-errors.md
+          rm -f  docs/builder/tools/clients/_category_.yml
+          rm -rf docs/builder/tools/cli
           rm -rf docs/builder/tutorials/miden-bank docs/builder/tutorials/index.md
           # Note: docs/builder/tutorials/rust-compiler/ is NOT cleaned to preserve local guides (testing, debugging, pitfalls)
 
@@ -186,10 +192,20 @@ jobs:
 
           if [ -d "vendor/miden-client/docs/external/src" ]; then
             mkdir -p docs/builder/tools/clients
-            cp -r vendor/miden-client/docs/external/src/* docs/builder/tools/clients/
-            echo "Synced miden-client → docs/builder/tools/clients"
+            # Selective ingestion: only subdirs/files we still auto-sync from miden-client.
+            # web-client/, react-sdk/, and top-level index.md are locally authored in the docs repo
+            # — they are preserved through this clean/ingest cycle.
+            for name in rust-client img theme; do
+              src="vendor/miden-client/docs/external/src/$name"
+              [ -d "$src" ] && cp -r "$src" docs/builder/tools/clients/
+            done
+            for name in common-errors.md _category_.yml; do
+              src="vendor/miden-client/docs/external/src/$name"
+              [ -f "$src" ] && cp "$src" docs/builder/tools/clients/
+            done
+            echo "Synced miden-client (rust-client, img, theme, common-errors, _category_) → docs/builder/tools/clients"
 
-            # Move CLI to its own section under tools
+            # Move CLI to its own section under tools (historical top-level layout)
             if [ -d "docs/builder/tools/clients/cli" ]; then
               mv docs/builder/tools/clients/cli docs/builder/tools/cli
               echo "Moved CLI → docs/builder/tools/cli"

--- a/docs/builder/private-multisig/typescript-sdk.md
+++ b/docs/builder/private-multisig/typescript-sdk.md
@@ -20,21 +20,25 @@ npm install @openzeppelin/miden-multisig-client @miden-sdk/miden-sdk
 
 ```typescript
 import { MultisigClient, FalconSigner } from '@openzeppelin/miden-multisig-client';
-import { WebClient, AuthSecretKey } from '@miden-sdk/miden-sdk';
+import { MidenClient, AuthSecretKey } from '@miden-sdk/miden-sdk';
 
-// Initialize the Miden WebClient
-const webClient = await WebClient.createClient('https://rpc.testnet.miden.io:443');
+// Initialize the Miden SDK client
+const midenClient = await MidenClient.createTestnet();
 
 // Create a Falcon signer
 const secretKey = AuthSecretKey.rpoFalconWithRNG(undefined);
 const signer = new FalconSigner(secretKey);
 
 // Create the multisig client and fetch Guardian info
-const client = new MultisigClient(webClient, {
+const client = new MultisigClient(midenClient, {
   psmEndpoint: 'http://localhost:3000',
 });
 const { psmCommitment } = await client.initialize();
 ```
+
+:::note
+The multisig client accepts any `MidenClient` instance, so `createTestnet()` / `createDevnet()` / `create({ rpcUrl })` all work. See the [Web SDK setup guide](../tools/clients/web-client/setup.md) for the full factory list.
+:::
 
 ## Creating a multisig account
 

--- a/docs/builder/tools/clients/index.md
+++ b/docs/builder/tools/clients/index.md
@@ -1,0 +1,28 @@
+---
+title: Client
+sidebar_position: 1
+---
+
+# Miden client
+
+The Miden client is the user-facing entry point to the Miden network. It manages accounts, builds and executes transactions, produces zero-knowledge proofs, and synchronises local state with the node. The same client logic ships across four consumer surfaces so you can pick the runtime that fits your application:
+
+| Surface | Package | Best for |
+| --- | --- | --- |
+| [**Rust library**](./rust-client/library.md) | `miden-client` crate | Native services, proving infrastructure, tests |
+| [**Rust CLI**](./rust-client/cli/index.md) | `miden-client` binary | Scripting, local exploration, ops workflows |
+| [**Web SDK**](./web-client/index.md) | `@miden-sdk/miden-sdk` (npm) | Browser and Node apps, Electron, service workers |
+| [**React SDK**](./react-sdk/index.md) | `@miden-sdk/react` (npm) | React / Next.js / React Native dApps |
+
+## How the surfaces relate
+
+- The **Rust library** contains the core state machine, transaction executor, prover, keystore abstraction, and note transport.
+- The **Rust CLI** wraps the library and exposes its functionality as commands.
+- The **Web SDK** compiles the Rust library to WebAssembly and exposes a typed JavaScript API (the `MidenClient` class). It is the canonical TypeScript/JavaScript entry point.
+- The **React SDK** wraps the Web SDK with a `MidenProvider` and a family of hooks (`useMiden`, `useAccount`, `useSend`, …). It shares the exact same on-chain semantics.
+
+Pick whichever surface matches your application — each section documents the full API for that runtime.
+
+## Common topics
+
+Errors, diagnostics, and other behaviour that is shared across all surfaces is documented once in [Common errors](./common-errors.md).

--- a/docs/builder/tools/clients/index.md
+++ b/docs/builder/tools/clients/index.md
@@ -9,10 +9,12 @@ The Miden client is the user-facing entry point to the Miden network. It manages
 
 | Surface | Package | Best for |
 | --- | --- | --- |
-| [**Rust library**](./rust-client/library.md) | `miden-client` crate | Native services, proving infrastructure, tests |
-| [**Rust CLI**](./rust-client/cli/index.md) | `miden-client` binary | Scripting, local exploration, ops workflows |
-| [**Web SDK**](./web-client/index.md) | `@miden-sdk/miden-sdk` (npm) | Browser and Node apps, Electron, service workers |
-| [**React SDK**](./react-sdk/index.md) | `@miden-sdk/react` (npm) | React / Next.js / React Native dApps |
+| **Rust library** | `miden-client` crate | Native services, proving infrastructure, tests |
+| **Rust CLI** | `miden-client` binary | Scripting, local exploration, ops workflows |
+| **Web SDK** | `@miden-sdk/miden-sdk` (npm) | Browser and Node apps, Electron, service workers |
+| **React SDK** | `@miden-sdk/react` (npm) | React / Next.js / React Native dApps |
+
+Navigate to each surface via the sidebar on the left.
 
 ## How the surfaces relate
 
@@ -25,4 +27,4 @@ Pick whichever surface matches your application — each section documents the f
 
 ## Common topics
 
-Errors, diagnostics, and other behaviour that is shared across all surfaces is documented once in [Common errors](./common-errors.md).
+Errors, diagnostics, and other behaviour that is shared across all surfaces is documented once under **Common errors** in the sidebar.

--- a/docs/builder/tools/clients/web-client/_category_.yml
+++ b/docs/builder/tools/clients/web-client/_category_.yml
@@ -1,0 +1,4 @@
+label: TypeScript
+# Sidebar position within tools/clients/ (Rust is 1, TypeScript is 2, React is 3)
+position: 2
+collapsed: true

--- a/docs/builder/tools/clients/web-client/accounts.md
+++ b/docs/builder/tools/clients/web-client/accounts.md
@@ -1,0 +1,292 @@
+---
+title: Accounts
+sidebar_position: 3
+---
+
+# Accounts
+
+`client.accounts` is the resource namespace for everything account-related: creation, lookup, listing, import / export, and address management. All ID fields accept an `AccountRef` — a hex string, bech32 string, `AccountId`, `Account`, or `AccountHeader` — so you rarely need to convert between them.
+
+## Account type and auth scheme values
+
+Account creation uses two small enums:
+
+| Kind | Accepted values | Meaning |
+| --- | --- | --- |
+| `AccountType.FungibleFaucet` | `0` | Mintable token source |
+| `AccountType.NonFungibleFaucet` | `1` | Non-fungible token source |
+| `AccountType.RegularAccountImmutableCode` | `2` | Immutable wallet or contract |
+| `AccountType.RegularAccountUpdatableCode` | `3` | Mutable wallet or contract (default) |
+| `auth` field | `"falcon"` \| `"ecdsa"` | Signing scheme — Falcon is the default |
+| `storage` field | `"public"` \| `"private"` \| `"network"` | Visibility and persistence mode |
+
+All snippets below use these names. The SDK also ships friendly aliases (`AccountType.MutableWallet`, `AccountType.ImmutableContract`, etc.) but prefer the canonical names above when writing TypeScript — the aliases currently fail strict type-checking in some builds.
+
+## Create
+
+### Wallet
+
+```typescript
+import { MidenClient, AccountType } from "@miden-sdk/miden-sdk";
+
+const client = await MidenClient.createTestnet();
+
+// Default: mutable wallet, private storage, Falcon auth
+const wallet = await client.accounts.create();
+
+// With explicit options
+const wallet2 = await client.accounts.create({
+  type: AccountType.RegularAccountImmutableCode, // immutable wallet
+  storage: "public",
+  auth: "ecdsa",
+  seed: "my-seed", // hashed to 32 bytes via SHA-256
+});
+
+console.log(wallet.id().toString());       // hex
+console.log(wallet.nonce().toString());
+console.log(wallet.isPublic());
+console.log(wallet.isPrivate());
+console.log(wallet.isFaucet());
+console.log(wallet.isRegularAccount());
+```
+
+### Faucet
+
+```typescript
+import { MidenClient, AccountType } from "@miden-sdk/miden-sdk";
+
+const client = await MidenClient.createTestnet();
+
+const faucet = await client.accounts.create({
+  type: AccountType.FungibleFaucet,
+  symbol: "TEST",
+  decimals: 8,
+  maxSupply: 10_000_000n, // number | bigint
+});
+
+const faucet2 = await client.accounts.create({
+  type: AccountType.FungibleFaucet,
+  symbol: "DAG",
+  decimals: 8,
+  maxSupply: 10_000_000n,
+  storage: "public",
+  auth: "falcon",
+});
+```
+
+### Contract
+
+Contract accounts hold custom MASM code. Compile the code into an `AccountComponent` with [`client.compile.component()`](./compile.md), then create the account:
+
+```typescript
+import {
+  MidenClient,
+  AccountType,
+  AuthSecretKey,
+  StorageSlot,
+} from "@miden-sdk/miden-sdk";
+
+const counterCode = `
+  use miden::protocol::active_account
+  use miden::protocol::native_account
+  use miden::core::word
+  use miden::core::sys
+
+  const COUNTER_SLOT = word("miden::tutorials::counter")
+
+  pub proc get_count
+    push.COUNTER_SLOT[0..2] exec.active_account::get_item
+    exec.sys::truncate_stack
+  end
+
+  pub proc increment_count
+    push.COUNTER_SLOT[0..2] exec.active_account::get_item
+    add.1
+    push.COUNTER_SLOT[0..2] exec.native_account::set_item
+    exec.sys::truncate_stack
+  end
+`;
+
+const client = await MidenClient.createTestnet();
+
+const component = await client.compile.component({
+  code: counterCode,
+  slots: [StorageSlot.emptyValue("miden::tutorials::counter")],
+});
+
+const seed = crypto.getRandomValues(new Uint8Array(32));
+const auth = AuthSecretKey.rpoFalconWithRNG(seed);
+
+const contract = await client.accounts.create({
+  type: AccountType.RegularAccountImmutableCode, // immutable contract
+  seed,
+  auth,
+  components: [component],
+});
+
+console.log("Contract:", contract.id().toString());
+console.log("Is public:", contract.isPublic()); // contracts default to public
+```
+
+Contract defaults:
+
+- **Storage** — defaults to `"public"` (so other accounts can read state for FPI). Pass `storage: "private"` to override.
+- **Auth** — must be a concrete `AuthSecretKey` instance, not a scheme string. The caller retains the key; the client uses it to sign transactions that touch the contract.
+- **Seed** — required, 32 bytes. Determines the account ID.
+
+### Pre-built via `AccountBuilder`
+
+When you need full control — e.g. an external signer that provides an auth commitment instead of a secret key — build the account manually and hand it to `insert()`:
+
+```typescript
+import {
+  MidenClient,
+  AccountBuilder,
+  AccountComponent,
+  AccountStorageMode,
+  AccountType,
+} from "@miden-sdk/miden-sdk";
+
+const client = await MidenClient.createTestnet();
+
+const commitment = /* externalSigner.getPublicKeyCommitment() */ (undefined as any);
+const seed = new Uint8Array(32); // deterministic seed from your derivation path
+
+const account = new AccountBuilder(seed)
+  .withAuthComponent(
+    AccountComponent.createAuthComponentFromCommitment(commitment, 1),
+  )
+  .accountType(AccountType.RegularAccountImmutableCode)
+  .storageMode(AccountStorageMode.public())
+  .withBasicWalletComponent()
+  .build().account;
+
+await client.accounts.insert({ account });
+```
+
+`accounts.insert()` is local-only: it persists the account to the store without any network call. Use it when you already have a valid `Account` object and just need to track it.
+
+## Retrieve
+
+### `get`
+
+```typescript
+const account = await client.accounts.get("0x1234...");
+if (!account) {
+  console.log("Not found locally");
+  return;
+}
+console.log(account.id().toString());
+console.log(account.nonce().toString());
+console.log(account.isPublic());
+console.log(account.isFaucet());
+```
+
+`get` only consults the local store. It returns `null` if the account isn't tracked.
+
+### `getOrImport`
+
+```typescript
+// Returns the local copy if present; otherwise fetches from the network and stores it.
+const account = await client.accounts.getOrImport(
+  "mtst1arjemrxne8lj5qz4mg9c8mtyxg954483",
+);
+console.log("Nonce:", account.nonce().toString());
+```
+
+Use `getOrImport` for accounts you didn't create — a faucet or contract deployed by another party, for example. Once imported, subsequent calls return the local copy without hitting the network.
+
+`get` vs `getOrImport`:
+
+- `get` for local-only reads. Cheap, no network.
+- `getOrImport` when the account may need to be pulled from chain.
+
+### `list`
+
+```typescript
+const accounts = await client.accounts.list();
+for (const header of accounts) {
+  console.log(header.id().toString(), header.nonce().toString());
+}
+```
+
+Returns `AccountHeader[]` — a lightweight summary suitable for listing UIs. Call `get()` if you need the full `Account`.
+
+### `getDetails`
+
+```typescript
+const details = await client.accounts.getDetails("0x1234...");
+console.log(details.account.id().toString());
+console.log(details.vault);   // AssetVault
+console.log(details.storage); // AccountStorage
+console.log(details.code);    // AccountCode | null
+console.log(details.keys);    // Word[] (public-key commitments)
+```
+
+One round-trip returns the full account plus its vault, storage, code, and key commitments.
+
+### `getBalance`
+
+```typescript
+const balance: bigint = await client.accounts.getBalance(
+  "0xACCOUNT...",
+  "0xFAUCET...",
+);
+console.log(`Balance: ${balance}`);
+```
+
+## Address management
+
+```typescript
+await client.accounts.addAddress("0xACCOUNT...", "mtst1address...");
+await client.accounts.removeAddress("0xACCOUNT...", "mtst1address...");
+```
+
+Associates one or more bech32 addresses with an account. Useful when your UI lets users alias accounts by a human-readable string.
+
+## Import
+
+`client.accounts.import()` accepts a discriminated union:
+
+```typescript
+// 1. By reference — fetches a public account from the network.
+await client.accounts.import("0x1234...");                           // hex
+await client.accounts.import("mtst1arjemrxne8lj5qz4mg9c8mtyxg954483"); // bech32
+
+// 2. From a previously exported file.
+await client.accounts.import({ file: accountFile });
+
+// 3. From a seed — PUBLIC ACCOUNTS ONLY.
+await client.accounts.import({
+  seed: initSeed, // Uint8Array
+  type: AccountType.RegularAccountUpdatableCode, // mutable wallet
+  auth: "falcon",
+});
+```
+
+:::warning[Seed imports are public-only]
+Import-by-seed works only for accounts originally created with `storage: "public"`. Private account state is never published on-chain, so it can't be reconstructed from a seed alone. For private accounts, use the file export / import workflow below.
+:::
+
+If you aren't sure whether the account is already in your local store, prefer [`getOrImport()`](#getorimport) — it skips the network call when the account is already known.
+
+## Export
+
+```typescript
+const accountFile = await client.accounts.export("0x1234...");
+// Persist accountFile to disk, send it to another device, etc.
+```
+
+`AccountFile` includes the full account state, code, seed (if new), and tracked secret keys. Treat it as sensitive.
+
+## Error behaviour
+
+- `get()` returns `null` when the account is not in the local store.
+- `getDetails()`, `getBalance()`, and `export()` throw `"Account not found: 0x..."` when the account is missing.
+- `import({ seed, ... })` on a private account throws at resolve time — private state isn't recoverable from a seed.
+
+## Next
+
+- [Transactions](./transactions.md) — spend, mint, consume, swap.
+- [Compile](./compile.md) — turn MASM into `AccountComponent`s for contract accounts.
+- [Sync and store](./sync.md) — refresh account state from the network.

--- a/docs/builder/tools/clients/web-client/compile.md
+++ b/docs/builder/tools/clients/web-client/compile.md
@@ -57,22 +57,27 @@ Options:
 
 - `code` — the MASM source for the component.
 - `slots` — initial storage slots. Use the `StorageSlot` helpers (`emptyValue`, etc.).
-- `supportAllTypes` — defaults to `true`. When `true`, the compiler injects `exec.auth::auth_tx_rpo_falcon512` so the component accepts all input types for Falcon-signed transactions. Set to `false` if your component already invokes an auth kernel procedure itself, or intentionally omits one.
+- `supportAllTypes` — defaults to `true`. When `true`, the compiler auto-injects an auth-kernel invocation so the component accepts the standard set of input types for authenticated transactions. Set to `false` if your component already invokes an auth kernel procedure itself, or intentionally omits one.
 
 ## Transaction scripts
 
 ### Without libraries
 
+A script with no `libraries` entry can only reference procedures that exist in the transaction kernel and the standard library — no custom external contracts:
+
 ```typescript
 const script = await client.compile.txScript({
   code: `
-    use external_contract::counter_contract
+    use miden::core::sys
     begin
-      call.counter_contract::increment_count
+      push.0
+      exec.sys::truncate_stack
     end
   `,
 });
 ```
+
+If your script needs to call into an external contract (as in the FPI section below), you must pass that contract's code through `libraries` — the compiler only links what you explicitly provide.
 
 ### With inline libraries
 

--- a/docs/builder/tools/clients/web-client/compile.md
+++ b/docs/builder/tools/clients/web-client/compile.md
@@ -1,0 +1,220 @@
+---
+title: Compile
+sidebar_position: 6
+---
+
+# Compile
+
+`client.compile` turns Miden Assembly (MASM) source into the three runtime artifacts the rest of the SDK consumes:
+
+| Method | Produces | Used by |
+| --- | --- | --- |
+| `client.compile.component({ code, slots?, supportAllTypes? })` | `AccountComponent` | [`accounts.create({ components: [...] })`](./accounts.md#contract) |
+| `client.compile.txScript({ code, libraries? })` | `TransactionScript` | [`transactions.execute({ script })`](./transactions.md#custom-transaction-scripts-execute) |
+| `client.compile.noteScript({ code, libraries? })` | `NoteScript` | `Note` construction utilities |
+
+Each call spins up a fresh `CodeBuilder`, so libraries linked in one call never leak into another.
+
+## Account components
+
+```typescript
+import { MidenClient, StorageSlot } from "@miden-sdk/miden-sdk";
+
+const client = await MidenClient.createTestnet();
+
+const contractCode = `
+  use miden::protocol::active_account
+  use miden::protocol::native_account
+  use miden::core::word
+  use miden::core::sys
+
+  const COUNTER_SLOT = word("miden::tutorials::counter")
+
+  pub proc get_count
+    push.COUNTER_SLOT[0..2] exec.active_account::get_item
+    exec.sys::truncate_stack
+  end
+
+  pub proc increment_count
+    push.COUNTER_SLOT[0..2] exec.active_account::get_item
+    add.1
+    push.COUNTER_SLOT[0..2] exec.native_account::set_item
+    exec.sys::truncate_stack
+  end
+`;
+
+const component = await client.compile.component({
+  code: contractCode,
+  slots: [StorageSlot.emptyValue("miden::tutorials::counter")],
+});
+
+// Use the procedure hash when calling this contract via FPI
+const getCountHash = component.getProcedureHash("get_count");
+console.log("get_count hash:", getCountHash);
+```
+
+Options:
+
+- `code` — the MASM source for the component.
+- `slots` — initial storage slots. Use the `StorageSlot` helpers (`emptyValue`, etc.).
+- `supportAllTypes` — defaults to `true`. When `true`, the compiler injects `exec.auth::auth_tx_rpo_falcon512` so the component accepts all input types for Falcon-signed transactions. Set to `false` if your component already invokes an auth kernel procedure itself, or intentionally omits one.
+
+## Transaction scripts
+
+### Without libraries
+
+```typescript
+const script = await client.compile.txScript({
+  code: `
+    use external_contract::counter_contract
+    begin
+      call.counter_contract::increment_count
+    end
+  `,
+});
+```
+
+### With inline libraries
+
+```typescript
+import { Linking } from "@miden-sdk/miden-sdk";
+
+const script = await client.compile.txScript({
+  code: `
+    use external_contract::my_contract
+    use miden::core::sys
+    begin
+      call.my_contract::do_something
+      exec.sys::truncate_stack
+    end
+  `,
+  libraries: [
+    {
+      namespace: "external_contract::my_contract",
+      code: myContractCode,
+      linking: Linking.Dynamic, // default
+    },
+  ],
+});
+```
+
+Each library takes:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `namespace` | yes | MASM namespace, e.g. `"counter::module"`. |
+| `code` | yes | MASM source. |
+| `linking` | no | `Linking.Dynamic` (default) or `Linking.Static`. `"dynamic"` / `"static"` string literals are also accepted. |
+
+### Linking modes
+
+| Value | Behaviour | When to use |
+| --- | --- | --- |
+| `Linking.Dynamic` (default) | Links via DYNCALL at prove time. The foreign contract's on-chain code is fetched by the prover. | FPI — foreign contract lives on-chain. |
+| `Linking.Static` | Inlines library code into the script at compile time. | Off-chain libraries that must be self-contained. |
+
+## Note scripts
+
+Note scripts run when an account consumes the note. The shape mirrors `txScript`; use it when you need custom logic on consumption.
+
+```typescript
+const noteScript = await client.compile.noteScript({
+  code: `
+    use miden::protocol::active_note
+    use miden::core::sys
+
+    begin
+      # Runs when the consuming account redeems this note.
+      # Real note scripts inspect note storage, assets, and account state
+      # using procedures from miden::protocol::active_note.
+      exec.sys::truncate_stack
+    end
+  `,
+});
+```
+
+Libraries follow the same `{ namespace, code, linking? }` shape as transaction scripts.
+
+## Procedure hashes (for FPI)
+
+Foreign procedure invocation requires the **hash** of the target procedure. Extract it from a compiled component:
+
+```typescript
+const component = await client.compile.component({
+  code: counterContractCode,
+  slots: [StorageSlot.emptyValue("miden::tutorials::counter")],
+});
+
+const getCountHash = component.getProcedureHash("get_count");
+
+const script = await client.compile.txScript({
+  code: `
+    use external_contract::count_reader_contract
+    use miden::core::sys
+    begin
+      push.${getCountHash}
+      push.${counterAccountId.suffix()}
+      push.${counterAccountId.prefix()}
+      call.count_reader_contract::copy_count
+      exec.sys::truncate_stack
+    end
+  `,
+  libraries: [
+    { namespace: "external_contract::count_reader_contract", code: countReaderCode },
+  ],
+});
+```
+
+## End-to-end: compile → create contract → execute script
+
+```typescript
+import {
+  MidenClient,
+  AccountType,
+  AuthSecretKey,
+  StorageSlot,
+} from "@miden-sdk/miden-sdk";
+
+const client = await MidenClient.createTestnet();
+await client.sync();
+
+// 1. Compile the contract component
+const component = await client.compile.component({
+  code: counterCode,
+  slots: [StorageSlot.emptyValue("miden::tutorials::counter")],
+});
+
+// 2. Create the contract account
+const seed = crypto.getRandomValues(new Uint8Array(32));
+const auth = AuthSecretKey.rpoFalconWithRNG(seed);
+
+const contract = await client.accounts.create({
+  type: AccountType.RegularAccountImmutableCode,
+  seed,
+  auth,
+  components: [component],
+});
+
+await client.sync();
+
+// 3. Compile the transaction script
+const script = await client.compile.txScript({
+  code: `
+    use external_contract::counter_contract
+    begin
+      call.counter_contract::increment_count
+    end
+  `,
+  libraries: [
+    { namespace: "external_contract::counter_contract", code: counterCode },
+  ],
+});
+
+// 4. Execute
+const { txId } = await client.transactions.execute({
+  account: contract.id(),
+  script,
+});
+
+console.log("Tx:", txId.toHex());
+```

--- a/docs/builder/tools/clients/web-client/index.md
+++ b/docs/builder/tools/clients/web-client/index.md
@@ -75,4 +75,4 @@ After `terminate()`, every subsequent method call throws `Error("Client terminat
 
 ## Migrating from `WebClient`
 
-The v0.13 flat `WebClient` class is deprecated. v0.14 introduces `MidenClient` with resource-based namespaces (`client.accounts`, `client.transactions`, …). See the [v0.13 → v0.14 Web SDK migration guide](../../../migration/client-changes.md) for the full delta.
+The v0.13 flat `WebClient` class is deprecated. v0.14 introduces `MidenClient` with resource-based namespaces (`client.accounts`, `client.transactions`, …). See the [v0.13 → v0.14 Web SDK migration guide](../../../migration/07-client-changes.md) for the full delta.

--- a/docs/builder/tools/clients/web-client/index.md
+++ b/docs/builder/tools/clients/web-client/index.md
@@ -1,0 +1,78 @@
+---
+title: Overview
+sidebar_position: 1
+---
+
+# Web SDK (@miden-sdk/miden-sdk)
+
+The Web SDK is the browser-focused toolkit for the Miden network. It wraps the Rust client, compiles to WebAssembly, and exposes a typed JavaScript API through the `MidenClient` class. Use it from web apps, wallets, dApps, service workers, Node servers — any JavaScript runtime that supports Web Workers and WebAssembly.
+
+## Capabilities
+
+- Read and write on-chain state: accounts, notes, transactions, tags.
+- Build and execute Miden transactions, including custom MASM scripts.
+- Compile Miden Assembly into account components, transaction scripts, and note scripts directly in the browser.
+- Generate zero-knowledge proofs locally via the in-browser prover, or offload proving to a remote or delegated prover.
+- Manage keys through built-in Falcon/ECDSA keystores or external signer integrations.
+- Exchange private notes through the Miden note transport network.
+- Import / export account files, note files, and full store snapshots for backup and migration.
+
+## Architecture
+
+```text
+┌────────────────────────────────────────────────┐
+│  @miden-sdk/miden-sdk (npm)                    │
+│                                                │
+│  MidenClient    (typed TS API)                 │
+│    │                                           │
+│    ├─ accounts / transactions / notes /        │
+│    │  tags / compile / keystore namespaces     │
+│    │                                           │
+│    └─ wraps WasmWebClient (Rust → WASM)        │
+│                                                │
+│  Runs prove / execute on a dedicated           │
+│  Web Worker to keep the main thread responsive │
+└────────────────────────────────────────────────┘
+```
+
+The SDK is built from the `web-client` Rust crate in [0xMiden/miden-client](https://github.com/0xMiden/miden-client), compiled with `wasm-bindgen`, and bundled with the WASM module, JavaScript bindings, and a dedicated Web Worker script.
+
+## Resource management
+
+Each `MidenClient` instance holds a dedicated Web Worker thread. When you no longer need a client — for example in a multi-wallet app that creates one client per active network — call `client.terminate()` to release the worker.
+
+```typescript
+import { MidenClient } from "@miden-sdk/miden-sdk";
+
+const client = await MidenClient.createTestnet();
+
+// ... use the client ...
+
+// Free the Web Worker when you are done
+client.terminate();
+```
+
+In environments that support the TC39 [explicit resource management](https://github.com/tc39/proposal-explicit-resource-management) proposal, you can use `using` to let the runtime handle cleanup automatically:
+
+```typescript
+{
+  using client = await MidenClient.createTestnet();
+  // ... client.terminate() is called automatically when the block exits
+}
+```
+
+After `terminate()`, every subsequent method call throws `Error("Client terminated")`.
+
+## Where to go next
+
+- [Setup](./setup.md) — install the SDK and create your first client.
+- [Accounts](./accounts.md) — create wallets, faucets, and contract accounts; look up existing ones.
+- [Transactions](./transactions.md) — mint, send, consume, swap, and run custom scripts.
+- [Notes](./notes.md) — list, import, export, and transport private notes.
+- [Compile](./compile.md) — turn Miden Assembly into account components and scripts.
+- [Sync and store](./sync.md) — pull network state and manage the local database.
+- [Testing](./testing.md) — drive a fully in-memory mock chain for fast, deterministic tests.
+
+## Migrating from `WebClient`
+
+The v0.13 flat `WebClient` class is deprecated. v0.14 introduces `MidenClient` with resource-based namespaces (`client.accounts`, `client.transactions`, …). See the [v0.13 → v0.14 Web SDK migration guide](../../../migration/client-changes.md) for the full delta.

--- a/docs/builder/tools/clients/web-client/notes.md
+++ b/docs/builder/tools/clients/web-client/notes.md
@@ -1,0 +1,145 @@
+---
+title: Notes
+sidebar_position: 5
+---
+
+# Notes
+
+Notes are the primary mechanism for transferring assets and data between accounts on Miden. This guide covers the `client.notes.*` surface: listing, lookup, import / export, private-note transport, and tags.
+
+## List received notes
+
+```typescript
+import { MidenClient } from "@miden-sdk/miden-sdk";
+
+const client = await MidenClient.createTestnet();
+
+// All input notes
+const all = await client.notes.list();
+
+// Filter by status
+const committed   = await client.notes.list({ status: "committed" });
+const consumed    = await client.notes.list({ status: "consumed" });
+const expected    = await client.notes.list({ status: "expected" });
+const processing  = await client.notes.list({ status: "processing" });
+const unverified  = await client.notes.list({ status: "unverified" });
+
+// Filter by specific IDs
+const specific = await client.notes.list({ ids: [noteId1, noteId2] });
+
+for (const note of all) {
+  console.log(note.id().toString());
+}
+```
+
+Statuses:
+
+- `"committed"` — on-chain, consumable.
+- `"consumed"` — already spent.
+- `"expected"` — the client expects this note to arrive.
+- `"processing"` — mid-consume.
+- `"unverified"` — on-chain, awaiting local verification.
+
+## Retrieve a single note
+
+```typescript
+const note = await client.notes.get("0xnote...");
+if (note) {
+  console.log(note.id().toString());
+}
+```
+
+Returns `null` when the note isn't tracked locally.
+
+## List sent notes (output notes)
+
+```typescript
+const sent = await client.notes.listSent();
+
+// With status filter
+const committedSent = await client.notes.listSent({ status: "committed" });
+```
+
+## List consumable notes for an account
+
+```typescript
+const records = await client.notes.listAvailable({ account: wallet });
+
+for (const record of records) {
+  console.log("Note:", record.id().toString());
+}
+```
+
+Returns the input notes available for the specified account. Use this to drive "inbox" UIs.
+
+## Import and export
+
+```typescript
+import { MidenClient, NoteExportFormat } from "@miden-sdk/miden-sdk";
+
+const client = await MidenClient.createTestnet();
+
+// Import from a previously exported NoteFile
+const noteId = await client.notes.import(noteFile);
+console.log("Imported:", noteId.toString());
+
+// Export — formats differ in completeness
+const idOnly  = await client.notes.export("0xnote...", { format: NoteExportFormat.Id });
+const full    = await client.notes.export("0xnote...", { format: NoteExportFormat.Full });
+const details = await client.notes.export("0xnote...", { format: NoteExportFormat.Details });
+```
+
+`NoteExportFormat`:
+
+- **`Id`** — just the note ID. Only works for public notes.
+- **`Full`** — complete note data plus inclusion proof. Requires the note to have an on-chain inclusion proof.
+- **`Details`** — note ID, metadata, and creation block.
+
+## Note transport (private notes)
+
+Private notes are delivered through the Miden note transport service. The sender emits a note with `type: "private"`; the recipient fetches it from the transport network.
+
+```typescript
+// Send a private note
+await client.notes.sendPrivate({
+  note: "0xnote...",           // NoteInput
+  to: "mtst1recipient...",     // recipient AccountRef
+});
+
+// Fetch — default is incremental (paginated)
+await client.notes.fetchPrivate();
+
+// Or fetch everything at once (initial-setup scenarios)
+await client.notes.fetchPrivate({ mode: "all" });
+
+// Now inspect the inbox
+const notes = await client.notes.list();
+console.log(`Fetched ${notes.length} notes`);
+```
+
+You need a note transport endpoint configured on the client — set `noteTransportUrl` in `ClientOptions`, or use a network factory (`createTestnet`, `createDevnet`) that preconfigures it.
+
+## Tags
+
+Tags are `u32` values that the sync process uses as a fuzzy filter to decide which notes to pull for your client. They come from three sources:
+
+1. **Account tags** — auto-registered for every account the client tracks.
+2. **Note tags** — auto-registered for notes the client expects.
+3. **User tags** — manually added via `client.tags.add()`.
+
+```typescript
+await client.tags.add(12345);
+
+const tags = await client.tags.list();
+console.log("Tracked tags:", tags);
+
+await client.tags.remove(12345);
+```
+
+Auto-generated tags (accounts, expected notes) cannot be removed — `remove()` only unregisters user-added tags. Use `NoteTag` helpers (exposed from the WASM module) to compute tag values from faucet IDs and account IDs.
+
+## Next
+
+- [Transactions](./transactions.md) — consume notes, send tokens, create output notes.
+- [Compile](./compile.md) — author note scripts in MASM.
+- [Sync and store](./sync.md) — the pipeline that feeds note state into your client.

--- a/docs/builder/tools/clients/web-client/setup.md
+++ b/docs/builder/tools/clients/web-client/setup.md
@@ -52,17 +52,33 @@ All factories are async — the SDK has to load its WebAssembly module and spin 
 
 ## `ClientOptions` reference
 
-`MidenClient.create()`, `createTestnet()`, and `createDevnet()` all accept the same options object. The network factories just pre-fill sensible defaults for `rpcUrl`, `proverUrl`, `noteTransportUrl`, and `autoSync`.
+All four factories accept the same `ClientOptions` shape. The differences are in what each factory pre-fills before the options are applied.
 
-| Option | Type | Default | Description |
-| --- | --- | --- | --- |
-| `rpcUrl` | `"testnet" \| "devnet" \| "localhost" \| "local" \| string` | SDK testnet RPC | Node RPC endpoint. Shorthands expand to the hosted Miden endpoints; any other string is treated as a raw URL. |
-| `noteTransportUrl` | `"testnet" \| "devnet" \| string` | — | Note transport service endpoint (required for private-note `sendPrivate` / `fetchPrivate`). |
-| `proverUrl` | `"local" \| "devnet" \| "testnet" \| string` | `"local"` | Default prover for transactions. `"local"` runs the prover in the browser; the other shorthands and URLs route to a remote/delegated prover. |
-| `autoSync` | `boolean` | `false` for `create`, `true` for network factories | When `true`, the client runs one sync pass before the promise resolves. |
-| `seed` | `string \| Uint8Array` | random | Seed for deterministic RNG. Strings are hashed to 32 bytes via SHA-256. |
-| `storeName` | `string` | per-build default | Store isolation key (IndexedDB database name in browsers). Set this to keep multiple clients' data separate in the same origin. |
-| `keystore` | `{ getKey, insertKey, sign }` | built-in keystore | External keystore callbacks. Leave unset to use the built-in keystore. |
+### Field reference
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `rpcUrl` | `"testnet" \| "devnet" \| "localhost" \| "local" \| string` | Node RPC endpoint. Shorthands expand to the hosted Miden endpoints; any other string is treated as a raw URL. |
+| `noteTransportUrl` | `"testnet" \| "devnet" \| string` | Note transport service endpoint. Required for private-note `sendPrivate` / `fetchPrivate`. |
+| `proverUrl` | `"local" \| "devnet" \| "testnet" \| string` | Default prover for transactions. `"local"` runs in the browser; remote shorthands and URLs route to a remote / delegated prover. |
+| `autoSync` | `boolean` | When `true`, the client runs one sync pass before the promise resolves. |
+| `seed` | `string \| Uint8Array` | Seed for deterministic RNG. Strings are hashed to 32 bytes via SHA-256. |
+| `storeName` | `string` | Store isolation key (IndexedDB database name in browsers). Set this to keep multiple clients' data separate in the same origin. |
+| `keystore` | `{ getKey, insertKey, sign }` | External keystore callbacks. Leave unset to use the built-in keystore. |
+
+### Factory defaults
+
+Any option not passed falls back to the factory default, then to an SDK default.
+
+| Factory | `rpcUrl` | `proverUrl` | `noteTransportUrl` | `autoSync` |
+| --- | --- | --- | --- | --- |
+| `createTestnet(opts?)` | `"testnet"` | `"testnet"` | `"testnet"` | `true` |
+| `createDevnet(opts?)` | `"devnet"` | `"devnet"` | `"devnet"` | `true` |
+| `create(opts?)` **with** `rpcUrl` | your value | `"local"` | _none_ | `false` |
+| `create(opts?)` **without** `rpcUrl` | _delegates to `createTestnet(opts)`_ | ← | ← | ← |
+| `createMock(opts?)` | _(no network)_ | _(dummy proving)_ | _(in-memory)_ | _(manual)_ |
+
+`create()` without an `rpcUrl` is not a separate "custom" client — it forwards its options to `createTestnet()`. If you want a no-prover, no-autosync client against localhost, pass `rpcUrl: "localhost"` explicitly.
 
 ### Testnet with an in-browser prover
 

--- a/docs/builder/tools/clients/web-client/setup.md
+++ b/docs/builder/tools/clients/web-client/setup.md
@@ -1,0 +1,142 @@
+---
+title: Setup
+sidebar_position: 2
+---
+
+# Setting up the Web SDK
+
+## Install
+
+Add `@miden-sdk/miden-sdk` to your project.
+
+```bash
+npm install @miden-sdk/miden-sdk
+# or
+yarn add @miden-sdk/miden-sdk
+# or
+pnpm add @miden-sdk/miden-sdk
+```
+
+The SDK targets modern browsers (Chrome, Firefox, Safari, Edge) with WebAssembly and Web Worker support. It also runs under Node 20+ when the host provides those primitives.
+
+## Create a client
+
+Every operation goes through a `MidenClient` instance. Four factories cover the common cases:
+
+| Factory | Use for |
+| --- | --- |
+| `MidenClient.createTestnet()` | Miden testnet — RPC, prover, and note transport preconfigured |
+| `MidenClient.createDevnet()` | Miden devnet — same shape, devnet endpoints |
+| `MidenClient.createMock()` | Deterministic in-memory chain for tests — no network |
+| `MidenClient.create({ ... })` | Custom endpoints (localhost, self-hosted node, or any shorthand) |
+
+```typescript
+import { MidenClient } from "@miden-sdk/miden-sdk";
+
+// Miden testnet (most common for dApps under development)
+const client = await MidenClient.createTestnet();
+
+// Local node — "localhost" / "local" shorthand resolves to http://localhost:57291
+const local = await MidenClient.create({ rpcUrl: "localhost" });
+
+// Any custom URL
+const custom = await MidenClient.create({
+  rpcUrl: "https://my-node.example.com",
+});
+
+// Mock chain (see the Testing guide)
+const mock = await MidenClient.createMock();
+```
+
+All factories are async — the SDK has to load its WebAssembly module and spin up a Web Worker before the client is usable.
+
+## `ClientOptions` reference
+
+`MidenClient.create()`, `createTestnet()`, and `createDevnet()` all accept the same options object. The network factories just pre-fill sensible defaults for `rpcUrl`, `proverUrl`, `noteTransportUrl`, and `autoSync`.
+
+| Option | Type | Default | Description |
+| --- | --- | --- | --- |
+| `rpcUrl` | `"testnet" \| "devnet" \| "localhost" \| "local" \| string` | SDK testnet RPC | Node RPC endpoint. Shorthands expand to the hosted Miden endpoints; any other string is treated as a raw URL. |
+| `noteTransportUrl` | `"testnet" \| "devnet" \| string` | — | Note transport service endpoint (required for private-note `sendPrivate` / `fetchPrivate`). |
+| `proverUrl` | `"local" \| "devnet" \| "testnet" \| string` | `"local"` | Default prover for transactions. `"local"` runs the prover in the browser; the other shorthands and URLs route to a remote/delegated prover. |
+| `autoSync` | `boolean` | `false` for `create`, `true` for network factories | When `true`, the client runs one sync pass before the promise resolves. |
+| `seed` | `string \| Uint8Array` | random | Seed for deterministic RNG. Strings are hashed to 32 bytes via SHA-256. |
+| `storeName` | `string` | per-build default | Store isolation key (IndexedDB database name in browsers). Set this to keep multiple clients' data separate in the same origin. |
+| `keystore` | `{ getKey, insertKey, sign }` | built-in keystore | External keystore callbacks. Leave unset to use the built-in keystore. |
+
+### Testnet with an in-browser prover
+
+```typescript
+// Testnet — but prove locally in the browser instead of offloading
+const client = await MidenClient.createTestnet({ proverUrl: "local" });
+```
+
+### Keeping two isolated clients in the same origin
+
+```typescript
+const a = await MidenClient.createTestnet({ storeName: "wallet-a" });
+const b = await MidenClient.createTestnet({ storeName: "wallet-b" });
+```
+
+Each call creates its own IndexedDB database. The two wallets' state never crosses over.
+
+## Keystores and authentication
+
+The built-in keystore handles signing for the common flows: `client.accounts.create()` generates a Falcon key, persists it, and the client uses it automatically during `client.transactions.*` calls.
+
+When you need explicit control — for example when creating a contract account with a pre-derived seed, or wiring an external signer — build an `AuthSecretKey` directly:
+
+```typescript
+import { AuthSecretKey } from "@miden-sdk/miden-sdk";
+
+// Falcon key (the default auth scheme for regular wallets)
+const seed = crypto.getRandomValues(new Uint8Array(32));
+const auth = AuthSecretKey.rpoFalconWithRNG(seed);
+```
+
+The caller is responsible for retaining `auth` as long as the account is in use: the client holds a reference for signing, but the secret material only exists on the caller side until it is handed to the keystore.
+
+See [Accounts](./accounts.md) for full examples covering wallets, contracts, and faucets. For advanced setups — external signers, hardware wallets — the `keystore` option on `ClientOptions` wires the SDK to your own `sign`/`getKey`/`insertKey` callbacks.
+
+## Remote provers and per-transaction overrides
+
+Local proving in the browser is CPU-intensive for larger transactions. Override globally via `ClientOptions.proverUrl`, or per transaction via the `prover` field:
+
+```typescript
+// Globally: every transaction uses the remote prover by default
+const client = await MidenClient.create({
+  rpcUrl: "testnet",
+  proverUrl: "https://prover.example.com",
+});
+
+// Per-transaction: pass a TransactionProver instance
+await client.transactions.send({
+  account: wallet,
+  to: recipient,
+  token: faucet,
+  amount: 100n,
+  prover: customProver,
+});
+```
+
+See [Transactions](./transactions.md) for the full lifecycle.
+
+## Minimal example
+
+```typescript
+import { MidenClient } from "@miden-sdk/miden-sdk";
+
+async function demo() {
+  const client = await MidenClient.createTestnet();
+  await client.sync();
+
+  const wallet = await client.accounts.create();
+  console.log("Wallet:", wallet.id().toString());
+
+  client.terminate();
+}
+
+demo().catch(console.error);
+```
+
+For a testable, offline-friendly version of this pattern, see [Testing](./testing.md).

--- a/docs/builder/tools/clients/web-client/sync.md
+++ b/docs/builder/tools/clients/web-client/sync.md
@@ -1,0 +1,88 @@
+---
+title: Sync and store
+sidebar_position: 7
+---
+
+# Sync and store
+
+Every operation the Web SDK performs reads from — or writes to — a local store. This page covers how to keep that store in sync with the Miden network, and how to back up / restore the store itself.
+
+## `client.sync()`
+
+Pulls updates from the Miden node and applies them to the local store. Returns a `SyncSummary` describing what changed.
+
+```typescript
+import { MidenClient } from "@miden-sdk/miden-sdk";
+
+const client = await MidenClient.createTestnet();
+
+const summary = await client.sync();
+
+console.log("Block:", summary.blockNum());
+console.log("Committed notes:", summary.committedNotes().length);
+console.log("Consumed notes:", summary.consumedNotes().length);
+console.log("Committed txs:", summary.committedTransactions().length);
+console.log("Updated accounts:", summary.updatedAccounts().length);
+```
+
+`SyncSummary` accessors:
+
+- `blockNum(): number` — tip block the summary is based on.
+- `committedNotes(): NoteId[]` — notes committed in this sync window.
+- `consumedNotes(): NoteId[]` — notes consumed in this sync window.
+- `committedTransactions(): TransactionId[]` — transactions that were committed.
+- `updatedAccounts(): AccountId[]` — accounts whose on-chain state advanced.
+
+## Sync with timeout
+
+```typescript
+// 30-second timeout
+const summary = await client.sync({ timeout: 30_000 });
+```
+
+## Auto-sync on creation
+
+The network factories (`createTestnet`, `createDevnet`) default `autoSync: true`, so one sync runs before the client is returned. `create()` defaults to `false`; pass `autoSync: true` explicitly if you want the same behaviour for a custom endpoint:
+
+```typescript
+const client = await MidenClient.create({
+  rpcUrl: "localhost",
+  autoSync: true,
+});
+```
+
+## Current sync height
+
+Cheap check of the locally-known tip, no network call:
+
+```typescript
+const height: number = await client.getSyncHeight();
+console.log("Local tip:", height);
+```
+
+## Store backup and restore
+
+The SDK exposes two **standalone** functions (not methods on `MidenClient`) for snapshotting the entire store:
+
+```typescript
+import { exportStore, importStore } from "@miden-sdk/miden-sdk";
+
+// Dump the store identified by storeName into a JSON string.
+const storeName = client.storeIdentifier(); // or pass your own storeName
+const dump = await exportStore(storeName);
+
+// Later — on another device, or after a page refresh — restore it.
+await importStore(storeName, dump);
+```
+
+- `exportStore(storeName)` → `Promise<string>` — returns a JSON dump of the IndexedDB store.
+- `importStore(storeName, dump)` → `Promise<void>` — replaces all existing data in the target store with the dump.
+
+`importStore` is destructive. It overwrites the target store entirely — keep a backup if you need the previous state.
+
+These helpers are package-level exports, not methods on `MidenClient`, so they can run without an active client — for example in a worker that performs scheduled backups.
+
+## Next
+
+- [Testing](./testing.md) — running a deterministic, in-memory mock chain for tests.
+- [Transactions](./transactions.md) — how network state feeds back into transaction flows.

--- a/docs/builder/tools/clients/web-client/testing.md
+++ b/docs/builder/tools/clients/web-client/testing.md
@@ -1,0 +1,132 @@
+---
+title: Testing
+sidebar_position: 8
+---
+
+# Testing with the mock client
+
+`MidenClient.createMock()` returns a client backed by a fully in-memory mock chain. It exposes the same resource API as the real client — `accounts`, `transactions`, `notes`, `tags`, `compile`, `keystore` — so tests for your application code don't need parallel mocking logic. It also adds a handful of mock-specific helpers for driving the chain manually.
+
+Use it for unit tests, CI, and offline development. It is orders of magnitude faster than hitting testnet, and it works on flaky networks.
+
+## Create
+
+```typescript
+import { MidenClient } from "@miden-sdk/miden-sdk";
+
+const client = await MidenClient.createMock();
+```
+
+`createMock()` accepts `MockOptions`:
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `seed` | `string \| Uint8Array` | RNG seed. Strings are hashed to 32 bytes via SHA-256. |
+| `serializedMockChain` | `Uint8Array` | Restore a previously serialized chain state. |
+| `serializedNoteTransport` | `Uint8Array` | Restore a previously serialized note-transport state. |
+
+## Basic flow
+
+The mock chain does not create blocks automatically — advance it with `proveBlock()` after each transaction batch. Between `proveBlock()` and subsequent reads, call `client.sync()` to hydrate the store.
+
+```typescript
+import { MidenClient, AccountType } from "@miden-sdk/miden-sdk";
+
+const client = await MidenClient.createMock();
+
+const wallet = await client.accounts.create();
+const faucet = await client.accounts.create({
+  type: AccountType.FungibleFaucet,
+  symbol: "TEST",
+  decimals: 8,
+  maxSupply: 10_000_000n,
+});
+
+client.proveBlock();
+await client.sync();
+
+await client.transactions.mint({
+  account: faucet,
+  to: wallet,
+  amount: 1000n,
+});
+
+client.proveBlock();
+await client.sync();
+
+const result = await client.transactions.consumeAll({ account: wallet });
+console.log(`Consumed ${result.consumed} notes`);
+
+client.proveBlock();
+await client.sync();
+
+const balance = await client.accounts.getBalance(wallet, faucet);
+console.log(`Balance: ${balance}`); // 1000n
+```
+
+## Dummy proving
+
+Transaction proving is automatically replaced with `LocalTransactionProver.prove_dummy()` on mock clients. You don't configure anything — any transaction method that would normally prove is instead given a dummy proof that the mock chain accepts. Key consequences:
+
+- Near-instant transactions, regardless of script complexity.
+- No prover configuration required — `proverUrl` is ignored on mock clients.
+- Dummy proofs are **not** valid on real chains.
+
+## Mock-only helpers
+
+The `MidenClient` class exposes a few methods that only make sense on mock clients. Guard them behind `usesMockChain()` if your code needs to work against both mock and real clients.
+
+```typescript
+if (client.usesMockChain()) {
+  client.proveBlock();
+}
+
+const chainBytes     = client.serializeMockChain();
+const transportBytes = client.serializeMockNoteTransportNode();
+```
+
+| Method | Purpose |
+| --- | --- |
+| `client.proveBlock()` | Advance the mock chain by one block. |
+| `client.usesMockChain()` | `true` on mock clients; `false` on real clients. |
+| `client.serializeMockChain()` | Snapshot mock chain state as bytes. |
+| `client.serializeMockNoteTransportNode()` | Snapshot mock note transport state as bytes. |
+
+## Snapshot and restore
+
+Serialize the state of a running mock client, then restore it in a new client. Useful for long-running test scaffolds that want a shared starting state:
+
+```typescript
+// Setup: create client, advance chain, fund accounts, etc.
+const setup = await MidenClient.createMock();
+// ...
+const chainState     = setup.serializeMockChain();
+const transportState = setup.serializeMockNoteTransportNode();
+setup.terminate();
+
+// In a test, restore from the snapshot
+const client = await MidenClient.createMock({
+  serializedMockChain: chainState,
+  serializedNoteTransport: transportState,
+});
+```
+
+## Private-note transport
+
+The mock client ships its own in-memory note transport. The same `sendPrivate` / `fetchPrivate` flow works:
+
+```typescript
+import { MidenClient } from "@miden-sdk/miden-sdk";
+
+const client = await MidenClient.createMock();
+
+await client.notes.sendPrivate({
+  note: "0xnote...",
+  to: "mtst1recipient...",
+});
+
+await client.notes.fetchPrivate();
+
+const notes = await client.notes.list();
+console.log(`Received ${notes.length} notes`);
+```

--- a/docs/builder/tools/clients/web-client/transactions.md
+++ b/docs/builder/tools/clients/web-client/transactions.md
@@ -45,6 +45,10 @@ const { txId, note } = await client.transactions.send({
 
 `reclaimAfter` and `timelockUntil` are **block numbers**, not wall-clock times.
 
+:::note
+The `returnNote: true` branch is a separate overload: it does not accept `reclaimAfter` or `timelockUntil`. If you need either of those, use the default branch (without `returnNote`) and retrieve the note through `client.notes.listSent()` instead.
+:::
+
 ### `mint`
 
 ```typescript
@@ -306,7 +310,7 @@ const request = new TransactionRequestBuilder()
 await client.transactions.submit(wallet, request);
 ```
 
-`withExpirationDelta()` is for builder flows where the script is auto-derived. It can't be combined with `withCustomScript()` — for custom scripts, set expiration inside the script itself.
+`withExpirationDelta()` composes with `withCustomScript()` — the builder applies the expiration at the request level regardless of how the script was provided. You can still set expiration inside the script itself when you need a different rule; the two paths don't interact.
 
 ## Remote proving
 

--- a/docs/builder/tools/clients/web-client/transactions.md
+++ b/docs/builder/tools/clients/web-client/transactions.md
@@ -1,0 +1,375 @@
+---
+title: Transactions
+sidebar_position: 4
+---
+
+# Transactions
+
+`client.transactions` is the resource namespace for everything that mutates on-chain state: sending, minting, consuming, swapping, running custom scripts, and inspecting history. Every mutation method handles the full lifecycle — execute, prove, submit — in one call.
+
+## Simplified operations
+
+### `send`
+
+Creates a pay-to-ID note that transfers tokens from one account to another.
+
+```typescript
+import { MidenClient } from "@miden-sdk/miden-sdk";
+
+const client = await MidenClient.createTestnet();
+
+const { txId } = await client.transactions.send({
+  account: senderWallet,
+  to: recipientWallet,
+  token: faucet,
+  amount: 100n,
+  type: "private",       // "public" or "private" — default "public"
+  reclaimAfter: 100,     // optional: block number after which sender can reclaim
+  timelockUntil: 90,     // optional: block number until which note is timelocked
+});
+console.log("Send tx:", txId.toString());
+```
+
+Set `returnNote: true` to receive the created `Note` in the result (useful when you need the note body — for QR delivery, for example):
+
+```typescript
+const { txId, note } = await client.transactions.send({
+  account: senderWallet,
+  to: recipientWallet,
+  token: faucet,
+  amount: 100n,
+  returnNote: true,
+});
+// `note` is guaranteed non-null when returnNote is true
+```
+
+`reclaimAfter` and `timelockUntil` are **block numbers**, not wall-clock times.
+
+### `mint`
+
+```typescript
+const { txId } = await client.transactions.mint({
+  account: faucet,    // the faucet account
+  to: wallet,         // recipient
+  amount: 1000n,
+  type: "private",    // optional, default "public"
+});
+console.log("Mint tx:", txId.toString());
+```
+
+### `consume`
+
+```typescript
+// Consume one or more input notes
+const { txId } = await client.transactions.consume({
+  account: wallet,
+  notes: [noteId1, noteId2],  // note references — hex strings, NoteIds, records, or Notes
+});
+
+// Single note also accepted directly, no array needed
+await client.transactions.consume({
+  account: wallet,
+  notes: noteId1,
+});
+```
+
+### `consumeAll`
+
+Consumes every available note for an account, up to an optional limit. Useful for quickly draining an inbox.
+
+```typescript
+const result = await client.transactions.consumeAll({ account: wallet });
+console.log(`Consumed ${result.consumed}, ${result.remaining} remaining`);
+if (result.txId) {
+  console.log("Tx:", result.txId.toString());
+}
+
+// Cap the number of notes consumed in one transaction
+await client.transactions.consumeAll({ account: wallet, maxNotes: 5 });
+```
+
+`result.remaining > 0` signals pagination — call `consumeAll` again to drain the rest.
+
+### `swap`
+
+Atomic swap between two assets.
+
+```typescript
+const { txId } = await client.transactions.swap({
+  account: wallet,
+  offer: { token: faucetA, amount: 100n },
+  request: { token: faucetB, amount: 200n },
+  type: "public",           // optional — visibility of the offer note
+  paybackType: "private",   // optional — visibility of the payback note
+});
+```
+
+## Waiting for confirmation
+
+All simplified operations return as soon as the transaction is submitted to the mempool. To block until the network commits the transaction, use `waitFor`:
+
+```typescript
+const { txId } = await client.transactions.mint({
+  account: faucet,
+  to: wallet,
+  amount: 1000n,
+});
+
+// Default: 60s timeout, 5s polling interval
+await client.transactions.waitFor(txId.toHex());
+
+// Custom polling
+await client.transactions.waitFor(txId.toHex(), {
+  timeout: 120_000,   // 2 minutes — set to 0 to poll indefinitely
+  interval: 3_000,
+  onProgress: (status) => {
+    console.log(`Status: ${status}`); // "pending" | "submitted" | "committed"
+  },
+});
+```
+
+`waitFor` throws on rejection or timeout.
+
+## Preview (dry run)
+
+Run any of the simplified operations as a dry-run to inspect its effects without submitting to the network. The return type is a `TransactionSummary`.
+
+```typescript
+const summary = await client.transactions.preview({
+  operation: "send",
+  account: wallet,
+  to: recipient,
+  token: faucet,
+  amount: 100n,
+});
+```
+
+`operation` accepts `"send"`, `"mint"`, `"consume"`, and `"swap"`.
+
+## Custom transaction scripts (`execute`)
+
+When the simplified operations aren't enough — for example to call a procedure on a contract account — compile a transaction script with [`client.compile.txScript()`](./compile.md) and run it through `execute`:
+
+```typescript
+import { MidenClient } from "@miden-sdk/miden-sdk";
+
+const client = await MidenClient.createTestnet();
+
+const script = await client.compile.txScript({
+  code: `
+    use external_contract::counter_contract
+    begin
+      call.counter_contract::increment_count
+    end
+  `,
+  libraries: [
+    {
+      namespace: "external_contract::counter_contract",
+      code: counterContractCode,
+    },
+  ],
+});
+
+const { txId } = await client.transactions.execute({
+  account: contractAccount.id(),
+  script,
+});
+
+console.log("Tx:", txId.toHex());
+```
+
+### Foreign procedure invocation (FPI)
+
+Pass `foreignAccounts` to read state from other contracts during execution:
+
+```typescript
+import { MidenClient, StorageSlot } from "@miden-sdk/miden-sdk";
+
+const client = await MidenClient.createTestnet();
+
+// Compile the foreign contract to get a procedure hash
+const counterComponent = await client.compile.component({
+  code: counterContractCode,
+  slots: [StorageSlot.emptyValue("miden::tutorials::counter")],
+});
+const getCountHash = counterComponent.getProcedureHash("get_count");
+
+const script = await client.compile.txScript({
+  code: `
+    use external_contract::count_reader_contract
+    use miden::core::sys
+    begin
+      push.${getCountHash}
+      push.${counterAccount.id().suffix()}
+      push.${counterAccount.id().prefix()}
+      call.count_reader_contract::copy_count
+      exec.sys::truncate_stack
+    end
+  `,
+  libraries: [
+    { namespace: "external_contract::count_reader_contract", code: countReaderCode },
+  ],
+});
+
+const { txId } = await client.transactions.execute({
+  account: countReaderAccount.id(),
+  script,
+  foreignAccounts: [
+    // Bare reference — client fetches storage requirements automatically
+    counterAccount.id(),
+    // Or with explicit storage requirements:
+    // { id: counterAccount.id(), storage: requirements },
+  ],
+});
+```
+
+## View calls (`executeProgram`)
+
+`executeProgram` runs a transaction script locally, returning the resulting stack without submitting or proving anything. Use it to read on-chain state — similar to `eth_call` in Ethereum.
+
+```typescript
+const script = await client.compile.txScript({
+  code: `
+    use external_contract::counter_contract
+    begin
+      call.counter_contract::get_count
+    end
+  `,
+  libraries: [
+    { namespace: "external_contract::counter_contract", code: counterContractCode },
+  ],
+});
+
+const stack = await client.transactions.executeProgram({
+  account: contractAccount.id(),
+  script,
+  foreignAccounts: [counterAccount.id()],
+});
+
+// stack is a FeltArray — 16 elements representing the final stack
+const count = stack.get(0).asInt();
+console.log("Count:", count);
+```
+
+Options:
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `account` | `AccountRef` | Account to execute the script against. |
+| `script` | `TransactionScript` | Compiled script. |
+| `adviceInputs` | `AdviceInputs?` | Advice inputs for the VM. Defaults to empty. |
+| `foreignAccounts` | `(AccountRef \| { id, storage? })[]?` | Foreign accounts for FPI reads. |
+
+## Manual `TransactionRequest`
+
+For full control over note inputs and outputs — e.g. emitting multiple custom output notes from one transaction — build a `TransactionRequest` yourself and pass it to `submit`.
+
+The builder accepts WASM array classes (`NoteArray`, `NoteDetailsAndTagArray`, `NoteRecipientArray`) rather than plain TS arrays. This is unusual but required by the underlying wasm-bindgen interface: the array types take ownership of their elements and are explicitly disposable.
+
+```typescript
+import {
+  MidenClient,
+  TransactionRequestBuilder,
+  NoteArray,
+} from "@miden-sdk/miden-sdk";
+
+const client = await MidenClient.createTestnet();
+
+// Populate a NoteArray with your output notes
+const ownOutputs = new NoteArray();
+for (const note of outputNotes) {
+  ownOutputs.push(note);
+}
+
+const request = new TransactionRequestBuilder()
+  .withCustomScript(transactionScript)
+  .withOwnOutputNotes(ownOutputs)
+  .build();
+
+const { txId } = await client.transactions.submit(wallet, request);
+console.log("Tx:", txId.toString());
+```
+
+Expected-note hints are also available:
+
+- `withExpectedFutureNotes(NoteDetailsAndTagArray)` — notes the transaction should produce but won't emit directly (e.g. for later pickup).
+- `withExpectedOutputRecipients(NoteRecipientArray)` — recipients for expected output notes.
+
+### Setting an expiration
+
+```typescript
+const request = new TransactionRequestBuilder()
+  .withOwnOutputNotes(ownOutputs)
+  .withExpirationDelta(10) // expires 10 blocks after submission
+  .build();
+
+await client.transactions.submit(wallet, request);
+```
+
+`withExpirationDelta()` is for builder flows where the script is auto-derived. It can't be combined with `withCustomScript()` — for custom scripts, set expiration inside the script itself.
+
+## Remote proving
+
+Local proving is CPU-intensive. Offload globally via `ClientOptions.proverUrl`, or per-transaction via the `prover` field:
+
+```typescript
+// Global: every transaction uses the remote prover
+const client = await MidenClient.create({
+  rpcUrl: "testnet",
+  proverUrl: "https://prover.example.com",
+});
+
+// Per-transaction: pass a TransactionProver instance
+await client.transactions.send({
+  account: wallet,
+  to: recipient,
+  token: faucet,
+  amount: 100n,
+  prover: customProver,
+});
+```
+
+## History
+
+Query past transactions through `client.transactions.list()`.
+
+```typescript
+// All transactions
+const all = await client.transactions.list();
+
+// Only uncommitted
+const uncommitted = await client.transactions.list({ status: "uncommitted" });
+
+// By ID
+const specific = await client.transactions.list({ ids: [txId1, txId2] });
+
+// By expiration
+const expired = await client.transactions.list({ expiredBefore: 1000 });
+```
+
+Each record exposes:
+
+```typescript
+for (const tx of all) {
+  tx.id().toString();
+  tx.accountId().toString();
+  tx.blockNum().toString();
+
+  const status = tx.transactionStatus();
+  if (status.isPending())    console.log("Pending");
+  if (status.isCommitted())  console.log("Committed at", status.getBlockNum(), status.getCommitTimestamp());
+  if (status.isDiscarded())  console.log("Discarded");
+
+  tx.initAccountState().toHex();
+  tx.finalAccountState().toHex();
+
+  tx.inputNoteNullifiers().map((n) => n.toHex());
+  tx.outputNotes().toString();
+}
+```
+
+## Next
+
+- [Notes](./notes.md) — list, import, export, private-note transport.
+- [Compile](./compile.md) — MASM for account components, transaction scripts, note scripts.
+- [Testing](./testing.md) — drive a fully in-memory mock chain for fast, deterministic tests.

--- a/docs/builder/tools/clients/web-client/transactions.md
+++ b/docs/builder/tools/clients/web-client/transactions.md
@@ -27,7 +27,7 @@ const { txId } = await client.transactions.send({
   reclaimAfter: 100,     // optional: block number after which sender can reclaim
   timelockUntil: 90,     // optional: block number until which note is timelocked
 });
-console.log("Send tx:", txId.toString());
+console.log("Send tx:", txId.toHex());
 ```
 
 Set `returnNote: true` to receive the created `Note` in the result (useful when you need the note body — for QR delivery, for example):
@@ -54,7 +54,7 @@ const { txId } = await client.transactions.mint({
   amount: 1000n,
   type: "private",    // optional, default "public"
 });
-console.log("Mint tx:", txId.toString());
+console.log("Mint tx:", txId.toHex());
 ```
 
 ### `consume`
@@ -81,7 +81,7 @@ Consumes every available note for an account, up to an optional limit. Useful fo
 const result = await client.transactions.consumeAll({ account: wallet });
 console.log(`Consumed ${result.consumed}, ${result.remaining} remaining`);
 if (result.txId) {
-  console.log("Tx:", result.txId.toString());
+  console.log("Tx:", result.txId.toHex());
 }
 
 // Cap the number of notes consumed in one transaction
@@ -287,7 +287,7 @@ const request = new TransactionRequestBuilder()
   .build();
 
 const { txId } = await client.transactions.submit(wallet, request);
-console.log("Tx:", txId.toString());
+console.log("Tx:", txId.toHex());
 ```
 
 Expected-note hints are also available:
@@ -351,8 +351,8 @@ Each record exposes:
 
 ```typescript
 for (const tx of all) {
-  tx.id().toString();
-  tx.accountId().toString();
+  tx.id().toHex();
+  tx.accountId().toString(); // AccountId.toString() returns canonical hex
   tx.blockNum().toString();
 
   const status = tx.transactionStatus();

--- a/docs/builder/tools/index.md
+++ b/docs/builder/tools/index.md
@@ -1,6 +1,5 @@
 ---
 title: Tools
-sidebar_position: 1
 ---
 
 # Tools


### PR DESCRIPTION
## Summary

Adds a locally-authored **Web SDK (TypeScript)** guide under `docs/builder/tools/clients/web-client/` covering the full `@miden-sdk/miden-sdk@0.14.x` surface. Scoped to the imperative `MidenClient` API — a React SDK section will follow in a separate PR.

This is **PR A of 2** for the v0.14 client docs rewrite. PR B (React SDK) will add `docs/builder/tools/clients/react-sdk/`.

## What's in this PR

Ten atomic commits:

1. `docs(ci): narrow miden-client ingestion to preserve locally-authored Web SDK docs` — swaps the bulk `cp -r vendor/miden-client/docs/external/src/* → docs/builder/tools/clients/` for a selective pattern that still auto-syncs `rust-client/`, `img/`, `theme/`, `common-errors.md`, and `_category_.yml`, but leaves `web-client/`, future `react-sdk/`, and the top-level `index.md` locally authored. Applied identically to `deploy-docs.yml` and `cut-versions.yml`.
2. `docs(web-sdk): add overview and setup pages` — 4-SDK overview at `tools/clients/index.md` (Rust library, Rust CLI, Web SDK, React SDK) + Web SDK landing (architecture, resource-management via `terminate()`, TC39 `using` pattern, deprecation pointer) + full `ClientOptions` reference including the `rpcUrl` / `proverUrl` / `noteTransportUrl` shorthand values.
3. `docs(web-sdk): add accounts guide` — wallets, faucets, contract accounts, pre-built via `AccountBuilder`, `get` / `getOrImport` / `list` / `getDetails` / `getBalance`, `import` union (reference / file / seed), address management.
4. `docs(web-sdk): add transactions guide` — `send` (with `returnNote` overload), `mint`, `consume`, `consumeAll`, `swap`, `waitFor`, `preview`, `execute` (custom scripts, FPI), `executeProgram` (view calls), `submit` (manual `TransactionRequest`), history.
5. `docs(web-sdk): add notes guide (notes + note transport + tags)` — bundles the three related namespaces into one user-facing page: list/get/listSent/listAvailable/import/export, private-note transport, tags.
6. `docs(web-sdk): add MASM compile guide` — `component` / `txScript` / `noteScript` including `supportAllTypes`, library linking, procedure hashes for FPI, end-to-end recipe.
7. `docs(web-sdk): add sync and store-management guide` — `sync` / `SyncSummary` / `getSyncHeight`, `autoSync` factory-default split, and the **standalone** `exportStore` / `importStore` helpers (old docs incorrectly showed these as methods on `MidenClient`).
8. `docs(web-sdk): add testing guide with mock client` — `createMock`, manual `proveBlock`, dummy proving, snapshot/restore, mock note transport.
9. `docs: update private-multisig TS guide to v0.14 MidenClient` — swaps the stale `WebClient.createClient(...)` bootstrap for `MidenClient.createTestnet()`.
10. `docs(web-sdk): fix broken-link warnings introduced by new Web SDK pages` — corrects the migration-guide path (`07-client-changes.md`) and trims the top-level `tools/clients/index.md` so it no longer creates broken-link warnings for ingested-only content.

## Workflow change — read carefully

The `docs/builder/tools/clients/` tree is now a **mix** of ingested and locally-authored content:

| Path | Source | Cleaned on build? |
| --- | --- | --- |
| `tools/clients/rust-client/` | Ingested from `miden-client/docs/external/src/rust-client/` | Yes — re-ingested on every build |
| `tools/clients/img/` | Ingested | Yes |
| `tools/clients/theme/` | Ingested | Yes |
| `tools/clients/common-errors.md` | Ingested | Yes |
| `tools/clients/_category_.yml` | Ingested | Yes |
| `tools/clients/index.md` | **Locally authored** | No |
| `tools/clients/web-client/` | **Locally authored** (this PR) | No |
| `tools/clients/react-sdk/` | Locally authored (PR B follow-up) | No |

If someone adds a new subdir under miden-client's `docs/external/src/` in the future and expects it to auto-ingest, they'll need to opt it in explicitly by adding its name to the workflow's `for name in ...` loop.

## Verification

- `npm run build` → `[SUCCESS]`, **zero new broken-link warnings** introduced. Remaining warnings in the output are pre-existing.
- Every TypeScript snippet across the 8 new pages typechecks green under `tsc --noEmit --strict` against shipped `@miden-sdk/miden-sdk@0.14.3`. The harness lives at `docs-tests/ts/web-client-demo/` (separate Projects/docs-tests workspace — not part of this repo).

The harness caught several real API drift bugs during authoring:
- `AccountType.MutableWallet` / `AuthScheme.ECDSA` friendly aliases are shadowed by the WASM enum and fail typecheck → used canonical names (`RegularAccountUpdatableCode`, etc.) and string literals (`"falcon"` / `"ecdsa"`).
- `preview({ operation: "custom", ... })` not shipped in 0.14.3 → documented the four simplified operations only.
- `TransactionRequestBuilder.withExpectedOutputNotes` does **not** exist → correct names are `withExpectedFutureNotes` and `withExpectedOutputRecipients`.
- `withOwnOutputNotes` takes the WASM `NoteArray` class, not a plain TS array.
- Store backup/restore: `exportStore(storeName)` / `importStore(storeName, dump)` are standalone package exports, not client methods.
- Private-note transport: `sendPrivate({ note, to })` (old docs had `noteId`).

## Test plan

- [ ] Reviewer runs `npm run build` locally on this branch — verifies `[SUCCESS]` with no new warnings on pages this PR touches.
- [ ] Reviewer spot-checks one or two snippets against `miden-client/crates/web-client/js/types/api-types.d.ts` for the shipped 0.14.x.
- [ ] Optional: reviewer runs the typecheck harness via `cd /Users/bs/Develop/Miden/Projects/docs-tests/ts/web-client-demo && npm install && npm run typecheck:strict` → expects exit 0.
- [ ] After merge, confirm on the next CI build that `rust-client/` still lands correctly under `tools/clients/` (workflow narrowing didn't break ingestion).

## Out of scope

- **React SDK** — separate PR B, same `tools/clients/` tree at a sibling path.
- **Rust client doc** — unchanged; still ingested from miden-client.
- **Back-migration into miden-client** — a later concern.