### PR TITLE
docs: add v0.14 React SDK guide under tools/clients (stacked on #247)

### DIFF
--- a/docs/builder/tools/clients/react-sdk/_category_.yml
+++ b/docs/builder/tools/clients/react-sdk/_category_.yml
@@ -1,0 +1,4 @@
+label: React
+# Sidebar position within tools/clients/ (Rust is 1, TypeScript is 2, React is 3)
+position: 3
+collapsed: true

--- a/docs/builder/tools/clients/react-sdk/advanced.md
+++ b/docs/builder/tools/clients/react-sdk/advanced.md
@@ -15,16 +15,16 @@ General-purpose transaction runner that accepts either a prebuilt `TransactionRe
 import { useTransaction } from "@miden-sdk/react";
 import { TransactionRequestBuilder } from "@miden-sdk/miden-sdk";
 
-const { executeTransaction, isLoading, stage } = useTransaction();
+const { execute, isLoading, stage } = useTransaction();
 
 // Direct request
-await executeTransaction({
+await execute({
   accountId: contractAccount,
   request: prebuiltRequest,
 });
 
 // Builder callback — receives the raw WebClient
-await executeTransaction({
+await execute({
   accountId: contractAccount,
   request: (client) =>
     new TransactionRequestBuilder()
@@ -32,6 +32,8 @@ await executeTransaction({
       .build(),
 });
 ```
+
+`UseTransactionResult` exposes `execute` (not `executeTransaction`), plus `result`, `isLoading`, `stage`, `error`, and `reset`.
 
 `ExecuteTransactionOptions`:
 
@@ -51,18 +53,20 @@ View call — executes a transaction script locally and returns the stack output
 ```tsx
 import { useExecuteProgram } from "@miden-sdk/react";
 
-const { executeProgram, isLoading, error } = useExecuteProgram();
+const { execute, isLoading, error } = useExecuteProgram();
 
-const result = await executeProgram({
+const result = await execute({
   accountId: contractAccount,
   script: compiledTxScript,
   foreignAccounts: [counterAccount], // optional
 });
 
-// result is a FeltArray — 16-element final stack
+// result is an ExecuteProgramResult — contains a 16-element stack
 const count = result.stack.get(0).asInt();
 console.log("Count:", count);
 ```
+
+`UseExecuteProgramResult` exposes `execute` (not `executeProgram`), plus `result`, `isLoading`, `error`, and `reset`. No `stage` — view calls don't prove or submit.
 
 See [`useCompile`](#usecompile) for producing the `TransactionScript`, and the [Web SDK transactions guide](../web-client/transactions.md#view-calls-executeprogram) for the shape of the returned `FeltArray`.
 
@@ -74,7 +78,7 @@ Compiles Miden Assembly into `AccountComponent`, `TransactionScript`, or `NoteSc
 import { useCompile } from "@miden-sdk/react";
 import { StorageSlot } from "@miden-sdk/miden-sdk";
 
-const { component, txScript, noteScript, isLoading, error } = useCompile();
+const { component, txScript, noteScript, isReady } = useCompile();
 
 // Account component
 const counterComponent = await component({
@@ -107,27 +111,45 @@ const attachScript = await noteScript({
 });
 ```
 
-See the [Web SDK compile guide](../web-client/compile.md) for the full `CompileComponentOptions` / `CompileTxScriptOptions` / `CompileNoteScriptOptions` shapes — the React hook just wraps the underlying `client.compile.*` calls with loading/error state.
+`UseCompileResult` exposes the three compile methods plus `isReady`. Loading and error state are tracked internally per call — catch errors at the individual `await` site. See the [Web SDK compile guide](../web-client/compile.md) for the full `CompileComponentOptions` / `CompileTxScriptOptions` / `CompileNoteScriptOptions` shapes.
 
 ## `useSessionAccount`
 
-Drives the "session wallet" pattern — create a throw-away wallet, fund it from another account, consume some notes, then discard or archive it. Useful for one-off interactions that shouldn't touch a long-lived account.
+Drives the "session wallet" pattern — create a throw-away wallet, wait for a funding note, consume it, then hand control back to your app. Useful for one-off interactions that shouldn't touch a long-lived account.
 
 ```tsx
 import { useSessionAccount } from "@miden-sdk/react";
 
-const { start, step, account, isLoading, error } = useSessionAccount({
-  funder: mainWallet,
-  fundAmount: 100n,
-  fundAsset: usdcFaucetId,
-});
+const { initialize, sessionAccountId, isReady, step, error, reset } =
+  useSessionAccount({
+    // Called with the new session wallet's bech32 ID once it's created.
+    // Your code is responsible for actually sending funds to it — e.g. by
+    // triggering a send from a main wallet elsewhere in the app.
+    fund: async (sessionAccountId) => {
+      await sendFromMainWallet(sessionAccountId);
+    },
+    assetId: usdcFaucetId,      // optional
+    walletOptions: { storageMode: "private", mutable: true },
+    pollIntervalMs: 3_000,      // default 3_000
+    maxWaitMs: 60_000,          // default 60_000
+  });
 
-await start();
-
-// step progresses through: "idle" | "creating" | "funding" | "consuming" | "ready"
+await initialize();
+// step progresses: "idle" → "creating" → "funding" → "consuming" → "ready"
 ```
 
-Options and return shapes vary by release — check `UseSessionAccountOptions` / `UseSessionAccountReturn` in `@miden-sdk/react` exports for the canonical names.
+`UseSessionAccountReturn`:
+
+| Field | Description |
+| --- | --- |
+| `initialize()` | Kicks off the create → fund → consume flow |
+| `sessionAccountId` | bech32 ID of the session wallet once created |
+| `isReady` | `true` after the funding note has been consumed |
+| `step` | `SessionAccountStep` — one of the five states above |
+| `error` | Non-null if any step failed |
+| `reset()` | Clears session data (and any persisted state under `storagePrefix`) |
+
+Session state persists under the configurable `storagePrefix` (default `"miden-session"`) so page reloads can resume mid-flow.
 
 ## `useExportStore` / `useImportStore`
 

--- a/docs/builder/tools/clients/react-sdk/advanced.md
+++ b/docs/builder/tools/clients/react-sdk/advanced.md
@@ -61,14 +61,14 @@ const result = await execute({
   foreignAccounts: [counterAccount], // optional
 });
 
-// result is an ExecuteProgramResult — contains a 16-element stack
-const count = result.stack.get(0).asInt();
+// result.stack is a bigint[] — read indices directly
+const count: bigint = result.stack[0];
 console.log("Count:", count);
 ```
 
 `UseExecuteProgramResult` exposes `execute` (not `executeProgram`), plus `result`, `isLoading`, `error`, and `reset`. No `stage` — view calls don't prove or submit.
 
-See [`useCompile`](#usecompile) for producing the `TransactionScript`, and the [Web SDK transactions guide](../web-client/transactions.md#view-calls-executeprogram) for the shape of the returned `FeltArray`.
+The React hook flattens the 16-element stack into a plain `bigint[]`. `useMidenClient()` exposes the underlying WASM `WebClient` directly — its method is `client.executeProgram(...)` (not namespaced under `client.transactions`). See the [Web SDK transactions guide](../web-client/transactions.md#view-calls-executeprogram) for the imperative `MidenClient.transactions.executeProgram` equivalent and the `FeltArray` shape.
 
 ## `useCompile`
 
@@ -99,12 +99,15 @@ const script = await txScript({
   ],
 });
 
-// Note script
+// Note script — v0.14 uses the @note_script attribute on a library proc
 const attachScript = await noteScript({
   code: `
     use miden::protocol::active_note
     use miden::core::sys
-    begin
+
+    @note_script
+    pub proc on_consume
+      # body runs when the consuming account redeems this note
       exec.sys::truncate_stack
     end
   `,
@@ -153,22 +156,24 @@ Session state persists under the configurable `storagePrefix` (default `"miden-s
 
 ## `useExportStore` / `useImportStore`
 
-Back up and restore the entire local store as encrypted bytes. Handy for wallet backup/restore UIs.
+Back up and restore the entire local store as a JSON dump. Handy for wallet backup/restore UIs.
 
 ```tsx
-import { useExportStore, useImportStore } from "@miden-sdk/react";
+import { useExportStore, useImportStore, useMidenClient } from "@miden-sdk/react";
 
-// Export
+// Export — returns a JSON string
 const { exportStore } = useExportStore();
-const bytes = await exportStore();
-download(bytes, "wallet-backup.bin");
+const dump: string = await exportStore();
+download(new Blob([dump]), "wallet-backup.json");
 
-// Import (destructive — overwrites the current store)
+// Import (destructive — overwrites the target store)
+// Positional: (storeDump, storeName, options?)
 const { importStore } = useImportStore();
-await importStore({ data: uploadedBytes });
+const client = useMidenClient();
+await importStore(uploadedDump, client.storeIdentifier(), { skipSync: false });
 ```
 
-`ImportStoreOptions` accepts the raw bytes (`data`) and any optional password/derivation args the release supports. Check `UseImportStoreResult` exports for the current shape.
+`ImportStoreOptions` exposes `skipSync` (default `false`) so you can defer the post-import sync. There's no second "raw bytes" form — `importStore` takes the JSON dump string as its first argument and the target store name as its second.
 
 ## `useImportNote` / `useExportNote`
 
@@ -192,15 +197,15 @@ Pause and resume the auto-sync loop without dismounting `MidenProvider`. Useful 
 ```tsx
 import { useSyncControl } from "@miden-sdk/react";
 
-const { pause, resume, isPaused } = useSyncControl();
+const { pauseSync, resumeSync, isPaused } = useSyncControl();
 
 // Before a long sequence
-pause();
+pauseSync();
 // ... operations that need a stable snapshot ...
-resume();
+resumeSync();
 ```
 
-`pause()` stops the timer but doesn't cancel an in-flight sync — wait for `isSyncing` to settle if you need a truly quiescent state.
+`pauseSync()` stops the timer but doesn't cancel an in-flight sync — wait for `isSyncing` from `useSyncState()` to settle if you need a truly quiescent state.
 
 ## Next
 

--- a/docs/builder/tools/clients/react-sdk/advanced.md
+++ b/docs/builder/tools/clients/react-sdk/advanced.md
@@ -1,0 +1,186 @@
+---
+title: Advanced
+sidebar_position: 5
+---
+
+# Advanced hooks
+
+Hooks beyond the core send / mint / consume trio: custom scripts, MASM compilation, session wallets, store backup, note serialization, and sync control.
+
+## `useTransaction`
+
+General-purpose transaction runner that accepts either a prebuilt `TransactionRequest` or a builder callback. This is the escape hatch when the higher-level hooks don't cover your flow.
+
+```tsx
+import { useTransaction } from "@miden-sdk/react";
+import { TransactionRequestBuilder } from "@miden-sdk/miden-sdk";
+
+const { executeTransaction, isLoading, stage } = useTransaction();
+
+// Direct request
+await executeTransaction({
+  accountId: contractAccount,
+  request: prebuiltRequest,
+});
+
+// Builder callback — receives the raw WebClient
+await executeTransaction({
+  accountId: contractAccount,
+  request: (client) =>
+    new TransactionRequestBuilder()
+      .withCustomScript(txScript)
+      .build(),
+});
+```
+
+`ExecuteTransactionOptions`:
+
+| Field | Description |
+| --- | --- |
+| `accountId` | Account the transaction applies to |
+| `request` | `TransactionRequest` or `(client: WebClient) => TransactionRequest \| Promise<TransactionRequest>` |
+| `skipSync` | Skip pre-send auto-sync (default `false`) |
+| `privateNoteTarget` | Deliver private output notes to this account after commit (any `AccountRef` form) |
+
+The `privateNoteTarget` field is the 4-step pipeline shortcut: execute the tx, commit on-chain, then auto-deliver the private note through the note transport to the target. Useful for "send private note" UIs where the recipient already has the React SDK running.
+
+## `useExecuteProgram`
+
+View call — executes a transaction script locally and returns the stack output. No prove, no submit, no state change. Think of it as Miden's `eth_call`.
+
+```tsx
+import { useExecuteProgram } from "@miden-sdk/react";
+
+const { executeProgram, isLoading, error } = useExecuteProgram();
+
+const result = await executeProgram({
+  accountId: contractAccount,
+  script: compiledTxScript,
+  foreignAccounts: [counterAccount], // optional
+});
+
+// result is a FeltArray — 16-element final stack
+const count = result.stack.get(0).asInt();
+console.log("Count:", count);
+```
+
+See [`useCompile`](#usecompile) for producing the `TransactionScript`, and the [Web SDK transactions guide](../web-client/transactions.md#view-calls-executeprogram) for the shape of the returned `FeltArray`.
+
+## `useCompile`
+
+Compiles Miden Assembly into `AccountComponent`, `TransactionScript`, or `NoteScript`. Each result method is independently callable — call only what you need for the current operation.
+
+```tsx
+import { useCompile } from "@miden-sdk/react";
+import { StorageSlot } from "@miden-sdk/miden-sdk";
+
+const { component, txScript, noteScript, isLoading, error } = useCompile();
+
+// Account component
+const counterComponent = await component({
+  code: counterContractCode,
+  slots: [StorageSlot.emptyValue("miden::tutorials::counter")],
+});
+
+// Transaction script (with optional libraries)
+const script = await txScript({
+  code: `
+    use external_contract::counter_contract
+    begin
+      call.counter_contract::increment_count
+    end
+  `,
+  libraries: [
+    { namespace: "external_contract::counter_contract", code: counterContractCode },
+  ],
+});
+
+// Note script
+const attachScript = await noteScript({
+  code: `
+    use miden::protocol::active_note
+    use miden::core::sys
+    begin
+      exec.sys::truncate_stack
+    end
+  `,
+});
+```
+
+See the [Web SDK compile guide](../web-client/compile.md) for the full `CompileComponentOptions` / `CompileTxScriptOptions` / `CompileNoteScriptOptions` shapes — the React hook just wraps the underlying `client.compile.*` calls with loading/error state.
+
+## `useSessionAccount`
+
+Drives the "session wallet" pattern — create a throw-away wallet, fund it from another account, consume some notes, then discard or archive it. Useful for one-off interactions that shouldn't touch a long-lived account.
+
+```tsx
+import { useSessionAccount } from "@miden-sdk/react";
+
+const { start, step, account, isLoading, error } = useSessionAccount({
+  funder: mainWallet,
+  fundAmount: 100n,
+  fundAsset: usdcFaucetId,
+});
+
+await start();
+
+// step progresses through: "idle" | "creating" | "funding" | "consuming" | "ready"
+```
+
+Options and return shapes vary by release — check `UseSessionAccountOptions` / `UseSessionAccountReturn` in `@miden-sdk/react` exports for the canonical names.
+
+## `useExportStore` / `useImportStore`
+
+Back up and restore the entire local store as encrypted bytes. Handy for wallet backup/restore UIs.
+
+```tsx
+import { useExportStore, useImportStore } from "@miden-sdk/react";
+
+// Export
+const { exportStore } = useExportStore();
+const bytes = await exportStore();
+download(bytes, "wallet-backup.bin");
+
+// Import (destructive — overwrites the current store)
+const { importStore } = useImportStore();
+await importStore({ data: uploadedBytes });
+```
+
+`ImportStoreOptions` accepts the raw bytes (`data`) and any optional password/derivation args the release supports. Check `UseImportStoreResult` exports for the current shape.
+
+## `useImportNote` / `useExportNote`
+
+Serialize notes to bytes for QR delivery or import notes handed over out-of-band. These complement the private-note transport layer — use the transport when the recipient is online, and QR/bytes when they aren't.
+
+```tsx
+import { useExportNote, useImportNote } from "@miden-sdk/react";
+
+const { exportNote } = useExportNote();
+const noteBytes = await exportNote(noteId);
+// encode noteBytes into a QR, link, email, etc.
+
+const { importNote } = useImportNote();
+await importNote(uploadedBytes);
+```
+
+## `useSyncControl`
+
+Pause and resume the auto-sync loop without dismounting `MidenProvider`. Useful when a long operation needs consistent local state, or during battery-sensitive background work.
+
+```tsx
+import { useSyncControl } from "@miden-sdk/react";
+
+const { pause, resume, isPaused } = useSyncControl();
+
+// Before a long sequence
+pause();
+// ... operations that need a stable snapshot ...
+resume();
+```
+
+`pause()` stops the timer but doesn't cancel an in-flight sync — wait for `isSyncing` to settle if you need a truly quiescent state.
+
+## Next
+
+- [Signers](./signers.md) — wire external wallets (Para, Turnkey, MidenFi) or build a custom signer.
+- [Recipes](./recipes.md) — end-to-end patterns.

--- a/docs/builder/tools/clients/react-sdk/index.md
+++ b/docs/builder/tools/clients/react-sdk/index.md
@@ -5,19 +5,19 @@ sidebar_position: 1
 
 # React SDK (@miden-sdk/react)
 
-The React SDK is a thin layer on top of the [Web SDK](../web-client/index.md). It wraps `@miden-sdk/miden-sdk`'s `MidenClient` with a React context (`MidenProvider`), a family of hooks (`useMiden`, `useAccount`, `useSend`, …), automatic sync polling, and a concurrency lock so multiple components never trip over the same WASM instance.
+The React SDK is a thin layer on top of the [Web SDK](../web-client/index.md). It wraps the underlying WASM `WebClient` with a React context (`MidenProvider`), a family of hooks (`useMiden`, `useAccount`, `useSend`, …), automatic sync polling, and a concurrency lock so multiple components never trip over the same WASM instance.
 
 ## When to use it
 
 Reach for the React SDK when your application is already a React app (Next.js, Vite + React, React Native, Electron + React, etc.). The hooks:
 
 - own lifecycle management (the WASM worker, signer wiring, auto-sync loop),
-- return standard `{ data, isLoading, error }` shapes that slot into normal React rendering,
+- expose per-hook result interfaces with a domain-named action (`send`, `mint`, `createWallet`, …) plus `isLoading` / `isCreating` / `isImporting`, `error`, and `reset`,
 - serialize mutations so concurrent component interactions don't corrupt the WASM state.
 
 If you are building a non-React app — a service worker, a Node backend, a vanilla-TS dApp — use the imperative [Web SDK](../web-client/index.md) directly.
 
-You can always reach the underlying `MidenClient` from any hook via `useMidenClient()` when a hook doesn't cover what you need.
+You can always reach the underlying WASM client from any hook via `useMidenClient()` when a hook doesn't cover what you need — it returns the low-level `WebClient`, not the imperative `MidenClient` wrapper.
 
 ## What's in the package
 
@@ -25,19 +25,14 @@ You can always reach the underlying `MidenClient` from any hook via `useMidenCli
 | --- | --- |
 | [`MidenProvider`](./setup.md) | Root React context; loads WASM, wires the client, runs auto-sync |
 | [`useMiden()`](./setup.md#client-lifecycle) | Raw lifecycle hook (`isReady`, `sync`, `runExclusive`) |
-| [`useMidenClient()`](./setup.md#client-lifecycle) | Shortcut for the ready `WebClient` |
+| [`useMidenClient()`](./setup.md#client-lifecycle) | Shortcut for the ready WASM `WebClient` |
 | [Query hooks](./query-hooks.md) | `useAccount(s)`, `useNotes`, `useNoteStream`, `useTransactionHistory`, `useSyncState`, `useAssetMetadata` |
 | [Mutation hooks](./mutation-hooks.md) | `useCreateWallet`, `useCreateFaucet`, `useImportAccount`, `useSend`, `useMultiSend`, `useMint`, `useConsume`, `useSwap` |
 | [Advanced hooks](./advanced.md) | `useTransaction`, `useExecuteProgram`, `useCompile`, `useSessionAccount`, `useExportStore`, `useImportStore`, `useImportNote`, `useExportNote`, `useSyncControl`, `useWaitForCommit`, `useWaitForNotes` |
 | [External signers](./signers.md) | `MultiSignerProvider`, `SignerContext`, `useSigner`, `useMultiSigner` — pluggable wallet integrations (Para, Turnkey, MidenFi, custom) |
 | Utilities | `formatAssetAmount`, `parseAssetAmount`, `getNoteSummary`, `toBech32AccountId`, `createNoteAttachment` / `readNoteAttachment`, … |
 
-Every hook shares one of two result shapes:
-
-- `QueryResult<T>` — `{ data, isLoading, error, refetch }`
-- `MutationResult<TData, TVariables>` — `{ mutate, data, isLoading, stage, error, reset }`
-
-Transaction mutations progress through the stages `idle → executing → proving → submitting → complete` (exposed on `stage`).
+Each hook exports its own result interface — not a generic `{ data, isLoading, error }` wrapper. Data lives in named fields (e.g. `accounts`, `wallets`, `records`, `wallet`, `faucet`). Transaction-producing mutations additionally expose a `stage` field that advances through `idle → executing → proving → submitting → complete`. See [setup](./setup.md#hook-result-conventions) for per-family details.
 
 ## Where to go next
 

--- a/docs/builder/tools/clients/react-sdk/index.md
+++ b/docs/builder/tools/clients/react-sdk/index.md
@@ -1,0 +1,49 @@
+---
+title: Overview
+sidebar_position: 1
+---
+
+# React SDK (@miden-sdk/react)
+
+The React SDK is a thin layer on top of the [Web SDK](../web-client/index.md). It wraps `@miden-sdk/miden-sdk`'s `MidenClient` with a React context (`MidenProvider`), a family of hooks (`useMiden`, `useAccount`, `useSend`, …), automatic sync polling, and a concurrency lock so multiple components never trip over the same WASM instance.
+
+## When to use it
+
+Reach for the React SDK when your application is already a React app (Next.js, Vite + React, React Native, Electron + React, etc.). The hooks:
+
+- own lifecycle management (the WASM worker, signer wiring, auto-sync loop),
+- return standard `{ data, isLoading, error }` shapes that slot into normal React rendering,
+- serialize mutations so concurrent component interactions don't corrupt the WASM state.
+
+If you are building a non-React app — a service worker, a Node backend, a vanilla-TS dApp — use the imperative [Web SDK](../web-client/index.md) directly.
+
+You can always reach the underlying `MidenClient` from any hook via `useMidenClient()` when a hook doesn't cover what you need.
+
+## What's in the package
+
+| Surface | Purpose |
+| --- | --- |
+| [`MidenProvider`](./setup.md) | Root React context; loads WASM, wires the client, runs auto-sync |
+| [`useMiden()`](./setup.md#client-lifecycle) | Raw lifecycle hook (`isReady`, `sync`, `runExclusive`) |
+| [`useMidenClient()`](./setup.md#client-lifecycle) | Shortcut for the ready `WebClient` |
+| [Query hooks](./query-hooks.md) | `useAccount(s)`, `useNotes`, `useNoteStream`, `useTransactionHistory`, `useSyncState`, `useAssetMetadata` |
+| [Mutation hooks](./mutation-hooks.md) | `useCreateWallet`, `useCreateFaucet`, `useImportAccount`, `useSend`, `useMultiSend`, `useMint`, `useConsume`, `useSwap` |
+| [Advanced hooks](./advanced.md) | `useTransaction`, `useExecuteProgram`, `useCompile`, `useSessionAccount`, `useExportStore`, `useImportStore`, `useImportNote`, `useExportNote`, `useSyncControl`, `useWaitForCommit`, `useWaitForNotes` |
+| [External signers](./signers.md) | `MultiSignerProvider`, `SignerContext`, `useSigner`, `useMultiSigner` — pluggable wallet integrations (Para, Turnkey, MidenFi, custom) |
+| Utilities | `formatAssetAmount`, `parseAssetAmount`, `getNoteSummary`, `toBech32AccountId`, `createNoteAttachment` / `readNoteAttachment`, … |
+
+Every hook shares one of two result shapes:
+
+- `QueryResult<T>` — `{ data, isLoading, error, refetch }`
+- `MutationResult<TData, TVariables>` — `{ mutate, data, isLoading, stage, error, reset }`
+
+Transaction mutations progress through the stages `idle → executing → proving → submitting → complete` (exposed on `stage`).
+
+## Where to go next
+
+- [Setup](./setup.md) — install the package, wrap your app in `MidenProvider`, configure the network.
+- [Query hooks](./query-hooks.md) — read accounts, notes, sync state, and asset metadata.
+- [Mutation hooks](./mutation-hooks.md) — create wallets and faucets, send, mint, consume, swap.
+- [Advanced](./advanced.md) — custom scripts, MASM compilation, session accounts, note import/export.
+- [Signers](./signers.md) — external wallets (Para, Turnkey, MidenFi) and custom signer providers.
+- [Recipes](./recipes.md) — end-to-end patterns and a pointer to Philipp's full wallet tutorial.

--- a/docs/builder/tools/clients/react-sdk/mutation-hooks.md
+++ b/docs/builder/tools/clients/react-sdk/mutation-hooks.md
@@ -5,11 +5,15 @@ sidebar_position: 4
 
 # Mutation hooks
 
-Mutation hooks own the full transaction lifecycle — execute, prove, submit — and serialize under the Web SDK's concurrency lock so two components can't corrupt the WASM state. Every mutation hook returns:
+Mutation hooks own the full transaction lifecycle — execute, prove, submit — and serialize under the Web SDK's concurrency lock so two components can't corrupt the WASM state.
+
+Two result-shape families show up across this page:
+
+**Transaction-producing hooks** (`useSend`, `useMultiSend`, `useMint`, `useConsume`, `useSwap`, `useTransaction`):
 
 ```ts
 {
-  [action]: (options) => Promise<Result>;  // `send`, `mint`, `consume`, ...
+  [action]: (options) => Promise<Result>;  // send, sendMany, mint, ...
   result: Result | null;
   isLoading: boolean;
   stage: TransactionStage;
@@ -18,18 +22,31 @@ Mutation hooks own the full transaction lifecycle — execute, prove, submit —
 }
 ```
 
-See [setup](./setup.md#hook-result-conventions) for the `TransactionStage` progression and general pattern.
+**Account-creation hooks** (`useCreateWallet`, `useCreateFaucet`, `useImportAccount`) don't go through the prove/submit pipeline, so they expose `isCreating` / `isImporting` instead of `isLoading` + `stage`:
+
+```ts
+{
+  createWallet: (opts?) => Promise<Account>;
+  wallet: Account | null;
+  isCreating: boolean;     // or `isImporting` for useImportAccount
+  error: Error | null;
+  reset: () => void;
+}
+```
+
+Polling helpers (`useWaitForCommit`, `useWaitForNotes`) are simpler still — they expose just the action. Per-hook exact shapes are called out below.
+
+See [setup](./setup.md#hook-result-conventions) for the `TransactionStage` progression.
 
 ## `useCreateWallet`
 
 Creates a new wallet account. Returns the `Account` object.
 
 ```tsx
-import { useCreateWallet } from "@miden-sdk/react";
-import { AuthScheme } from "@miden-sdk/react";
+import { useCreateWallet, AuthScheme } from "@miden-sdk/react";
 
 function NewWalletButton() {
-  const { createWallet, isLoading, error } = useCreateWallet();
+  const { createWallet, wallet, isCreating, error } = useCreateWallet();
 
   const handleCreate = async () => {
     const account = await createWallet({
@@ -40,7 +57,9 @@ function NewWalletButton() {
     console.log("Created:", account.bech32id());
   };
 
-  return <button onClick={handleCreate} disabled={isLoading}>Create wallet</button>;
+  return (
+    <button onClick={handleCreate} disabled={isCreating}>Create wallet</button>
+  );
 }
 ```
 
@@ -61,19 +80,21 @@ Creates a fungible-token faucet.
 import { useCreateFaucet } from "@miden-sdk/react";
 
 function NewFaucetButton() {
-  const { createFaucet, isLoading } = useCreateFaucet();
+  const { createFaucet, faucet, isCreating } = useCreateFaucet();
 
   const handleCreate = async () => {
-    const faucet = await createFaucet({
+    const created = await createFaucet({
       tokenSymbol: "TEST",
       decimals: 8,             // default 8
       maxSupply: 10_000_000n,  // number | bigint
       storageMode: "public",   // default "private"; public allows FPI reads
     });
-    console.log("Faucet:", faucet.bech32id());
+    console.log("Faucet:", created.bech32id());
   };
 
-  return <button onClick={handleCreate} disabled={isLoading}>Create faucet</button>;
+  return (
+    <button onClick={handleCreate} disabled={isCreating}>Create faucet</button>
+  );
 }
 ```
 
@@ -136,14 +157,14 @@ function SendForm({ from, to, usdcFaucetId }: Props) {
 
 ## `useMultiSend`
 
-Batches multiple recipients into one transaction. All outputs must share the same sender and asset.
+Batches multiple recipients into one transaction. All outputs must share the same sender and asset. The action function is named `sendMany`.
 
 ```tsx
 import { useMultiSend } from "@miden-sdk/react";
 
-const { multiSend, isLoading } = useMultiSend();
+const { sendMany, isLoading } = useMultiSend();
 
-await multiSend({
+await sendMany({
   from: senderAccountId,
   assetId: faucetId,
   recipients: [
@@ -239,10 +260,9 @@ await swap({
 Imports an account by ID (fetches from network), by previously-exported file, or by seed.
 
 ```tsx
-import { useImportAccount } from "@miden-sdk/react";
-import { AuthScheme } from "@miden-sdk/react";
+import { useImportAccount, AuthScheme } from "@miden-sdk/react";
 
-const { importAccount } = useImportAccount();
+const { importAccount, account, isImporting, error } = useImportAccount();
 
 // By ID — public accounts only
 const imported = await importAccount({
@@ -269,27 +289,39 @@ The `type` discriminant is required. For private accounts, use the `"file"` vari
 
 ## `useWaitForCommit` / `useWaitForNotes`
 
-Poll helpers for transaction confirmation and note inbox arrivals.
+Polling helpers for transaction confirmation and note inbox arrivals. Both are minimal hooks — they only expose the action function.
+
+### `useWaitForCommit`
+
+Signature: `waitForCommit(txId, options?)` — `txId` is positional (hex string or `TransactionId`), `options` are merged with defaults.
 
 ```tsx
-import { useWaitForCommit, useWaitForNotes } from "@miden-sdk/react";
+import { useWaitForCommit } from "@miden-sdk/react";
 
 const { waitForCommit } = useWaitForCommit();
-await waitForCommit({
-  transactionId: result.transactionId,
+await waitForCommit(result.txId, {
   timeoutMs: 30_000,  // default 10_000
   intervalMs: 1_000,  // default 1_000
 });
+```
 
-const { waitForNotes } = useWaitForNotes();
-await waitForNotes({
+### `useWaitForNotes`
+
+Exposes `waitForConsumableNotes(options)` and returns the matching `ConsumableNoteRecord[]` when the threshold is reached.
+
+```tsx
+import { useWaitForNotes } from "@miden-sdk/react";
+
+const { waitForConsumableNotes } = useWaitForNotes();
+
+const notes = await waitForConsumableNotes({
   accountId: recipient,
-  minCount: 1,      // default 1
+  minCount: 1,     // default 1
   timeoutMs: 30_000,
 });
 ```
 
-Both reject on timeout — wrap them in a `try/catch` if you want a graceful fallback.
+Both reject on timeout — wrap them in `try/catch` when you want a graceful fallback.
 
 ## Next
 

--- a/docs/builder/tools/clients/react-sdk/mutation-hooks.md
+++ b/docs/builder/tools/clients/react-sdk/mutation-hooks.md
@@ -1,0 +1,298 @@
+---
+title: Mutation hooks
+sidebar_position: 4
+---
+
+# Mutation hooks
+
+Mutation hooks own the full transaction lifecycle — execute, prove, submit — and serialize under the Web SDK's concurrency lock so two components can't corrupt the WASM state. Every mutation hook returns:
+
+```ts
+{
+  [action]: (options) => Promise<Result>;  // `send`, `mint`, `consume`, ...
+  result: Result | null;
+  isLoading: boolean;
+  stage: TransactionStage;
+  error: Error | null;
+  reset: () => void;
+}
+```
+
+See [setup](./setup.md#hook-result-conventions) for the `TransactionStage` progression and general pattern.
+
+## `useCreateWallet`
+
+Creates a new wallet account. Returns the `Account` object.
+
+```tsx
+import { useCreateWallet } from "@miden-sdk/react";
+import { AuthScheme } from "@miden-sdk/react";
+
+function NewWalletButton() {
+  const { createWallet, isLoading, error } = useCreateWallet();
+
+  const handleCreate = async () => {
+    const account = await createWallet({
+      storageMode: "private",        // "private" | "public" | "network" (default private)
+      mutable: true,                 // default true — updatable code
+      authScheme: AuthScheme.AuthRpoFalcon512, // default
+    });
+    console.log("Created:", account.bech32id());
+  };
+
+  return <button onClick={handleCreate} disabled={isLoading}>Create wallet</button>;
+}
+```
+
+`CreateWalletOptions` (all optional):
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `storageMode` | `"private"` | `"private"` / `"public"` / `"network"` |
+| `mutable` | `true` | Whether code can be updated after deployment |
+| `authScheme` | `AuthScheme.AuthRpoFalcon512` | Signing scheme |
+| `initSeed` | random | 32-byte seed for deterministic account-ID derivation |
+
+## `useCreateFaucet`
+
+Creates a fungible-token faucet.
+
+```tsx
+import { useCreateFaucet } from "@miden-sdk/react";
+
+function NewFaucetButton() {
+  const { createFaucet, isLoading } = useCreateFaucet();
+
+  const handleCreate = async () => {
+    const faucet = await createFaucet({
+      tokenSymbol: "TEST",
+      decimals: 8,             // default 8
+      maxSupply: 10_000_000n,  // number | bigint
+      storageMode: "public",   // default "private"; public allows FPI reads
+    });
+    console.log("Faucet:", faucet.bech32id());
+  };
+
+  return <button onClick={handleCreate} disabled={isLoading}>Create faucet</button>;
+}
+```
+
+`CreateFaucetOptions`:
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `tokenSymbol` | required | Display symbol (e.g. `"USDC"`) |
+| `maxSupply` | required | `bigint \| number` |
+| `decimals` | `8` | Token decimals |
+| `storageMode` | `"private"` | Public faucets are discoverable/readable on-chain |
+| `authScheme` | `AuthScheme.AuthRpoFalcon512` | Signing scheme |
+
+## `useSend`
+
+Sends tokens from one account to another.
+
+```tsx
+import { useSend } from "@miden-sdk/react";
+
+function SendForm({ from, to, usdcFaucetId }: Props) {
+  const { send, isLoading, stage, error } = useSend();
+
+  const handleSend = async () => {
+    const { txId, note } = await send({
+      from,
+      to,
+      assetId: usdcFaucetId,
+      amount: 100n,
+      noteType: "private",    // default "private"
+    });
+    console.log("Transaction:", txId);
+  };
+
+  return (
+    <button onClick={handleSend} disabled={isLoading}>
+      {isLoading ? `${stage}…` : "Send"}
+    </button>
+  );
+}
+```
+
+`SendOptions`:
+
+| Field | Required | Description |
+| --- | --- | --- |
+| `from` | yes | Sender `AccountRef` |
+| `to` | yes | Recipient `AccountRef` |
+| `assetId` | yes | Token faucet `AccountRef` |
+| `amount` | unless `sendAll` | `bigint \| number` |
+| `noteType` | — | `"private"` / `"public"` (default `"private"`) |
+| `recallHeight` | — | Block height after which sender can reclaim the note |
+| `timelockHeight` | — | Block height after which recipient can consume the note |
+| `attachment` | — | `bigint[] \| Uint8Array \| number[]` — payload attached to the note |
+| `skipSync` | — | Skip the pre-send auto-sync (default `false`) |
+| `sendAll` | — | Drain full balance of `assetId` — when `true`, `amount` is ignored |
+| `returnNote` | — | Return the `Note` object in the result (for out-of-band delivery, QR codes, etc.) |
+
+`SendResult`: `{ txId: string; note: Note | null }`. `note` is non-null only when `returnNote: true`.
+
+## `useMultiSend`
+
+Batches multiple recipients into one transaction. All outputs must share the same sender and asset.
+
+```tsx
+import { useMultiSend } from "@miden-sdk/react";
+
+const { multiSend, isLoading } = useMultiSend();
+
+await multiSend({
+  from: senderAccountId,
+  assetId: faucetId,
+  recipients: [
+    { to: recipient1, amount: 500n, noteType: "private" },
+    { to: recipient2, amount: 300n },
+  ],
+  noteType: "private", // default for recipients that don't override
+});
+```
+
+`MultiSendOptions`:
+
+| Field | Description |
+| --- | --- |
+| `from`, `assetId` | Single sender + single faucet for the whole batch |
+| `recipients` | `MultiSendRecipient[]` — each `{ to, amount, noteType?, attachment? }` |
+| `noteType` | Default for recipients that don't specify one (default `"private"`) |
+| `skipSync` | Skip pre-send auto-sync |
+
+## `useMint`
+
+Mints tokens from a faucet you control into a recipient account.
+
+```tsx
+import { useMint } from "@miden-sdk/react";
+
+const { mint, isLoading, stage } = useMint();
+
+const result = await mint({
+  targetAccountId: recipient,
+  faucetId: myFaucet,
+  amount: 10_000n,
+  noteType: "private",  // default "private"
+});
+console.log("Mint tx:", result.transactionId);
+```
+
+`MintOptions`:
+
+| Field | Description |
+| --- | --- |
+| `targetAccountId` | Recipient `AccountRef` |
+| `faucetId` | Faucet `AccountRef` (must be owned by the caller) |
+| `amount` | `bigint \| number` |
+| `noteType` | `"private"` / `"public"` (default `"private"`) |
+
+Returns `TransactionResult`: `{ transactionId: string }`.
+
+## `useConsume`
+
+Claims one or more notes into an account.
+
+```tsx
+import { useConsume } from "@miden-sdk/react";
+
+const { consume, isLoading } = useConsume();
+
+await consume({
+  accountId: myAccountId,
+  notes: [noteIdHex1, noteIdHex2],  // hex IDs, NoteId objects, InputNoteRecord, or Note
+});
+```
+
+`ConsumeOptions`:
+
+| Field | Description |
+| --- | --- |
+| `accountId` | Account consuming the notes |
+| `notes` | `(string \| NoteId \| InputNoteRecord \| Note)[]` — mix-and-match accepted |
+
+## `useSwap`
+
+Atomic swap between two assets.
+
+```tsx
+import { useSwap } from "@miden-sdk/react";
+
+const { swap, isLoading } = useSwap();
+
+await swap({
+  accountId: myWallet,
+  offeredFaucetId: usdcFaucet,
+  offeredAmount: 100n,
+  requestedFaucetId: dagFaucet,
+  requestedAmount: 200n,
+  noteType: "public",          // default "private"
+  paybackNoteType: "private",  // default "private"
+});
+```
+
+## `useImportAccount`
+
+Imports an account by ID (fetches from network), by previously-exported file, or by seed.
+
+```tsx
+import { useImportAccount } from "@miden-sdk/react";
+import { AuthScheme } from "@miden-sdk/react";
+
+const { importAccount } = useImportAccount();
+
+// By ID — public accounts only
+const imported = await importAccount({
+  type: "id",
+  accountId: "mtst1qy35...",
+});
+
+// By seed — public accounts only
+await importAccount({
+  type: "seed",
+  seed: initSeed,        // Uint8Array
+  mutable: true,         // default true
+  authScheme: AuthScheme.AuthRpoFalcon512,
+});
+
+// By file — works for both public and private accounts
+await importAccount({
+  type: "file",
+  file: accountFileBytes, // AccountFile | Uint8Array | ArrayBuffer
+});
+```
+
+The `type` discriminant is required. For private accounts, use the `"file"` variant — private account state isn't reconstructible from a seed alone.
+
+## `useWaitForCommit` / `useWaitForNotes`
+
+Poll helpers for transaction confirmation and note inbox arrivals.
+
+```tsx
+import { useWaitForCommit, useWaitForNotes } from "@miden-sdk/react";
+
+const { waitForCommit } = useWaitForCommit();
+await waitForCommit({
+  transactionId: result.transactionId,
+  timeoutMs: 30_000,  // default 10_000
+  intervalMs: 1_000,  // default 1_000
+});
+
+const { waitForNotes } = useWaitForNotes();
+await waitForNotes({
+  accountId: recipient,
+  minCount: 1,      // default 1
+  timeoutMs: 30_000,
+});
+```
+
+Both reject on timeout — wrap them in a `try/catch` if you want a graceful fallback.
+
+## Next
+
+- [Advanced](./advanced.md) — custom scripts, MASM compilation, session accounts, store import/export.
+- [Signers](./signers.md) — external wallets (Para, Turnkey, MidenFi) and custom signers.
+- [Recipes](./recipes.md) — realistic patterns + link-outs to Philipp's full wallet tutorial.

--- a/docs/builder/tools/clients/react-sdk/query-hooks.md
+++ b/docs/builder/tools/clients/react-sdk/query-hooks.md
@@ -1,0 +1,250 @@
+---
+title: Query hooks
+sidebar_position: 3
+---
+
+# Query hooks
+
+Query hooks read from the local store (and trigger a fetch when the cache is cold). Every query hook shares `{ isLoading, error, refetch }` alongside hook-specific data fields. Refetching is automatic after successful syncs, so most components don't need to call `refetch()` manually.
+
+## `useAccounts`
+
+Lists every account tracked by the client, pre-categorised into wallets and faucets.
+
+```tsx
+import { useAccounts } from "@miden-sdk/react";
+
+function AccountList() {
+  const { accounts, wallets, faucets, isLoading, error } = useAccounts();
+
+  if (isLoading) return <p>Loading…</p>;
+  if (error) return <p>{error.message}</p>;
+
+  return (
+    <>
+      <h3>Wallets ({wallets.length})</h3>
+      {wallets.map((w) => <div key={w.id().toString()}>{w.id().toString()}</div>)}
+
+      <h3>Faucets ({faucets.length})</h3>
+      {faucets.map((f) => <div key={f.id().toString()}>{f.id().toString()}</div>)}
+    </>
+  );
+}
+```
+
+Return type (`AccountsResult`):
+
+```ts
+{
+  accounts: AccountHeader[];  // every tracked account
+  wallets: AccountHeader[];   // regular accounts
+  faucets: AccountHeader[];   // token faucets
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+```
+
+## `useAccount(id)`
+
+Full details for a single account, including per-asset balances decorated with symbol + decimals when metadata is available.
+
+```tsx
+import { useAccount } from "@miden-sdk/react";
+
+function AccountDetails({ id }: { id: string }) {
+  const { account, assets, getBalance, isLoading, error } = useAccount(id);
+
+  if (isLoading) return <p>Loading…</p>;
+  if (error) return <p>{error.message}</p>;
+  if (!account) return <p>Not found</p>;
+
+  return (
+    <>
+      <p>Account: {account.bech32id()}</p>
+      <p>Nonce: {account.nonce().toString()}</p>
+      <p>USDC balance: {getBalance(usdcFaucetId).toString()}</p>
+
+      <ul>
+        {assets.map((a) => (
+          <li key={a.assetId}>
+            {a.amount.toString()} {a.symbol ?? a.assetId}
+          </li>
+        ))}
+      </ul>
+    </>
+  );
+}
+```
+
+Return type (`AccountResult`):
+
+```ts
+{
+  account: Account | null;
+  assets: AssetBalance[]; // { assetId, amount, symbol?, decimals? }
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+  getBalance: (assetId: string) => bigint;
+}
+```
+
+`getBalance(assetId)` is a convenience for single-asset reads — returns `0n` when the account doesn't hold that asset.
+
+## `useNotes(filter?)`
+
+Lists input notes (received) and consumable notes (ready to claim) with optional filtering.
+
+```tsx
+import { useNotes } from "@miden-sdk/react";
+
+function NotesInbox({ account }: { account: string }) {
+  const { notes, consumableNotes, noteSummaries, refetch } = useNotes({
+    status: "committed",
+    accountId: account,
+  });
+
+  return (
+    <>
+      <button onClick={refetch}>Refresh</button>
+      <h3>Received ({notes.length})</h3>
+      {noteSummaries.map((s) => (
+        <div key={s.id}>
+          {s.assets.map((a) => `${a.amount} ${a.symbol ?? a.assetId}`).join(", ")}
+        </div>
+      ))}
+
+      <h3>Consumable ({consumableNotes.length})</h3>
+    </>
+  );
+}
+```
+
+Filter options (`NotesFilter`):
+
+| Field | Values | Description |
+| --- | --- | --- |
+| `status` | `"all" \| "consumed" \| "committed" \| "expected" \| "processing"` | Filter by note lifecycle state |
+| `accountId` | `AccountRef` | Only notes relevant to this account |
+| `sender` | `AccountRef` (any format) | Only notes from this sender — normalised internally |
+| `excludeIds` | `string[]` | Skip these note IDs (useful for hiding notes your UI already rendered elsewhere) |
+
+Return type (`NotesResult`):
+
+```ts
+{
+  notes: InputNoteRecord[];              // raw SDK records
+  consumableNotes: ConsumableNoteRecord[];
+  noteSummaries: NoteSummary[];          // pre-computed { id, assets[], sender? }
+  consumableNoteSummaries: NoteSummary[];
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+```
+
+`noteSummaries` is the pragmatic choice for UIs — it pre-extracts asset info and runs metadata resolution.
+
+## `useNoteStream(options)`
+
+Temporal note tracking with first-seen timestamps and per-stream filtering. Useful for notification UIs that want to highlight new arrivals.
+
+```tsx
+import { useNoteStream } from "@miden-sdk/react";
+
+function NewNotesToast({ account }: { account: string }) {
+  const { notes, markAllHandled } = useNoteStream({
+    accountId: account,
+    since: "now",            // only notes seen after this component mounted
+  });
+
+  return (
+    <>
+      {notes.map((n) => (
+        <div key={n.id}>New note at {new Date(n.firstSeen).toISOString()}</div>
+      ))}
+      <button onClick={markAllHandled}>Dismiss</button>
+    </>
+  );
+}
+```
+
+See the SDK types for the full `UseNoteStreamOptions` / `UseNoteStreamReturn` shape — each streamed note carries `{ id, firstSeen, ...summary }`.
+
+## `useTransactionHistory(options?)`
+
+Transaction records for an account, with optional filters by ID or status.
+
+```tsx
+import { useTransactionHistory } from "@miden-sdk/react";
+
+function HistoryTable({ account }: { account: string }) {
+  const { transactions, isLoading } = useTransactionHistory({ accountId: account });
+  if (isLoading) return <p>Loading…</p>;
+
+  return (
+    <table>
+      {transactions.map((tx) => (
+        <tr key={tx.id().toHex()}>
+          <td>{tx.id().toHex()}</td>
+          <td>{tx.blockNum().toString()}</td>
+        </tr>
+      ))}
+    </table>
+  );
+}
+```
+
+Options:
+
+| Field | Description |
+| --- | --- |
+| `id` | Single transaction ID lookup — returns just that record |
+| `ids` | List of transaction IDs |
+| `accountId` | All transactions for an account |
+| `status` | `"pending" \| "committed" \| "discarded"` |
+
+Return includes `status` as a convenience when a single `id` was provided.
+
+## `useSyncState`
+
+Sync heights and manual-trigger controls.
+
+```tsx
+import { useSyncState } from "@miden-sdk/react";
+
+function SyncBadge() {
+  const { syncHeight, isSyncing, lastSyncTime, sync } = useSyncState();
+
+  return (
+    <button onClick={() => sync()} disabled={isSyncing}>
+      Block {syncHeight ?? "—"} {isSyncing && "(syncing…)"}
+    </button>
+  );
+}
+```
+
+Manual `sync()` composes with the auto-sync loop (configured via `autoSyncInterval` on `MidenProvider`) — call it when you want to force an immediate refresh.
+
+## `useAssetMetadata(assetId | assetId[])`
+
+Symbol + decimals lookup for one or many asset IDs.
+
+```tsx
+import { useAssetMetadata } from "@miden-sdk/react";
+
+function TokenChip({ assetId }: { assetId: string }) {
+  const { assetMetadata } = useAssetMetadata(assetId);
+  const meta = assetMetadata.get(assetId);
+  return <span>{meta?.symbol ?? assetId}</span>;
+}
+```
+
+`assetMetadata` is a `Map<string, AssetMetadata>` keyed by asset ID. Pass an array for batch lookups; the hook dedupes and caches internally so components sharing metadata share cost.
+
+## Next
+
+- [Mutation hooks](./mutation-hooks.md) — create wallets, faucets, send tokens, consume notes.
+- [Advanced](./advanced.md) — custom scripts, note import/export, session accounts.
+- [Recipes](./recipes.md) — end-to-end patterns.

--- a/docs/builder/tools/clients/react-sdk/query-hooks.md
+++ b/docs/builder/tools/clients/react-sdk/query-hooks.md
@@ -146,51 +146,58 @@ Return type (`NotesResult`):
 
 `noteSummaries` is the pragmatic choice for UIs — it pre-extracts asset info and runs metadata resolution.
 
-## `useNoteStream(options)`
+## `useNoteStream(options?)`
 
 Temporal note tracking with first-seen timestamps and per-stream filtering. Useful for notification UIs that want to highlight new arrivals.
 
 ```tsx
 import { useNoteStream } from "@miden-sdk/react";
 
-function NewNotesToast({ account }: { account: string }) {
-  const { notes, markAllHandled } = useNoteStream({
-    accountId: account,
-    since: "now",            // only notes seen after this component mounted
+function NewNotesToast() {
+  const { notes, latest, markHandled, markAllHandled } = useNoteStream({
+    status: "committed",       // default "committed"
+    since: Date.now(),         // numeric timestamp; drop notes seen earlier
+    amountFilter: (amount) => amount > 0n,
   });
 
   return (
     <>
+      {latest && <p>New: {latest.id}</p>}
       {notes.map((n) => (
-        <div key={n.id}>New note at {new Date(n.firstSeen).toISOString()}</div>
+        <div key={n.id}>
+          {n.id} at {new Date(n.firstSeen).toISOString()}
+          <button onClick={() => markHandled(n.id)}>dismiss</button>
+        </div>
       ))}
-      <button onClick={markAllHandled}>Dismiss</button>
+      <button onClick={markAllHandled}>Dismiss all</button>
     </>
   );
 }
 ```
 
-See the SDK types for the full `UseNoteStreamOptions` / `UseNoteStreamReturn` shape — each streamed note carries `{ id, firstSeen, ...summary }`.
+`UseNoteStreamOptions` fields: `status`, `sender`, `since` (numeric timestamp), `excludeIds` (`Set<string>` or `string[]`), and `amountFilter` for predicate-based filtering. The stream also exposes `snapshot()` for passing state across unmount / remount boundaries.
 
 ## `useTransactionHistory(options?)`
 
-Transaction records for an account, with optional filters by ID or status.
+Transaction records, with optional filters for specific IDs or a custom `TransactionFilter`.
 
 ```tsx
 import { useTransactionHistory } from "@miden-sdk/react";
 
-function HistoryTable({ account }: { account: string }) {
-  const { transactions, isLoading } = useTransactionHistory({ accountId: account });
+function HistoryTable() {
+  const { records, isLoading } = useTransactionHistory();
   if (isLoading) return <p>Loading…</p>;
 
   return (
     <table>
-      {transactions.map((tx) => (
-        <tr key={tx.id().toHex()}>
-          <td>{tx.id().toHex()}</td>
-          <td>{tx.blockNum().toString()}</td>
-        </tr>
-      ))}
+      <tbody>
+        {records.map((tx) => (
+          <tr key={tx.id().toHex()}>
+            <td>{tx.id().toHex()}</td>
+            <td>{tx.blockNum().toString()}</td>
+          </tr>
+        ))}
+      </tbody>
     </table>
   );
 }
@@ -200,12 +207,25 @@ Options:
 
 | Field | Description |
 | --- | --- |
-| `id` | Single transaction ID lookup — returns just that record |
+| `id` | Single transaction ID lookup |
 | `ids` | List of transaction IDs |
-| `accountId` | All transactions for an account |
-| `status` | `"pending" \| "committed" \| "discarded"` |
+| `filter` | Custom `TransactionFilter` (overrides `id` / `ids`) |
+| `refreshOnSync` | Re-fetch after every auto-sync (default `true`) |
 
-Return includes `status` as a convenience when a single `id` was provided.
+Result (`TransactionHistoryResult`):
+
+```ts
+{
+  records: TransactionRecord[];
+  record: TransactionRecord | null;   // convenience when a single id was provided
+  status: TransactionStatus | null;   // convenience when a single id was provided
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+```
+
+For account-scoped history use a `TransactionFilter` that targets the account — see the `@miden-sdk/miden-sdk` `TransactionFilter` API.
 
 ## `useSyncState`
 
@@ -227,21 +247,33 @@ function SyncBadge() {
 
 Manual `sync()` composes with the auto-sync loop (configured via `autoSyncInterval` on `MidenProvider`) — call it when you want to force an immediate refresh.
 
-## `useAssetMetadata(assetId | assetId[])`
+## `useAssetMetadata(assetIds?)`
 
-Symbol + decimals lookup for one or many asset IDs.
+Symbol + decimals lookup for a batch of asset IDs. The argument is an optional `string[]`; pass an empty array (or nothing) to read the global cache without triggering new fetches.
 
 ```tsx
 import { useAssetMetadata } from "@miden-sdk/react";
 
 function TokenChip({ assetId }: { assetId: string }) {
-  const { assetMetadata } = useAssetMetadata(assetId);
+  const { assetMetadata } = useAssetMetadata([assetId]);
   const meta = assetMetadata.get(assetId);
   return <span>{meta?.symbol ?? assetId}</span>;
 }
+
+function TokenLegend({ ids }: { ids: string[] }) {
+  const { assetMetadata } = useAssetMetadata(ids);
+  return (
+    <>
+      {ids.map((id) => {
+        const m = assetMetadata.get(id);
+        return <span key={id}>{m?.symbol ?? id}</span>;
+      })}
+    </>
+  );
+}
 ```
 
-`assetMetadata` is a `Map<string, AssetMetadata>` keyed by asset ID. Pass an array for batch lookups; the hook dedupes and caches internally so components sharing metadata share cost.
+`assetMetadata` is a `Map<string, AssetMetadata>` keyed by asset ID. The hook dedupes and caches across components, so siblings that ask for overlapping IDs share cost.
 
 ## Next
 

--- a/docs/builder/tools/clients/react-sdk/query-hooks.md
+++ b/docs/builder/tools/clients/react-sdk/query-hooks.md
@@ -127,7 +127,7 @@ Filter options (`NotesFilter`):
 | --- | --- | --- |
 | `status` | `"all" \| "consumed" \| "committed" \| "expected" \| "processing"` | Filter by note lifecycle state |
 | `accountId` | `AccountRef` | Only notes relevant to this account |
-| `sender` | `AccountRef` (any format) | Only notes from this sender — normalised internally |
+| `sender` | `string` | Account ID in any accepted format (hex or bech32) — normalised internally |
 | `excludeIds` | `string[]` | Skip these note IDs (useful for hiding notes your UI already rendered elsewhere) |
 
 Return type (`NotesResult`):
@@ -165,7 +165,7 @@ function NewNotesToast() {
       {latest && <p>New: {latest.id}</p>}
       {notes.map((n) => (
         <div key={n.id}>
-          {n.id} at {new Date(n.firstSeen).toISOString()}
+          {n.id} at {new Date(n.firstSeenAt).toISOString()}
           <button onClick={() => markHandled(n.id)}>dismiss</button>
         </div>
       ))}

--- a/docs/builder/tools/clients/react-sdk/recipes.md
+++ b/docs/builder/tools/clients/react-sdk/recipes.md
@@ -68,7 +68,7 @@ const { send } = useSend();
 const { waitForCommit } = useWaitForCommit();
 
 const result = await send({ from, to, assetId, amount: 100n });
-await waitForCommit({ transactionId: result.txId });
+await waitForCommit(result.txId);
 ```
 
 ## Drop to the raw client
@@ -112,20 +112,9 @@ function CompoundFlow() {
 
 ## Isolated clients for multi-wallet apps
 
-Use a unique `storeName` (via `MidenProvider` config or a custom signer) per user account so their IndexedDB databases don't share storage:
+`MidenProvider`'s config does not accept a `storeName` directly. Per-user isolation flows through the active signer: each `SignerContext.Provider` supplies its own `storeName` field, and `MidenProvider` reads that when initialising the underlying client. See the [Signers](./signers.md#custom-signer-providers) guide for a custom signer that picks a unique store name per connected user (typically the wallet address or a hash of it).
 
-```tsx
-<MidenProvider
-  config={{
-    rpcUrl: "testnet",
-    seed: undefined,
-    // storeName is set via the active SignerContext in practice;
-    // see the Signers guide for the custom-signer path.
-  }}
->
-  <App />
-</MidenProvider>
-```
+If you just need two wallets side-by-side in a dev environment and don't want to wire a signer, mount two separate `MidenProvider`s in isolated subtrees backed by different signer contexts.
 
 ## Account IDs — hex and bech32 interchangeably
 

--- a/docs/builder/tools/clients/react-sdk/recipes.md
+++ b/docs/builder/tools/clients/react-sdk/recipes.md
@@ -90,17 +90,25 @@ function BlockHeaderPeek() {
 Two user actions can fire in quick succession — a double-click on "Send", or a hook plus a manual button both wanting to sign. The React SDK exposes a lock:
 
 ```tsx
-import { useMiden } from "@miden-sdk/react";
+import { useMiden, useMidenClient } from "@miden-sdk/react";
 
-const { runExclusive } = useMiden();
+function CompoundFlow() {
+  const { runExclusive } = useMiden();
+  const client = useMidenClient();
 
-await runExclusive(async (client) => {
-  // Multiple client calls that must not interleave with other hooks'
-  // WASM work run here — the lock serialises them across the whole app.
-});
+  const run = () =>
+    runExclusive(async () => {
+      // Multiple client calls that must not interleave with other hooks'
+      // WASM work run here — the lock serialises them across the whole app.
+      await client.sync();
+      // ...
+    });
+
+  return <button onClick={run}>Run</button>;
+}
 ```
 
-Built-in mutations already use this lock internally; `runExclusive` is the escape hatch for your own compound flows.
+`runExclusive<T>(fn)` takes a zero-argument async function; reach for the client via `useMidenClient()` inside it. Built-in mutations already use this lock internally; `runExclusive` is the escape hatch for your own compound flows.
 
 ## Isolated clients for multi-wallet apps
 

--- a/docs/builder/tools/clients/react-sdk/recipes.md
+++ b/docs/builder/tools/clients/react-sdk/recipes.md
@@ -1,0 +1,152 @@
+---
+title: Recipes
+sidebar_position: 7
+---
+
+# Recipes
+
+Short patterns covering the common cases. For longer walkthroughs — building a full wallet app from scratch, including UI — see the [React wallet tutorial](https://github.com/0xMiden/tutorials/blob/main/docs/src/web-client/react_wallet_tutorial.md) in the tutorials repo, which uses these hooks end-to-end.
+
+## Show transaction progress
+
+Every mutation hook exposes `isLoading` and `stage`; use them for optimistic UI:
+
+```tsx
+import { useSend } from "@miden-sdk/react";
+
+function SendButton({ from, to, assetId }: Props) {
+  const { send, stage, isLoading, error } = useSend();
+
+  const handleSend = async () => {
+    try {
+      await send({ from, to, assetId, amount: 100n });
+    } catch (err) {
+      console.error("Send failed:", err);
+    }
+  };
+
+  return (
+    <>
+      <button onClick={handleSend} disabled={isLoading}>
+        {isLoading ? `${stage}…` : "Send"}
+      </button>
+      {error && <p role="alert">{error.message}</p>}
+    </>
+  );
+}
+```
+
+## Format token amounts
+
+```tsx
+import { formatAssetAmount, parseAssetAmount } from "@miden-sdk/react";
+
+// Display: 1_000_000n with 8 decimals → "0.01"
+const display = formatAssetAmount(balance, 8);
+
+// User input: "0.01" with 8 decimals → 1_000_000n
+const amount = parseAssetAmount("0.01", 8);
+```
+
+## Display a note summary
+
+```tsx
+import { getNoteSummary, formatNoteSummary } from "@miden-sdk/react";
+
+const summary = getNoteSummary(note);
+const text = formatNoteSummary(summary); // "1.5 USDC"
+```
+
+`noteSummaries` from `useNotes()` already runs `getNoteSummary` for you — these helpers are for ad-hoc formatting elsewhere.
+
+## Wait for confirmation after a send
+
+```tsx
+import { useSend, useWaitForCommit } from "@miden-sdk/react";
+
+const { send } = useSend();
+const { waitForCommit } = useWaitForCommit();
+
+const result = await send({ from, to, assetId, amount: 100n });
+await waitForCommit({ transactionId: result.txId });
+```
+
+## Drop to the raw client
+
+```tsx
+import { useMidenClient } from "@miden-sdk/react";
+
+function BlockHeaderPeek() {
+  const client = useMidenClient();
+  const header = await client.getBlockHeaderByNumber(100);
+  // ... whatever the hooks don't expose
+}
+```
+
+`useMidenClient()` throws if the provider isn't ready — guard with `useMiden().isReady` when you render before init.
+
+## Prevent race conditions
+
+Two user actions can fire in quick succession — a double-click on "Send", or a hook plus a manual button both wanting to sign. The React SDK exposes a lock:
+
+```tsx
+import { useMiden } from "@miden-sdk/react";
+
+const { runExclusive } = useMiden();
+
+await runExclusive(async (client) => {
+  // Multiple client calls that must not interleave with other hooks'
+  // WASM work run here — the lock serialises them across the whole app.
+});
+```
+
+Built-in mutations already use this lock internally; `runExclusive` is the escape hatch for your own compound flows.
+
+## Isolated clients for multi-wallet apps
+
+Use a unique `storeName` (via `MidenProvider` config or a custom signer) per user account so their IndexedDB databases don't share storage:
+
+```tsx
+<MidenProvider
+  config={{
+    rpcUrl: "testnet",
+    seed: undefined,
+    // storeName is set via the active SignerContext in practice;
+    // see the Signers guide for the custom-signer path.
+  }}
+>
+  <App />
+</MidenProvider>
+```
+
+## Account IDs — hex and bech32 interchangeably
+
+Every hook accepts either:
+
+```tsx
+// Both are valid
+useAccount("0x1234567890abcdef");
+useAccount("mtst1qy35...");
+
+// Convert for display
+account.bech32id(); // "mtst1qy35..."
+
+import { toBech32AccountId } from "@miden-sdk/react";
+toBech32AccountId(someHexId); // "mtst1qy35..."
+```
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+| --- | --- |
+| `"Client not ready"` thrown by a hook | Component rendered before `MidenProvider` finished initializing. Guard with `useMiden().isReady` or render via `MidenProvider`'s `loadingComponent`. |
+| Transactions stuck in `"proving"` | Remote prover unreachable. Check `prover` config and network; consider `prover: { primary: "testnet", fallback: "local" }`. |
+| Notes not appearing after mint | Call `sync()` from `useSyncState()` or verify `autoSyncInterval` isn't `0`. |
+| Bech32 address has wrong prefix | `rpcUrl` doesn't match the network you intended. `"testnet"` → `mtst1...`, `"devnet"` → `mdev1...`. |
+| WASM init fails in dev | Ensure your bundler serves `.wasm` with the `application/wasm` MIME type. Vite does this automatically; some custom setups don't. |
+| `"A send is already in progress"` | Two `useSend` mutations fired simultaneously. Either `await` the previous call before starting the next, or use `runExclusive` to coordinate. |
+
+## Next
+
+- Longer walkthrough: [React wallet tutorial](https://github.com/0xMiden/tutorials/blob/main/docs/src/web-client/react_wallet_tutorial.md) — builds a complete wallet app on top of these hooks.
+- Reference: [Setup](./setup.md), [Query hooks](./query-hooks.md), [Mutation hooks](./mutation-hooks.md), [Advanced](./advanced.md), [Signers](./signers.md).

--- a/docs/builder/tools/clients/react-sdk/setup.md
+++ b/docs/builder/tools/clients/react-sdk/setup.md
@@ -1,0 +1,211 @@
+---
+title: Setup
+sidebar_position: 2
+---
+
+# Setting up the React SDK
+
+## Install
+
+The React SDK has a hard peer dependency on `@miden-sdk/miden-sdk` — install both:
+
+```bash
+npm install @miden-sdk/react @miden-sdk/miden-sdk
+# or
+yarn add @miden-sdk/react @miden-sdk/miden-sdk
+# or
+pnpm add @miden-sdk/react @miden-sdk/miden-sdk
+```
+
+React 18 or newer is required.
+
+## Wrap your app in `MidenProvider`
+
+`MidenProvider` loads the Web SDK's WebAssembly module, spins up the dedicated worker, wires the keystore, and kicks off the auto-sync loop. Put it at the root of your React tree — typically in `App.tsx` or your Next.js root layout.
+
+```tsx
+import { MidenProvider } from "@miden-sdk/react";
+
+function App() {
+  return (
+    <MidenProvider config={{ rpcUrl: "testnet" }}>
+      <YourApp />
+    </MidenProvider>
+  );
+}
+```
+
+Every hook in the rest of this section assumes a `MidenProvider` is mounted somewhere above it.
+
+## Configuration
+
+```tsx
+<MidenProvider
+  config={{
+    rpcUrl: "testnet",           // "devnet" | "testnet" | "localhost" | custom URL
+    prover: "testnet",           // "local" | "devnet" | "testnet" | custom URL
+    autoSyncInterval: 15_000,    // ms; set to 0 to disable auto-sync
+    noteTransportUrl: "testnet", // optional; required for private notes
+  }}
+  loadingComponent={<Loading />} // rendered while WASM boots
+  errorComponent={<Error />}     // rendered if init fails
+>
+  <YourApp />
+</MidenProvider>
+```
+
+### `MidenConfig` fields
+
+| Field | Type | Description |
+| --- | --- | --- |
+| `rpcUrl` | `"devnet" \| "testnet" \| "localhost" \| string` | Node RPC endpoint. Shorthands expand to hosted Miden endpoints; any other string is treated as a raw URL. |
+| `prover` | `"local" \| "devnet" \| "testnet" \| string \| ProverConfig` | Default prover. `"local"` runs in-browser. `ProverConfig` supports a `primary` + `fallback` pair if you want automatic fallback. |
+| `autoSyncInterval` | `number` | Milliseconds between automatic sync pulls. `0` disables the loop (you can still call `sync()` manually). Default: 15000. |
+| `noteTransportUrl` | `"devnet" \| "testnet" \| string` | Note transport service. Required for `sendPrivate` / `fetchPrivate`. |
+| `proverTimeoutMs` | `number` | Per-transaction prover timeout. |
+| `seed` | `Uint8Array` | 32-byte RNG seed for deterministic account-ID derivation in tests. |
+
+### Network shorthands
+
+| Shorthand | Meaning |
+| --- | --- |
+| `devnet` | Development / pre-production testing, fake tokens |
+| `testnet` | Pre-production testing against the hosted Miden testnet |
+| `localhost` | Local node at `http://localhost:57291` |
+
+### `loadingComponent` and `errorComponent`
+
+- `loadingComponent` is rendered during the brief WASM load phase (first render only).
+- `errorComponent` is rendered if initialization fails. It accepts either a `ReactNode` or `(error: Error) => ReactNode`.
+
+Both are optional. Leaving them unset uses sensible defaults.
+
+## Client lifecycle
+
+`useMiden()` is the raw context hook. Most apps never need it — the specialized hooks are easier — but it's there when you want to reach into lifecycle state directly.
+
+```tsx
+import { useMiden } from "@miden-sdk/react";
+
+function Status() {
+  const { isReady, isInitializing, error, sync, runExclusive } = useMiden();
+
+  if (isInitializing) return <p>Loading Miden…</p>;
+  if (error) return <p>Init error: {error.message}</p>;
+
+  return <button onClick={() => sync()}>Sync</button>;
+}
+```
+
+- `isReady` — `true` once the WASM module, keystore, and signer are fully initialised.
+- `isInitializing` — `true` during the first load.
+- `error` — non-null if init failed.
+- `sync()` — trigger a manual sync pass outside the auto-sync loop.
+- `runExclusive(fn)` — serialize a block of client calls under the internal lock (see [race conditions](./recipes.md#prevent-race-conditions)).
+
+`useMidenClient()` is a shortcut that returns the ready `WebClient` directly, throwing if the provider isn't ready yet:
+
+```tsx
+import { useMidenClient } from "@miden-sdk/react";
+
+function AdvancedCall() {
+  const client = useMidenClient();
+  const header = await client.getBlockHeaderByNumber(100);
+  // ...
+}
+```
+
+Use it for APIs the React SDK hooks don't expose.
+
+## Hook result conventions
+
+Each hook exports its own result interface — `UseSendResult`, `AccountsResult`, `NotesResult`, and so on — rather than a generic `QueryResult<T>` wrapper. Data lives in named fields (e.g. `accounts`, `wallets`, `faucets`) not inside a common `data` key. The shared machinery is narrower than that:
+
+### Query hooks
+
+Every query hook exposes at least:
+
+```ts
+{
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => Promise<void>;
+}
+```
+
+Plus the hook-specific data fields. For example:
+
+```tsx
+const { wallets, faucets, isLoading, error, refetch } = useAccounts();
+
+if (isLoading) return <Spinner />;
+if (error) return <p>{error.message}</p>;
+return <AccountList wallets={wallets} faucets={faucets} />;
+```
+
+### Mutation hooks
+
+Every mutation hook exposes:
+
+```ts
+{
+  // Domain-specific action function — `send` for useSend, `mint` for useMint, etc.
+  [action]: (options) => Promise<Result>;
+  result: Result | null;
+  isLoading: boolean;
+  stage: TransactionStage;
+  error: Error | null;
+  reset: () => void;
+}
+```
+
+The action function name mirrors the hook: `useSend` returns `send`, `useMint` returns `mint`, `useConsume` returns `consume`. That keeps call sites readable without destructured renames.
+
+Transaction-producing mutations progress through the `TransactionStage` states:
+
+```ts
+type TransactionStage =
+  | "idle"
+  | "executing"
+  | "proving"
+  | "submitting"
+  | "complete";
+```
+
+Pattern:
+
+```tsx
+const { send, stage, isLoading, error } = useSend();
+
+return (
+  <button
+    onClick={() => send({ from, to, assetId, amount: 100n })}
+    disabled={isLoading}
+  >
+    {isLoading ? `${stage}…` : "Send"}
+  </button>
+);
+```
+
+See [Mutation hooks](./mutation-hooks.md) for the full surface.
+
+## Account ID formats
+
+Every hook accepts either form:
+
+```tsx
+useAccount("0x1234567890abcdef");         // hex
+useAccount("miden1qy35...");              // bech32
+
+// Convert for display
+account.bech32id(); // "miden1qy35..."
+```
+
+The SDK normalises internally — you don't need to convert yourself.
+
+## Next
+
+- [Query hooks](./query-hooks.md) — read account, note, sync, and metadata state.
+- [Mutation hooks](./mutation-hooks.md) — create wallets, send, mint, consume, swap.
+- [Advanced](./advanced.md) — custom scripts, session wallets, import/export.
+- [Signers](./signers.md) — integrate Para, Turnkey, MidenFi, or a custom wallet.

--- a/docs/builder/tools/clients/react-sdk/setup.md
+++ b/docs/builder/tools/clients/react-sdk/setup.md
@@ -101,7 +101,7 @@ function Status() {
 - `isInitializing` — `true` during the first load.
 - `error` — non-null if init failed.
 - `sync()` — trigger a manual sync pass outside the auto-sync loop.
-- `runExclusive(fn)` — serialize a block of client calls under the internal lock (see [race conditions](./recipes.md#prevent-race-conditions)).
+- `runExclusive<T>(fn: () => Promise<T>): Promise<T>` — serialize a block of async work under the internal lock. `fn` takes no arguments; reach for the client via `useMidenClient()` if you need one inside. See [race conditions](./recipes.md#prevent-race-conditions).
 
 `useMidenClient()` is a shortcut that returns the ready `WebClient` directly, throwing if the provider isn't ready yet:
 

--- a/docs/builder/tools/clients/react-sdk/setup.md
+++ b/docs/builder/tools/clients/react-sdk/setup.md
@@ -194,14 +194,14 @@ See [Mutation hooks](./mutation-hooks.md) for the full surface.
 Every hook accepts either form:
 
 ```tsx
-useAccount("0x1234567890abcdef");         // hex
-useAccount("miden1qy35...");              // bech32
+useAccount("0x1234567890abcdef");   // hex
+useAccount("mtst1qy35...");         // bech32 (testnet prefix)
 
 // Convert for display
-account.bech32id(); // "miden1qy35..."
+account.bech32id(); // "mtst1qy35..." on testnet
 ```
 
-The SDK normalises internally — you don't need to convert yourself.
+The SDK normalises internally — you don't need to convert yourself. Bech32 prefixes encode the network: `mtst1…` on testnet, `mdev1…` on devnet. The prefix is derived from the `rpcUrl` you configured on `MidenProvider`.
 
 ## Next
 

--- a/docs/builder/tools/clients/react-sdk/signers.md
+++ b/docs/builder/tools/clients/react-sdk/signers.md
@@ -1,0 +1,194 @@
+---
+title: External signers
+sidebar_position: 6
+---
+
+# External signers
+
+The React SDK treats signing as a pluggable contract: `MidenProvider` accepts any `SignerContext` that exposes a `signCb` function, and hooks call into it whenever a transaction needs a signature. Prebuilt providers exist for the major wallet integrations; you can also build your own.
+
+## Built-in signer providers
+
+### Para (EVM wallets)
+
+```tsx
+import { ParaSignerProvider } from "@miden-sdk/para";
+import { MidenProvider } from "@miden-sdk/react";
+
+function App() {
+  return (
+    <ParaSignerProvider apiKey="your-api-key" environment="PRODUCTION">
+      <MidenProvider config={{ rpcUrl: "testnet" }}>
+        <YourApp />
+      </MidenProvider>
+    </ParaSignerProvider>
+  );
+}
+```
+
+Expose Para-specific data inside your app:
+
+```tsx
+import { useParaSigner } from "@miden-sdk/para";
+
+const { para, wallet, isConnected } = useParaSigner();
+```
+
+### Turnkey
+
+```tsx
+import { TurnkeySignerProvider } from "@miden-sdk/miden-turnkey-react";
+
+// Config is optional — defaults to https://api.turnkey.com and reads
+// VITE_TURNKEY_ORG_ID from the environment.
+<TurnkeySignerProvider>
+  <MidenProvider config={{ rpcUrl: "testnet" }}>
+    <YourApp />
+  </MidenProvider>
+</TurnkeySignerProvider>
+
+// Or with explicit config:
+<TurnkeySignerProvider
+  config={{
+    apiBaseUrl: "https://api.turnkey.com",
+    defaultOrganizationId: "your-org-id",
+  }}
+>
+  ...
+</TurnkeySignerProvider>
+```
+
+Connect via passkey authentication:
+
+```tsx
+import { useSigner } from "@miden-sdk/react";
+import { useTurnkeySigner } from "@miden-sdk/miden-turnkey-react";
+
+function ConnectButton() {
+  const { isConnected, connect, disconnect } = useSigner();
+  if (!isConnected) return <button onClick={connect}>Connect</button>;
+
+  const { client, account, setAccount } = useTurnkeySigner();
+  return <button onClick={disconnect}>Disconnect ({account?.name})</button>;
+}
+```
+
+### MidenFi wallet adapter
+
+```tsx
+import { MidenFiSignerProvider } from "@miden-sdk/wallet-adapter-react";
+
+<MidenFiSignerProvider network="testnet">
+  <MidenProvider config={{ rpcUrl: "testnet" }}>
+    <YourApp />
+  </MidenProvider>
+</MidenFiSignerProvider>
+```
+
+## Unified signer interface
+
+Every prebuilt provider exposes the same `useSigner` surface, so UI code that only cares about connect/disconnect stays signer-agnostic:
+
+```tsx
+import { useSigner } from "@miden-sdk/react";
+
+function Header() {
+  const { isConnected, connect, disconnect, name } = useSigner();
+
+  if (!isConnected) return <button onClick={connect}>Connect {name}</button>;
+  return <button onClick={disconnect}>Disconnect</button>;
+}
+```
+
+## Custom signer providers
+
+For a signing service that doesn't have a prebuilt provider — internal HSM, hardware wallet, or experimental integration — wire `SignerContext` directly:
+
+```tsx
+import { SignerContext, type SignerContextValue } from "@miden-sdk/react";
+
+const signer: SignerContextValue = {
+  name: "MyWallet",
+  storeName: `mywallet_${userAddress}`, // unique per user for DB isolation
+  isConnected: true,
+  accountConfig: {
+    publicKeyCommitment: userPublicKeyCommitment, // Uint8Array
+    storageMode: "private",
+    accountType: "RegularAccountUpdatableCode",
+  },
+  signCb: async (pubKey, signingInputs) => {
+    // Route to your signing service
+    return signature; // Uint8Array
+  },
+  connect: async () => {
+    /* trigger wallet connection */
+  },
+  disconnect: async () => {
+    /* clear session */
+  },
+};
+
+function App() {
+  return (
+    <SignerContext.Provider value={signer}>
+      <MidenProvider config={{ rpcUrl: "testnet" }}>
+        <YourApp />
+      </MidenProvider>
+    </SignerContext.Provider>
+  );
+}
+```
+
+`storeName` is critical: each user's data lives in its own IndexedDB database, so make the `storeName` unique per signing identity (typically the wallet address or a derived hash).
+
+## Custom `AccountComponent`s
+
+Attach application-specific components — compiled from `.masp` packages, e.g. a DEX module — alongside the default auth and basic wallet components:
+
+```tsx
+import { type SignerAccountConfig } from "@miden-sdk/react";
+import { AccountComponent } from "@miden-sdk/miden-sdk";
+
+const myDexComponent: AccountComponent = await loadCompiledComponent();
+
+const accountConfig: SignerAccountConfig = {
+  publicKeyCommitment: userPublicKeyCommitment,
+  accountType: "RegularAccountUpdatableCode",
+  storageMode: "private",
+  customComponents: [myDexComponent],
+};
+```
+
+Components are appended to the `AccountBuilder` after the default basic wallet component and before `build()` is called, so the account always includes wallet functionality plus any extras you pass. The field is optional; leaving it unset (or passing an empty array) preserves the default behaviour.
+
+## `MultiSignerProvider`
+
+For apps that need to swap between multiple signer providers at runtime (e.g. "connect with Para" or "connect with Turnkey"), use `MultiSignerProvider` and `SignerSlot`:
+
+```tsx
+import { MultiSignerProvider, SignerSlot } from "@miden-sdk/react";
+
+<MultiSignerProvider>
+  <SignerSlot id="para">
+    <ParaSignerProvider apiKey="...">{children}</ParaSignerProvider>
+  </SignerSlot>
+
+  <SignerSlot id="turnkey">
+    <TurnkeySignerProvider>{children}</TurnkeySignerProvider>
+  </SignerSlot>
+</MultiSignerProvider>
+```
+
+Switch the active signer via `useMultiSigner()`:
+
+```tsx
+import { useMultiSigner } from "@miden-sdk/react";
+
+const { activeSigner, setActiveSigner } = useMultiSigner();
+// setActiveSigner("para" | "turnkey" | ...)
+```
+
+## Next
+
+- [Recipes](./recipes.md) — end-to-end patterns with signer integration examples.
+- [Setup](./setup.md) — client config and lifecycle.

--- a/docs/builder/tools/clients/react-sdk/signers.md
+++ b/docs/builder/tools/clients/react-sdk/signers.md
@@ -58,18 +58,26 @@ import { TurnkeySignerProvider } from "@miden-sdk/miden-turnkey-react";
 </TurnkeySignerProvider>
 ```
 
-Connect via passkey authentication:
+Connect via passkey authentication. `useSigner()` returns `SignerContextValue | null` (null when no signer provider is above the component), so always null-guard:
 
 ```tsx
 import { useSigner } from "@miden-sdk/react";
 import { useTurnkeySigner } from "@miden-sdk/miden-turnkey-react";
 
 function ConnectButton() {
-  const { isConnected, connect, disconnect } = useSigner();
-  if (!isConnected) return <button onClick={connect}>Connect</button>;
+  const signer = useSigner();
+  const turnkey = useTurnkeySigner(); // call unconditionally — rules of hooks
 
-  const { client, account, setAccount } = useTurnkeySigner();
-  return <button onClick={disconnect}>Disconnect ({account?.name})</button>;
+  if (!signer) return null; // no signer provider mounted
+
+  if (!signer.isConnected) {
+    return <button onClick={signer.connect}>Connect</button>;
+  }
+  return (
+    <button onClick={signer.disconnect}>
+      Disconnect ({turnkey.account?.name})
+    </button>
+  );
 }
 ```
 
@@ -87,16 +95,19 @@ import { MidenFiSignerProvider } from "@miden-sdk/wallet-adapter-react";
 
 ## Unified signer interface
 
-Every prebuilt provider exposes the same `useSigner` surface, so UI code that only cares about connect/disconnect stays signer-agnostic:
+Every prebuilt provider exposes the same `useSigner` surface, so UI code that only cares about connect/disconnect stays signer-agnostic. Note the return is `SignerContextValue | null`:
 
 ```tsx
 import { useSigner } from "@miden-sdk/react";
 
 function Header() {
-  const { isConnected, connect, disconnect, name } = useSigner();
+  const signer = useSigner();
+  if (!signer) return null; // no signer provider above
 
-  if (!isConnected) return <button onClick={connect}>Connect {name}</button>;
-  return <button onClick={disconnect}>Disconnect</button>;
+  if (!signer.isConnected) {
+    return <button onClick={signer.connect}>Connect {signer.name}</button>;
+  }
+  return <button onClick={signer.disconnect}>Disconnect</button>;
 }
 ```
 
@@ -163,30 +174,49 @@ Components are appended to the `AccountBuilder` after the default basic wallet c
 
 ## `MultiSignerProvider`
 
-For apps that need to swap between multiple signer providers at runtime (e.g. "connect with Para" or "connect with Turnkey"), use `MultiSignerProvider` and `SignerSlot`:
+For apps that need to swap between multiple signer providers at runtime (e.g. "connect with Para" or "connect with Turnkey"), use `MultiSignerProvider`. Each registered signer provider renders its own `<SignerSlot />` (the component takes no children — it registers the provider's current `SignerContext` with the multi-signer context) and `MidenProvider` sits as a sibling inside `MultiSignerProvider`:
 
 ```tsx
-import { MultiSignerProvider, SignerSlot } from "@miden-sdk/react";
+import { MultiSignerProvider, SignerSlot, MidenProvider } from "@miden-sdk/react";
 
-<MultiSignerProvider>
-  <SignerSlot id="para">
-    <ParaSignerProvider apiKey="...">{children}</ParaSignerProvider>
-  </SignerSlot>
+function App() {
+  return (
+    <MultiSignerProvider>
+      <ParaSignerProvider apiKey="...">
+        <SignerSlot />
+      </ParaSignerProvider>
+      <TurnkeySignerProvider>
+        <SignerSlot />
+      </TurnkeySignerProvider>
 
-  <SignerSlot id="turnkey">
-    <TurnkeySignerProvider>{children}</TurnkeySignerProvider>
-  </SignerSlot>
-</MultiSignerProvider>
+      <MidenProvider config={{ rpcUrl: "testnet" }}>
+        <YourApp />
+      </MidenProvider>
+    </MultiSignerProvider>
+  );
+}
 ```
 
-Switch the active signer via `useMultiSigner()`:
+Connect and disconnect by name via `useMultiSigner()`:
 
 ```tsx
 import { useMultiSigner } from "@miden-sdk/react";
 
-const { activeSigner, setActiveSigner } = useMultiSigner();
-// setActiveSigner("para" | "turnkey" | ...)
+function SignerPicker() {
+  const multi = useMultiSigner();
+  if (!multi) return null; // no MultiSignerProvider above
+
+  return (
+    <>
+      <button onClick={() => multi.connectSigner("Para")}>Connect Para</button>
+      <button onClick={() => multi.connectSigner("Turnkey")}>Connect Turnkey</button>
+      <button onClick={() => multi.disconnectSigner()}>Disconnect</button>
+    </>
+  );
+}
 ```
+
+`useMultiSigner()` returns `MultiSignerContextValue | null`; its `connectSigner(name)` / `disconnectSigner()` actions switch and clear the active signer respectively. The name passed to `connectSigner` matches the `name` field on each signer's `SignerContextValue`.
 
 ## Next
 


### PR DESCRIPTION
## Summary

Adds a locally-authored **React SDK (@miden-sdk/react)** guide under `docs/builder/tools/clients/react-sdk/` covering the full shipping 0.14.3 hook surface: provider lifecycle, query hooks, mutation hooks, advanced hooks, external signers, and recipes.

**Stacked on #247** (Web SDK docs + workflow narrowing). Base is `brian/web-sdk-docs` so this PR's diff shows only React SDK content. Once #247 merges, GitHub will rebase this PR onto `main` automatically.

## What's in this PR

Six atomic commits:

1. `docs(react-sdk): add overview and setup pages` — `_category_.yml` (label "React", position 3), landing `index.md` with the three hook families + signer pointer, `setup.md` covering install, `MidenProvider`, the full `MidenConfig` reference, client-lifecycle hooks (`useMiden`, `useMidenClient`), and the per-hook result conventions (query vs transaction-producing vs account-creation vs polling-helper shapes).
2. `docs(react-sdk): add query hooks guide` — `useAccounts`, `useAccount`, `useNotes` (with full `NotesFilter`), `useNoteStream`, `useTransactionHistory`, `useSyncState`, `useAssetMetadata`.
3. `docs(react-sdk): add mutation hooks guide` — `useCreateWallet`, `useCreateFaucet`, `useSend` (incl. `returnNote` / `sendAll` / `recallHeight` / `timelockHeight`), `useMultiSend`, `useMint`, `useConsume`, `useSwap`, `useImportAccount` (discriminated union by `type`), `useWaitForCommit` / `useWaitForNotes`.
4. `docs(react-sdk): add advanced hooks guide` — `useTransaction` (with `privateNoteTarget` pipeline), `useExecuteProgram`, `useCompile`, `useSessionAccount`, `useExportStore` / `useImportStore`, `useImportNote` / `useExportNote`, `useSyncControl`.
5. `docs(react-sdk): add signers and recipes guides` — prebuilt signer providers (Para, Turnkey, MidenFi), unified `useSigner` interface, custom `SignerContext` with the full `SignerContextValue`, `customComponents` on `SignerAccountConfig`, `MultiSignerProvider` + `SignerSlot`. Recipes for transaction progress UI, formatting, wait-for-commit, `runExclusive`, account-ID formats, troubleshooting.
6. `docs(react-sdk): correct hook shapes against shipped 0.14.3 types` — applied 13+ fixes after running `tsc --strict` against the installed `@miden-sdk/react@0.14.3` types (see commit body).

## Verification

- ✅ `cd docs-tests/react/react-sdk-demo && npx tsc --noEmit --strict` — exit 0. Every TSX snippet across 7 pages (index, setup, query-hooks, mutation-hooks, advanced, signers, recipes) typechecks against shipped types.
- ✅ `npm run build` — `[SUCCESS]`, zero new broken-link warnings from this PR. All remaining warnings are pre-existing.
- ✅ Harness (`docs-tests/react/react-sdk-demo/`) mirrors the PR A pattern — one TSX file per docs page, with snippets lifted verbatim.

The harness caught real API drift in first drafts, now fixed:
- `useMultiSend` action is `sendMany`, not `multiSend`.
- `useWaitForCommit` is positional: `waitForCommit(txId, options?)`, not an options-object.
- `useWaitForNotes` exposes `waitForConsumableNotes`, not `waitForNotes`.
- `useCreateWallet` / `useCreateFaucet` / `useImportAccount` use `isCreating` / `isImporting` (no `stage`) — they don't go through the prove/submit pipeline.
- `useTransaction` / `useExecuteProgram` both expose `execute` (not `executeTransaction` / `executeProgram`).
- `useCompile` surface is `{ component, txScript, noteScript, isReady }` — no top-level `isLoading` / `error`.
- `useTransactionHistory` returns `records` (not `transactions`); options don't include `accountId` — callers pass a `TransactionFilter` for scoped queries.
- `useAssetMetadata` takes `string[]` only, not a single string.
- `useNoteStream` options don't include `accountId`.
- `useSessionAccount` options/return shapes completely rewritten (initialize / sessionAccountId / step).
- `useMiden().runExclusive<T>(fn)` takes a zero-argument callback — reach for the client via `useMidenClient()` inside.

## Test plan

- [ ] Reviewer runs `npm run build` locally on this branch — verifies `[SUCCESS]` with no new warnings on pages this PR touches.
- [ ] Reviewer spot-checks one or two hook signatures against `@miden-sdk/react@0.14.3`'s `dist/index.d.ts`.
- [ ] Optional: `cd docs-tests/react/react-sdk-demo && npm install && npm run typecheck:strict` → exits 0.
- [ ] After #247 merges, rebase this PR onto `main` (GitHub should do this automatically for stacked PRs).

## Out of scope

- **Web SDK** — covered in #247.
- **Rust client** — untouched, still ingested from miden-client.
- **React SDK feature work** — docs-only.
- **Full Vitest + @testing-library/react runtime harness** — type-check harness catches API-shape drift cheaply; runtime testing (using the SDK's own direct-store-injection pattern) is out of scope for this PR.