### PR TITLE
fix(deploy): handle protocol/standards split layout from 0xMiden/protocol

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -146,7 +146,7 @@ jobs:
           echo "Aggregating vendor docs into v0.4 IA structure..."
 
           # Clean directories that will be re-synced (v0.4 nested paths)
-          rm -rf docs/core-concepts/protocol docs/core-concepts/miden-vm docs/core-concepts/node docs/core-concepts/compiler
+          rm -rf docs/core-concepts/protocol docs/core-concepts/standards docs/core-concepts/miden-vm docs/core-concepts/node docs/core-concepts/compiler
           # tools/clients: only clean ingested subdirs; preserve locally-authored web-client/, react-sdk/, index.md
           rm -rf docs/builder/tools/clients/rust-client
           rm -rf docs/builder/tools/clients/img
@@ -169,10 +169,24 @@ jobs:
           rm -rf docs/builder/tutorials/recipes/img
 
           # Core Concepts docs → docs/core-concepts/*
-          if [ -d "vendor/protocol/docs/src" ]; then
+          # 0xMiden/protocol switched its docs/src layout to a split:
+          #   docs/src/protocol/   → docs/core-concepts/protocol/
+          #   docs/src/standards/  → docs/core-concepts/standards/
+          # Released versions (e.g. v0.14.x) still ship the flat layout, so
+          # fall back to the legacy ingest if no protocol/ subdir is present.
+          if [ -d "vendor/protocol/docs/src/protocol" ]; then
+            mkdir -p docs/core-concepts/protocol
+            cp -r vendor/protocol/docs/src/protocol/. docs/core-concepts/protocol/
+            echo "Synced protocol → docs/core-concepts/protocol"
+            if [ -d "vendor/protocol/docs/src/standards" ]; then
+              mkdir -p docs/core-concepts/standards
+              cp -r vendor/protocol/docs/src/standards/. docs/core-concepts/standards/
+              echo "Synced standards → docs/core-concepts/standards"
+            fi
+          elif [ -d "vendor/protocol/docs/src" ]; then
             mkdir -p docs/core-concepts/protocol
             cp -r vendor/protocol/docs/src/* docs/core-concepts/protocol/
-            echo "Synced protocol → docs/core-concepts/protocol"
+            echo "Synced protocol (legacy flat layout) → docs/core-concepts/protocol"
           fi
 
           if [ -d "vendor/miden-vm/docs/src" ]; then


### PR DESCRIPTION
## Summary

Companion to [0xMiden/protocol#2835](https://github.com/0xMiden/protocol/pull/2835), which reorganises `docs/src/*` into `docs/src/protocol/` and `docs/src/standards/` subfolders.

Once that PR lands on `next`, the current ingest

```bash
cp -r vendor/protocol/docs/src/* docs/core-concepts/protocol/
```

would produce double-nested paths like `/core-concepts/protocol/protocol/` and would not pick up the new standards section at all.

This PR detects the new layout by checking for `vendor/protocol/docs/src/protocol/` and copies each subdir to its own destination under `docs/core-concepts/`. The legacy flat-copy is preserved as a fallback so versioned builds against older refs (e.g. `v0.14.x`) keep working unchanged.

## What changes

- New layout (`next` after #2835): `docs/src/protocol/` → `docs/core-concepts/protocol/`, `docs/src/standards/` → `docs/core-concepts/standards/`.
- Old layout (tagged releases): `docs/src/*` → `docs/core-concepts/protocol/` (unchanged).
- Cleanup step also removes `docs/core-concepts/standards` between runs.

## Test plan

- [ ] Local manual ingestion + Docusaurus dev server reproduces the new IA (commands in the [protocol PR thread](https://github.com/0xMiden/protocol/pull/2835)).
- [ ] After 0xMiden/protocol#2835 merges to `next`, trigger this workflow via `workflow_dispatch` from `main` (default `miden_base_ref=next`) and verify the build succeeds and the new `/core-concepts/standards/` route is reachable.
- [ ] Versioned build for `v0.14.x` still falls through the `elif` legacy branch.

## Merge order

This PR is safe to merge independently of #2835:
- If merged first, the workflow keeps using the legacy branch until `vendor/protocol/docs/src/protocol/` exists on the resolved ref.
- If merged second, no production deploys break in between because the deploy workflow only runs from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)