### PR TITLE
fix(sidebars): drop recipes/web/setup_guide until PR #186 merges

### DIFF
--- a/sidebars.ts
+++ b/sidebars.ts
@@ -122,7 +122,10 @@ const sidebars: SidebarsConfig = {
               link: { type: "doc", id: "builder/tutorials/recipes/web/index" },
               collapsed: true,
               items: [
-                "builder/tutorials/recipes/web/setup_guide",
+                // NOTE: "builder/tutorials/recipes/web/setup_guide" lives
+                // only on 0xMiden/tutorials#186 (kbg/chore/v14-migration).
+                // Re-add once that PR merges into tutorials' main —
+                // it'll be part of the v0.14 release branch meanwhile.
                 "builder/tutorials/recipes/web/counter_contract_tutorial",
                 "builder/tutorials/recipes/web/create_deploy_tutorial",
                 "builder/tutorials/recipes/web/mint_consume_create_tutorial",


### PR DESCRIPTION
## Summary

PR #254 enumerated the new `recipes/web/*` entries in the sidebar, including `setup_guide` — but that file only exists on [`0xMiden/tutorials#186`](https://github.com/0xMiden/tutorials/pull/186) (`kbg/chore/v14-migration`). That PR has not merged into tutorials `main` yet, and `deploy-docs.yml` ingests tutorials from `main`, so every push-to-main build since #254 has aborted in Docusaurus's sidebar validator:

```
Invalid sidebar file at "sidebars.ts".
These sidebar document ids do not exist:
  - builder/tutorials/recipes/web/setup_guide
```

See failing run: [`24820901856`](https://github.com/0xMiden/docs/actions/runs/24820901856/job/72645192218).

## Fix

Remove the single offending line from `sidebars.ts` with an inline TODO to re-add once `0xMiden/tutorials#186` lands upstream. The `setup_guide` page will still appear in the v0.14 release branch (which explicitly pins the tutorials ingest to `refs/pull/186/head`).

## Verification

Reproduced the CI failure locally by ingesting tutorials from `main`:

```
[ERROR] Loading of version failed for version current
  [cause]: Error: Invalid sidebar file at "sidebars.ts".
    These sidebar document ids do not exist:
      - builder/tutorials/recipes/web/setup_guide
```

Applied the fix, re-ran the same ingest + build: `[SUCCESS] Generated static files in "build"`, exit 0.

## Follow-up

Re-add `"builder/tutorials/recipes/web/setup_guide"` in a separate one-line PR once `0xMiden/tutorials#186` merges into tutorials `main`. The v0.14 release branch (`brian/v0.14-release`, in progress) will carry the entry since it ingests PR #186's tree directly.