### PR TITLE
docs: fix typo, update docker compose syntax, and correct midenup install command

### DIFF
--- a/docs/builder/faq.md
+++ b/docs/builder/faq.md
@@ -92,7 +92,7 @@ A Miden operator is an entity that maintains the infrastructure necessary for th
 4. Maintaining Data Availability
 5. Participating in the Consensus Mechanism
 
-## How does bridging works in Miden?
+## How does bridging work in Miden?
 
 Miden does not yet have a fully operational bridge, work in progress.
 

--- a/docs/builder/get-started/setup/installation.md
+++ b/docs/builder/get-started/setup/installation.md
@@ -85,12 +85,8 @@ v22.x.x  # or higher
 The Miden toolchain installer makes it easy to manage Miden components:
 
 ```bash title=">_ Terminal"
-cargo install midenup
+cargo install --git https://github.com/0xMiden/midenup.git
 ```
-
-:::info
-Until published to crates.io, install using: `cargo install --git https://github.com/0xMiden/midenup.git`
-:::
 
 **Initialize midenup**
 

--- a/docs/builder/miden-guardian/operator-guide/running.md
+++ b/docs/builder/miden-guardian/operator-guide/running.md
@@ -19,7 +19,7 @@ The repository includes a Docker Compose configuration with PostgreSQL:
 ```bash
 git clone https://github.com/OpenZeppelin/guardian.git
 cd guardian
-docker-compose up -d
+docker compose up -d
 ```
 
 This starts:
@@ -33,13 +33,13 @@ This starts:
 View logs:
 
 ```bash
-docker-compose logs -f
+docker compose logs -f
 ```
 
 Stop services:
 
 ```bash
-docker-compose down
+docker compose down
 ```
 
 ## Building from source


### PR DESCRIPTION
## Summary

Three small documentation fixes:

### 1. `docs/builder/faq.md`
Grammar fix: "How does bridging works in Miden?" → "How does bridging work in Miden?"

### 2. `docs/builder/miden-guardian/operator-guide/running.md`
Updated 3 instances of `docker-compose` (deprecated) to `docker compose` (current Docker CLI plugin syntax).

### 3. `docs/builder/get-started/setup/installation.md`
Fixed contradictory installation instructions for `midenup`. The primary command was `cargo install midenup`, which silently fails because `midenup` is not yet published on crates.io. The correct git URL was buried in an `:::info` note.

Updated the primary command to use the git URL directly and removed the now-redundant note.

## Changes
- 3 files changed
- `docs/builder/faq.md`
- `docs/builder/miden-guardian/operator-guide/running.md`
- `docs/builder/get-started/setup/installation.md`