### PR TITLE
docs: add midenup page · flip tutorials ingest back to main

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -41,10 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DEFAULT_REF: next
-      # v0.14 pins tutorials to the PR #186 branch (kbg/chore/v14-migration)
-      # so the live /next/ ingest matches what v0.14 snapshot was cut from.
-      # TODO: flip back to `main` once 0xMiden/tutorials#186 merges upstream.
-      DEFAULT_TUTORIALS_REF: kbg/chore/v14-migration
+      DEFAULT_TUTORIALS_REF: main
     steps:
       - name: Checkout docs site
         uses: actions/checkout@v4

--- a/.release/release-manifest.yml
+++ b/.release/release-manifest.yml
@@ -3,7 +3,7 @@ refs: # exact, immutable refs per source repo (tags or release branches)
   protocol: "refs/tags/v0.14.4"
   node: "refs/tags/v0.14.9"
   miden-client: "refs/tags/v0.14.4"
-  tutorials: "refs/pull/186/head"
+  tutorials: "refs/heads/main"
   miden-vm: "refs/tags/v0.22.1"
   compiler: "refs/tags/v0.8.1"
 next_version: "0.15"

--- a/docs/builder/tools/index.md
+++ b/docs/builder/tools/index.md
@@ -22,9 +22,12 @@ Developer tools for building on and interacting with the Miden network. Use the 
   </Card>
 </CardGrid>
 
-## Environments
+## Toolchain + environments
 
-<CardGrid cols={2}>
+<CardGrid cols={3}>
+  <Card title="midenup" href="./midenup" eyebrow="Toolchain installer">
+    Install and switch between Miden toolchain channels — VM, compiler, client, stdlib, kernel — from a unified `miden` command.
+  </Card>
   <Card title="Playground" href="./playground" eyebrow="Browser">
     Interactive environment for writing and testing Miden Assembly programs.
   </Card>

--- a/docs/builder/tools/midenup.md
+++ b/docs/builder/tools/midenup.md
@@ -1,0 +1,116 @@
+---
+title: midenup
+sidebar_position: 2
+description: "The Miden toolchain installer — bootstrap, pin, and switch between Miden VM / compiler / client / stdlib toolchains from a single `miden` entry point."
+---
+
+# midenup
+
+`midenup` is the Miden toolchain installer. One install gives you a unified `miden` command that delegates to the Miden VM, compiler (`midenc` + `cargo-miden`), client, stdlib, and transaction kernel — all versioned together as a single release channel.
+
+<CardGrid cols={2}>
+  <Card title="midenup on GitHub ↗" href="https://github.com/0xMiden/midenup" eyebrow="Source · Installer">
+    The installer repo. Tracks the canonical channel manifest and publishes prebuilt toolchain releases.
+  </Card>
+  <Card title="Channel manifest ↗" href="https://0xmiden.github.io/midenup/channel-manifest.json" eyebrow="JSON">
+    Machine-readable inventory of available toolchain channels and the component versions each one pins.
+  </Card>
+</CardGrid>
+
+## Install
+
+```bash title=">_ Install midenup"
+cargo install midenup && midenup init
+```
+
+`midenup init` sets up `$MIDENUP_HOME`, writes a `miden` symlink into `$CARGO_HOME/bin`, and prepares the toolchain cache. Since most Rust users already have `$CARGO_HOME/bin` on their PATH, the `miden` command is ready immediately.
+
+<Callout variant="tip" title="Check it worked">
+Run `miden --version`. If you see "command not found," add `$CARGO_HOME/bin` (default `~/.cargo/bin`) to your PATH and re-open the shell.
+</Callout>
+
+## Components it manages
+
+<CardGrid cols={3}>
+  <Card title="Miden VM" eyebrow="Execution">
+    The MASM interpreter, prover, and verifier. Used by every Miden program.
+  </Card>
+  <Card title="Compiler" eyebrow="Rust → MASM">
+    `midenc` and `cargo-miden` — the Rust frontend that compiles `#[miden]` code to MASM.
+  </Card>
+  <Card title="Miden client" eyebrow="SDK + CLI">
+    `miden-client` — accounts, transactions, notes, proving.
+  </Card>
+  <Card title="Standard library" eyebrow="MASM stdlib">
+    `miden-stdlib` — the canonical MASM standard library.
+  </Card>
+  <Card title="Transaction kernel" eyebrow="Kernel library">
+    `miden-base` — the transaction kernel that runs inside every account and note script.
+  </Card>
+  <Card title="(more coming)" eyebrow="Roadmap">
+    Additional Miden components will be added to `midenup` as they ship.
+  </Card>
+</CardGrid>
+
+## Toolchain management
+
+### Install a channel
+
+```bash
+midenup install stable        # latest matching component set
+midenup install 0.14          # pin to a specific release line
+```
+
+### Switch the active toolchain
+
+```bash
+midenup set 0.14              # pin for the current project (writes miden-toolchain.toml)
+midenup override 0.14         # set the system-wide default
+midenup show active-toolchain # which one is active right now?
+```
+
+A `miden-toolchain.toml` in the current directory always wins — otherwise the system default applies, falling back to `stable` if none is set.
+
+### Uninstall
+
+```bash
+midenup uninstall 0.14
+```
+
+Delete `$MIDENUP_HOME` to uninstall `midenup` itself. Find its location with `midenup show home`.
+
+<Callout variant="warning" title="Don't delete toolchain dirs by hand">
+Removing toolchain directories manually corrupts the `midenup` environment. Use `midenup uninstall` so the installer updates its bookkeeping.
+</Callout>
+
+## The `miden` entry point
+
+`miden` delegates to the right component based on the subcommand. Common aliases:
+
+| `miden` command | Delegates to | What it does |
+| --- | --- | --- |
+| `miden new` | `cargo miden new` | Create a new Miden Rust project |
+| `miden build` | `cargo miden build` | Build the project |
+| `miden new-wallet` | `miden-client new-wallet --deploy` | Create and deploy a wallet account |
+| `miden account` | `miden-client account` | Create or inspect a local account |
+| `miden faucet` | `miden-client mint` | Fund an account from the faucet |
+| `miden deploy` | `miden-client -s public --account-type regular-account-immutable-code` | Deploy a public, immutable-code contract |
+| `miden call` | `miden-client account --show` | Read state from an account (view) |
+| `miden send` | `miden-client send` | Send a state-changing transaction |
+| `miden simulate` | `miden-client exec` | Dry-run a transaction without committing |
+
+Everything outside the alias table is forwarded to the underlying binary — e.g., `miden exec …` goes straight through to `miden-client exec`.
+
+## Related
+
+<CardGrid cols={3}>
+  <Card title="Installation" href="../get-started/setup/installation" eyebrow="Get started">
+    Full environment setup — prerequisites, node install, first account.
+  </Card>
+  <Card title="CLI basics" href="../get-started/setup/cli-basics" eyebrow="Commands">
+    Walk through `miden account`, `miden send`, `miden faucet`, and the rest.
+  </Card>
+  <Card title="Network" href="./network" eyebrow="Testnet · Services">
+    Endpoints the `miden` CLI points at — RPC, faucet, remote prover, block explorer.
+  </Card>
+</CardGrid>

--- a/docs/builder/tools/midenup.md
+++ b/docs/builder/tools/midenup.md
@@ -1,5 +1,6 @@
 ---
 title: midenup
+sidebar_label: Midenup
 sidebar_position: 2
 description: "The Miden toolchain installer — bootstrap, pin, and switch between Miden VM / compiler / client / stdlib toolchains from a single `miden` entry point."
 ---

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -241,6 +241,7 @@ const sidebars: SidebarsConfig = {
             },
           ],
         },
+        "builder/tools/midenup",
         "builder/tools/playground",
         "builder/tools/network",
       ],

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -73,10 +73,10 @@ export default function Home(): JSX.Element {
                   <span aria-hidden="true">→</span>
                 </Link>
                 <Link
-                  to="https://github.com/0xMiden/midenup"
+                  to="/builder/tools/midenup"
                   className={styles.ctaSecondary}
                 >
-                  Install midenup <span aria-hidden="true">↗</span>
+                  Install midenup <span aria-hidden="true">→</span>
                 </Link>
               </div>
             </div>

--- a/versioned_docs/version-0.14/builder/tools/index.md
+++ b/versioned_docs/version-0.14/builder/tools/index.md
@@ -22,9 +22,12 @@ Developer tools for building on and interacting with the Miden network. Use the 
   </Card>
 </CardGrid>
 
-## Environments
+## Toolchain + environments
 
-<CardGrid cols={2}>
+<CardGrid cols={3}>
+  <Card title="midenup" href="./midenup" eyebrow="Toolchain installer">
+    Install and switch between Miden toolchain channels — VM, compiler, client, stdlib, kernel — from a unified `miden` command.
+  </Card>
   <Card title="Playground" href="./playground" eyebrow="Browser">
     Interactive environment for writing and testing Miden Assembly programs.
   </Card>

--- a/versioned_docs/version-0.14/builder/tools/midenup.md
+++ b/versioned_docs/version-0.14/builder/tools/midenup.md
@@ -1,0 +1,116 @@
+---
+title: midenup
+sidebar_position: 2
+description: "The Miden toolchain installer — bootstrap, pin, and switch between Miden VM / compiler / client / stdlib toolchains from a single `miden` entry point."
+---
+
+# midenup
+
+`midenup` is the Miden toolchain installer. One install gives you a unified `miden` command that delegates to the Miden VM, compiler (`midenc` + `cargo-miden`), client, stdlib, and transaction kernel — all versioned together as a single release channel.
+
+<CardGrid cols={2}>
+  <Card title="midenup on GitHub ↗" href="https://github.com/0xMiden/midenup" eyebrow="Source · Installer">
+    The installer repo. Tracks the canonical channel manifest and publishes prebuilt toolchain releases.
+  </Card>
+  <Card title="Channel manifest ↗" href="https://0xmiden.github.io/midenup/channel-manifest.json" eyebrow="JSON">
+    Machine-readable inventory of available toolchain channels and the component versions each one pins.
+  </Card>
+</CardGrid>
+
+## Install
+
+```bash title=">_ Install midenup"
+cargo install midenup && midenup init
+```
+
+`midenup init` sets up `$MIDENUP_HOME`, writes a `miden` symlink into `$CARGO_HOME/bin`, and prepares the toolchain cache. Since most Rust users already have `$CARGO_HOME/bin` on their PATH, the `miden` command is ready immediately.
+
+<Callout variant="tip" title="Check it worked">
+Run `miden --version`. If you see "command not found," add `$CARGO_HOME/bin` (default `~/.cargo/bin`) to your PATH and re-open the shell.
+</Callout>
+
+## Components it manages
+
+<CardGrid cols={3}>
+  <Card title="Miden VM" eyebrow="Execution">
+    The MASM interpreter, prover, and verifier. Used by every Miden program.
+  </Card>
+  <Card title="Compiler" eyebrow="Rust → MASM">
+    `midenc` and `cargo-miden` — the Rust frontend that compiles `#[miden]` code to MASM.
+  </Card>
+  <Card title="Miden client" eyebrow="SDK + CLI">
+    `miden-client` — accounts, transactions, notes, proving.
+  </Card>
+  <Card title="Standard library" eyebrow="MASM stdlib">
+    `miden-stdlib` — the canonical MASM standard library.
+  </Card>
+  <Card title="Transaction kernel" eyebrow="Kernel library">
+    `miden-base` — the transaction kernel that runs inside every account and note script.
+  </Card>
+  <Card title="(more coming)" eyebrow="Roadmap">
+    Additional Miden components will be added to `midenup` as they ship.
+  </Card>
+</CardGrid>
+
+## Toolchain management
+
+### Install a channel
+
+```bash
+midenup install stable        # latest matching component set
+midenup install 0.14          # pin to a specific release line
+```
+
+### Switch the active toolchain
+
+```bash
+midenup set 0.14              # pin for the current project (writes miden-toolchain.toml)
+midenup override 0.14         # set the system-wide default
+midenup show active-toolchain # which one is active right now?
+```
+
+A `miden-toolchain.toml` in the current directory always wins — otherwise the system default applies, falling back to `stable` if none is set.
+
+### Uninstall
+
+```bash
+midenup uninstall 0.14
+```
+
+Delete `$MIDENUP_HOME` to uninstall `midenup` itself. Find its location with `midenup show home`.
+
+<Callout variant="warning" title="Don't delete toolchain dirs by hand">
+Removing toolchain directories manually corrupts the `midenup` environment. Use `midenup uninstall` so the installer updates its bookkeeping.
+</Callout>
+
+## The `miden` entry point
+
+`miden` delegates to the right component based on the subcommand. Common aliases:
+
+| `miden` command | Delegates to | What it does |
+| --- | --- | --- |
+| `miden new` | `cargo miden new` | Create a new Miden Rust project |
+| `miden build` | `cargo miden build` | Build the project |
+| `miden new-wallet` | `miden-client new-wallet --deploy` | Create and deploy a wallet account |
+| `miden account` | `miden-client account` | Create or inspect a local account |
+| `miden faucet` | `miden-client mint` | Fund an account from the faucet |
+| `miden deploy` | `miden-client -s public --account-type regular-account-immutable-code` | Deploy a public, immutable-code contract |
+| `miden call` | `miden-client account --show` | Read state from an account (view) |
+| `miden send` | `miden-client send` | Send a state-changing transaction |
+| `miden simulate` | `miden-client exec` | Dry-run a transaction without committing |
+
+Everything outside the alias table is forwarded to the underlying binary — e.g., `miden exec …` goes straight through to `miden-client exec`.
+
+## Related
+
+<CardGrid cols={3}>
+  <Card title="Installation" href="../get-started/setup/installation" eyebrow="Get started">
+    Full environment setup — prerequisites, node install, first account.
+  </Card>
+  <Card title="CLI basics" href="../get-started/setup/cli-basics" eyebrow="Commands">
+    Walk through `miden account`, `miden send`, `miden faucet`, and the rest.
+  </Card>
+  <Card title="Network" href="./network" eyebrow="Testnet · Services">
+    Endpoints the `miden` CLI points at — RPC, faucet, remote prover, block explorer.
+  </Card>
+</CardGrid>

--- a/versioned_docs/version-0.14/builder/tools/midenup.md
+++ b/versioned_docs/version-0.14/builder/tools/midenup.md
@@ -1,5 +1,6 @@
 ---
 title: midenup
+sidebar_label: Midenup
 sidebar_position: 2
 description: "The Miden toolchain installer — bootstrap, pin, and switch between Miden VM / compiler / client / stdlib toolchains from a single `miden` entry point."
 ---

--- a/versioned_sidebars/version-0.14-sidebars.json
+++ b/versioned_sidebars/version-0.14-sidebars.json
@@ -270,6 +270,7 @@
             }
           ]
         },
+        "builder/tools/midenup",
         "builder/tools/playground",
         "builder/tools/network"
       ]


### PR DESCRIPTION
## Summary

Two small post-v0.14-cut updates.

### 1. New midenup toolchain page
midenup has been a real part of the ecosystem for a while (`cargo install midenup && midenup init` → unified \`miden\` entry point delegating to VM, midenc, cargo-miden, client, stdlib, transaction kernel), but docs.miden.xyz only referenced it in passing from installation/node-setup. Add a dedicated page at `/builder/tools/midenup`:

- Install (`cargo install midenup && midenup init`)
- Components it manages
- Toolchain management — install / set / override / show / uninstall
- The `miden` entry-point alias table (`miden new`, `miden build`, `miden faucet`, `miden send`, `miden simulate`, …)
- Cross-links to Installation, CLI basics, Network

Surfaced on the Tools landing — bumped the Environments CardGrid to `cols={3}` so midenup sits alongside Playground and Network.

Mirrored into `versioned_docs/version-0.14/` + `versioned_sidebars/` so the default (root = v0.14) routes show it too — midenup predates v0.14, no reason to hide it from the current snapshot.

### 2. Flip tutorials ingest back to main
[`0xMiden/tutorials#186`](https://github.com/0xMiden/tutorials/pull/186) merged upstream at 2026-04-23 10:11 UTC (merge commit [`71cc533`](https://github.com/0xMiden/tutorials/commit/71cc533de53191cb48cc925144cd0f7a75dd966a)). The PR branch (`kbg/chore/v14-migration`) we pinned in PR #256 is now superseded by `main` — the merged state is identical.

- `.release/release-manifest.yml`: `tutorials: refs/pull/186/head → refs/heads/main`
- `.github/workflows/deploy-docs.yml`: `DEFAULT_TUTORIALS_REF: kbg/chore/v14-migration → main`

## Verification

Local `npm run build` with tutorials freshly re-cloned from `main` (merge commit 71cc533) and all other vendors on `next` (matches deploy-docs.yml CI state):

```
exit: 0
[SUCCESS] Generated static files in \"build\".
broken-link count: 10  (same as post-PR-256, no regressions)
```

Both `/builder/tools/midenup/` (default = v0.14) and `/next/builder/tools/midenup/` build successfully.

## Test plan

- [ ] Deploy workflow on `main` post-merge exits green.
- [ ] `docs.miden.xyz/builder/tools/midenup` renders the new page.
- [ ] `docs.miden.xyz/builder/tools/` Environments grid shows 3 cards (midenup / Playground / Network).
- [ ] Navbar sidebar under Tools has midenup as a leaf item between Clients and Playground.
- [ ] `docs.miden.xyz/next/builder/tutorials/recipes/web/setup_guide` still resolves (content comes from tutorials main, which now contains PR #186).