### PR TITLE
docs(tools): fix Playground URL — .io → .xyz

### DIFF
--- a/docs/builder/tools/playground.md
+++ b/docs/builder/tools/playground.md
@@ -9,7 +9,7 @@ description: "Browser-based environment to write, compile, and execute Miden Ass
 An interactive browser environment for writing, compiling, and executing Miden Assembly (MASM) programs. No installation required — prototype account code, test note scripts, and experiment with VM instructions straight from a URL.
 
 <CardGrid cols={2}>
-  <Card title="Open the Playground ↗" href="https://playground.miden.io/" eyebrow="External · playground.miden.io">
+  <Card title="Open the Playground ↗" href="https://playground.miden.xyz/" eyebrow="External · playground.miden.xyz">
     Launch the browser IDE and start writing MASM immediately.
   </Card>
   <Card title="Miden VM reference" href="/core-concepts" eyebrow="Reference · MASM">

--- a/versioned_docs/version-0.14/builder/tools/playground.md
+++ b/versioned_docs/version-0.14/builder/tools/playground.md
@@ -9,7 +9,7 @@ description: "Browser-based environment to write, compile, and execute Miden Ass
 An interactive browser environment for writing, compiling, and executing Miden Assembly (MASM) programs. No installation required — prototype account code, test note scripts, and experiment with VM instructions straight from a URL.
 
 <CardGrid cols={2}>
-  <Card title="Open the Playground ↗" href="https://playground.miden.io/" eyebrow="External · playground.miden.io">
+  <Card title="Open the Playground ↗" href="https://playground.miden.xyz/" eyebrow="External · playground.miden.xyz">
     Launch the browser IDE and start writing MASM immediately.
   </Card>
   <Card title="Miden VM reference" href="/core-concepts" eyebrow="Reference · MASM">


### PR DESCRIPTION
## Summary

The Playground card on `/builder/tools/playground` linked to `https://playground.miden.io/`, but the live deployment is at `https://playground.miden.xyz/`. Same fix in both the current docs and the v0.14 snapshot:

- `docs/builder/tools/playground.md` — Card `href` + eyebrow caption
- `versioned_docs/version-0.14/builder/tools/playground.md` — same

No other references in the tree (verified via grep across `docs/`, `versioned_docs/`, `src/`, `docusaurus.config.ts`).

## Test plan

- [ ] After deploy, click the "Open the Playground" card on `/builder/tools/playground` — should land on `playground.miden.xyz`.
- [ ] Same on `/v0.14/builder/tools/playground`.