### PR TITLE
docs(guardian): rewrite operator-guide pages with code-grounded reference data

### DIFF
--- a/docs/builder/miden-guardian/operator-guide/deployment.md
+++ b/docs/builder/miden-guardian/operator-guide/deployment.md
@@ -3,95 +3,87 @@ title: Deployment
 sidebar_position: 2
 ---
 
-# How to Deploy
+# Deploying Miden Guardian
 
-This page covers Guardian server configuration for production deployments.
+The repository deploy script provisions and updates the AWS infrastructure used by the reference Guardian deployment. Operators on other platforms can run the same server binary with the same environment variables — adapt the surrounding services to taste.
+
+The reference AWS deployment uses:
+
+- ECS / Fargate
+- Application Load Balancer
+- RDS Postgres
+- Secrets Manager (env vars + ack keys)
+- ECR for container images
+- CloudWatch for logs
+
+## AWS deploy script
+
+```bash
+DEPLOY_STAGE=dev \
+GUARDIAN_NETWORK_TYPE=MidenTestnet \
+./scripts/aws-deploy.sh deploy
+```
+
+```bash
+DEPLOY_STAGE=dev ./scripts/aws-deploy.sh status
+DEPLOY_STAGE=dev ./scripts/aws-deploy.sh logs
+```
+
+Before serving production traffic, bootstrap the acknowledgement keys:
+
+```bash
+DEPLOY_STAGE=prod ./scripts/aws-deploy.sh bootstrap-ack-keys
+```
+
+`bootstrap-ack-keys` runs the `ack-keygen` binary to generate fresh Falcon and ECDSA secret keys, then writes them to AWS Secrets Manager as `guardian-prod/server/ack-falcon-secret-key` and `guardian-prod/server/ack-ecdsa-secret-key`. It refuses to overwrite either secret if it already exists, so re-running on a deployed environment is safe.
 
 ## Environment variables
 
-| Variable | Default | Description |
-|---|---|---|
-| `DATABASE_URL` | — | PostgreSQL connection URL (required for Postgres backend) |
-| `PSM_KEYSTORE_PATH` | `/var/psm/keystore` | Path for cryptographic key storage |
-| `PSM_STORAGE_PATH` | — | Storage backend path (states and deltas) |
-| `PSM_METADATA_PATH` | — | Metadata store path |
-| `PSM_ENV` | `dev` | Environment mode |
-| `RUST_LOG` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
+### Core
 
-### Rate limiting
+| Var                       | Default                                                          | Notes                                                                                                       |
+| ------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `GUARDIAN_NETWORK_TYPE`   | `MidenDevnet` (binary) · `MidenTestnet` (deploy script)          | Set explicitly for production.                                                                              |
+| `GUARDIAN_ENV`            | unset                                                            | When `prod`, ack keys are loaded from AWS Secrets Manager; otherwise from the filesystem keystore.          |
+| `AWS_REGION`              | `us-east-1` (deploy script)                                      | Required at runtime when `GUARDIAN_ENV=prod`.                                                               |
+| `DATABASE_URL`            | none                                                             | Required for Postgres builds. Server panics on startup if missing.                                          |
+| `GUARDIAN_STORAGE_PATH`   | `/var/guardian/storage`                                          | Filesystem-mode account state.                                                                              |
+| `GUARDIAN_METADATA_PATH`  | `/var/guardian/metadata`                                         | Filesystem-mode metadata (auth timestamps, proposals).                                                      |
+| `GUARDIAN_KEYSTORE_PATH`  | `/var/guardian/keystore`                                         | Filesystem-mode key material when `GUARDIAN_ENV` ≠ `prod`.                                                  |
+| `RUST_LOG`                | `info` is a sensible baseline                                    | Standard `tracing-subscriber` filter syntax.                                                                |
 
-| Variable | Default | Description |
-|---|---|---|
-| `PSM_RATE_BURST_PER_SEC` | `10` | Max requests per second (burst) |
-| `PSM_RATE_PER_MIN` | `60` | Max requests per minute (sustained) |
+Filesystem storage is the default local backend; the `postgres` feature with a valid `DATABASE_URL` switches the storage and metadata stores to Postgres.
 
-Rate limits are applied per client IP, with enhanced keying when `x-pubkey` or `account_id` is present. Exceeded limits return `429 Too Many Requests` with a `Retry-After` header.
+### Limits and rate-limiting
 
-### Request size limits
+| Var                                          | Default     | AWS prod override |
+| -------------------------------------------- | ----------- | ----------------- |
+| `GUARDIAN_RATE_LIMIT_ENABLED`                | `true`      | —                 |
+| `GUARDIAN_RATE_BURST_PER_SEC`                | `10`        | `200`             |
+| `GUARDIAN_RATE_PER_MIN`                      | `60`        | `5000`            |
+| `GUARDIAN_MAX_REQUEST_BYTES`                 | `1048576`   | —                 |
+| `GUARDIAN_MAX_PENDING_PROPOSALS_PER_ACCOUNT` | `20`        | —                 |
+| `GUARDIAN_DB_POOL_MAX_SIZE`                  | `16`        | `32`              |
+| `GUARDIAN_METADATA_DB_POOL_MAX_SIZE`         | (matches storage pool) | —      |
 
-| Variable | Default | Description |
-|---|---|---|
-| `PSM_MAX_REQUEST_BYTES` | `1048576` (1 MB) | Maximum request body size |
+Rate limiting is on by default; pass `0`, `false`, `no`, or `off` to `GUARDIAN_RATE_LIMIT_ENABLED` to disable. Invalid values for `GUARDIAN_MAX_REQUEST_BYTES` are silently ignored — the default is used.
 
-Requests exceeding this limit receive `413 Payload Too Large`.
+### Operator allowlist + CORS
 
-## Storage backends
+| Var                                       | Notes                                                                                                              |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `GUARDIAN_OPERATOR_PUBLIC_KEYS_SECRET_ID` | AWS Secrets Manager secret ID containing the allowlist; requires `AWS_REGION`. Set automatically by the AWS Terraform. |
+| `GUARDIAN_OPERATOR_PUBLIC_KEYS_FILE`      | Filesystem alternative when not on AWS.                                                                            |
+| `GUARDIAN_CORS_ALLOWED_ORIGINS`           | Comma-separated origin list. Unset = allow any origin without credentials. Wildcard `*` is rejected when credentialed origins are configured. |
 
-Guardian uses a single storage backend per instance.
+## Canonicalization
 
-### Filesystem (default)
-
-Stores state and deltas on disk. No external dependencies. Used when the binary is built without the `postgres` feature.
-
-Ensure `PSM_STORAGE_PATH` points to a writable directory with sufficient disk space.
-
-### PostgreSQL (optional)
-
-Requires the `postgres` feature flag at build time. Migrations run automatically on startup.
-
-```bash
-DATABASE_URL=postgres://psm:password@localhost:5432/psm \
-  cargo run --features postgres --package guardian-server
-```
-
-## Metadata store
-
-The metadata store can be configured independently from the storage backend. It supports both filesystem and PostgreSQL backends.
-
-Ensure `PSM_METADATA_PATH` points to a writable directory (filesystem mode) or configure `DATABASE_URL` (Postgres mode).
-
-## Logging
-
-The server uses structured logging via the `tracing` crate.
-
-```bash
-# Debug level for entire server
-RUST_LOG=debug cargo run --package guardian-server
-
-# Trace only canonicalization jobs
-RUST_LOG=server::jobs::canonicalization=trace cargo run
-
-# Multiple modules
-RUST_LOG=server::jobs=debug,server::services=info cargo run
-```
-
-## Canonicalization configuration
-
-When canonicalization is enabled (default), configure the verification window:
-
-| Parameter | Default | Description |
-|---|---|---|
-| `delay_seconds` | 900 (15 min) | How long a candidate waits before verification |
-| `check_interval_seconds` | 60 (1 min) | How often the canonicalization worker runs |
-
-Set to **optimistic mode** to skip the verification window and mark deltas canonical immediately.
+The server runs a canonicalization pass every **10 seconds** with a **10-minute** submission grace period. Both values are hard-coded in `crates/server/src/main.rs` and are **not** configurable via environment variable — embedders that need different timing must call the builder API in code.
 
 ## Reproducible builds
 
-The server binary supports reproducible builds. Building from the same source code and target architecture produces bit-for-bit identical binaries:
-
 ```bash
-./crates/server/tests/verify-build-hash.sh
+./crates/server/verify-build-hash.sh
 ```
 
-This is useful for verifying published binaries match the source code.
+The script must run inside a git checkout of the repo with a `Dockerfile` at the root. It builds the server image, copies the resulting `/app/server` binary out, and prints its SHA256, size, and the source commit. Uncommitted local changes produce a warning but do not fail the script.

--- a/docs/builder/miden-guardian/operator-guide/running.md
+++ b/docs/builder/miden-guardian/operator-guide/running.md
@@ -3,84 +3,93 @@ title: Running
 sidebar_position: 1
 ---
 
-# How to Run
+# Running Miden Guardian
 
-This guide covers running a Guardian server locally for development or testing.
+Miden Guardian exposes:
 
-## Prerequisites
+- HTTP API on port `3000`
+- gRPC API on port `50051`
 
-- [Docker](https://docs.docker.com/get-docker/) and Docker Compose (recommended), or
-- Rust toolchain 1.90+ (to build from source)
+Both ports are hard-coded in the server binary and are not currently overridable via environment variable. Embedders calling the builder API directly can configure them in code.
 
-## Docker Compose (recommended)
-
-The repository includes a Docker Compose configuration with PostgreSQL:
+## Run with Docker Compose
 
 ```bash
-git clone https://github.com/OpenZeppelin/guardian.git
-cd guardian
-docker-compose up -d
+docker compose up --build -d
 ```
 
-This starts:
-
-| Service | Port | Description |
-|---|---|---|
-| Guardian HTTP API | `localhost:3000` | REST endpoints |
-| Guardian gRPC API | `localhost:50051` | gRPC service |
-| PostgreSQL | `localhost:5432` | Metadata and state storage |
-
-View logs:
-
-```bash
-docker-compose logs -f
-```
-
-Stop services:
-
-```bash
-docker-compose down
-```
-
-## Building from source
-
-```bash
-git clone https://github.com/OpenZeppelin/guardian.git
-cd guardian
-
-# With filesystem storage (default)
-cargo build --release --bin server
-cargo run --release --bin server
-
-# With PostgreSQL storage
-DATABASE_URL=postgres://psm:password@localhost:5432/psm \
-  cargo run --features postgres --package guardian-server
-```
-
-## Ports
-
-| Protocol | Default Port | Description |
-|---|---|---|
-| HTTP | `3000` | REST API |
-| gRPC | `50051` | gRPC service |
-
-Both can be configured programmatically via the `ServerBuilder`:
-
-```rust
-use server::builder::ServerBuilder;
-
-let builder = ServerBuilder::new()
-    .http(true, 3000)
-    .grpc(true, 50051);
-```
-
-## Verifying the server
-
-Once running, check the server's acknowledgment public key:
+Confirm the server is up by fetching its public key:
 
 ```bash
 curl http://localhost:3000/pubkey
-# Returns: { "pubkey": "0x..." }
 ```
 
-This endpoint is unauthenticated and confirms the server is operational.
+Expected shape:
+
+```json
+{ "commitment": "0x..." }
+```
+
+`/pubkey` is unauthenticated and is the canonical "is the server up + which key am I trusting" probe. Pass `?scheme=ecdsa` to also receive the ECDSA public key:
+
+```bash
+curl 'http://localhost:3000/pubkey?scheme=ecdsa'
+```
+
+```json
+{ "commitment": "0x...", "pubkey": "0x..." }
+```
+
+Stop the server:
+
+```bash
+docker compose down
+```
+
+## Run from source
+
+Requirements:
+
+- Rust `1.93+`
+- Docker, if using local Postgres
+
+Filesystem storage is the default local mode. The three paths are independent — there is no single root-path override:
+
+```bash
+mkdir -p /tmp/guardian/storage /tmp/guardian/metadata /tmp/guardian/keystore
+
+GUARDIAN_STORAGE_PATH=/tmp/guardian/storage \
+GUARDIAN_METADATA_PATH=/tmp/guardian/metadata \
+GUARDIAN_KEYSTORE_PATH=/tmp/guardian/keystore \
+cargo run -p guardian-server --bin server
+```
+
+If those env vars are omitted, the server falls back to `/var/guardian/storage`, `/var/guardian/metadata`, and `/var/guardian/keystore` respectively.
+
+Run with local Postgres (requires the `postgres` feature):
+
+```bash
+docker compose -f docker-compose.postgres.yml up -d
+
+DATABASE_URL=postgres://guardian:guardian_dev_password@localhost:5432/guardian \
+cargo run -p guardian-server --features postgres --bin server
+```
+
+## HTTP API surface
+
+| Endpoint                      | Auth              |
+| ----------------------------- | ----------------- |
+| `GET /`                       | Unauthenticated   |
+| `GET /pubkey`                 | Unauthenticated   |
+| `POST /configure`             | Signed headers    |
+| `POST /delta`                 | Signed headers    |
+| `GET /delta`                  | Signed headers    |
+| `GET /delta/since`            | Signed headers    |
+| `GET /state`                  | Signed headers    |
+| `POST /delta/proposal`        | Signed headers    |
+| `GET /delta/proposal`         | Signed headers    |
+| `GET /delta/proposal/single`  | Signed headers    |
+| `PUT /delta/proposal`         | Signed headers    |
+| `/dashboard/accounts*`        | Dashboard session |
+
+Signed requests carry three headers: `x-pubkey`, `x-signature`, and `x-timestamp`. Timestamps must be within ±5 minutes of server time and strictly greater than the last value the server saw for that public key — see [Authentication failures](./troubleshooting#authentication-failures) if requests are being rejected.

--- a/docs/builder/miden-guardian/operator-guide/troubleshooting.md
+++ b/docs/builder/miden-guardian/operator-guide/troubleshooting.md
@@ -3,72 +3,71 @@ title: Troubleshooting
 sidebar_position: 3
 ---
 
-# Troubleshooting
+# Troubleshooting Miden Guardian
 
-Common issues when operating a Guardian server and how to resolve them.
+## Server does not start
 
-## Server won't start
+Check that storage paths are writable:
 
-**Symptom**: Server exits immediately or fails to bind ports.
+```bash
+ls -ld /var/guardian/storage /var/guardian/metadata /var/guardian/keystore
+```
 
-- Check that ports 3000 (HTTP) and 50051 (gRPC) are not already in use.
-- If using Postgres, ensure `DATABASE_URL` is set and the database is reachable.
-- Check logs with `RUST_LOG=debug` for detailed error messages.
+For Postgres mode, confirm `DATABASE_URL` is set and reachable. The server panics on startup if it's missing.
 
-## Acknowledgment key mismatch
+## Public key changed unexpectedly
 
-**Symptom**: Clients report `ack_sig` verification failures.
+The Guardian key is loaded from the configured keystore path. Confirm the same `GUARDIAN_KEYSTORE_PATH` is used across restarts.
 
-- Verify the server's public key via `GET /pubkey` and compare with what clients expect.
-- If the keystore was regenerated (new `PSM_KEYSTORE_PATH`), clients need to re-fetch the server's public key.
-- Ensure `PSM_KEYSTORE_PATH` is persistent across restarts — a new key on every restart will break client verification.
+For production AWS deployments, confirm `GUARDIAN_ENV=prod` and `AWS_REGION` are set so acknowledgement keys are loaded from Secrets Manager rather than the filesystem.
 
 ## Authentication failures
 
-**Symptom**: Requests return `400 AuthenticationFailed`.
+Guardian requires signed requests. Each carries three headers — `x-pubkey`, `x-signature`, and `x-timestamp` — and the timestamp is validated against two rules:
 
-- **Clock skew**: Client timestamp must be within 300 seconds of the server's time. Ensure NTP synchronization.
-- **Replay rejection**: Each request's timestamp must be strictly greater than the account's `last_auth_timestamp`. Rapid-fire requests with the same timestamp will fail.
-- **Wrong key**: The `x-pubkey` commitment must be in the account's cosigner allowlist. Verify the account's auth configuration.
+- It must be within ±5 minutes of server time (`MAX_TIMESTAMP_SKEW_MS = 300_000`).
+- It must be **strictly greater** than the last timestamp the server saw for that public key. The metadata store enforces this with a CAS update; a request with a timestamp equal to or below the previous one is rejected even if otherwise valid.
 
-## Deltas stuck as candidates
+Common causes:
 
-**Symptom**: Deltas remain in `candidate` status and never become `canonical`.
+- Client clock is more than 5 minutes from server time.
+- Timestamp was reused (replay attempt or accidental retry without re-signing).
+- Request body changed after signing.
+- Client is using the wrong Guardian public key — re-fetch `/pubkey`.
 
-- Check that the canonicalization worker is running (default: checks every 60 seconds).
-- Deltas must wait at least `delay_seconds` (default: 15 minutes) before the worker processes them.
-- If the on-chain commitment doesn't match, deltas are `discarded`. Check that the transaction was actually submitted and confirmed on-chain.
-- Inspect canonicalization logs: `RUST_LOG=server::jobs::canonicalization=debug`
+## Proposal stays pending
 
-## Storage and metadata path issues
+```bash
+DEPLOY_STAGE=dev ./scripts/aws-deploy.sh logs
+```
 
-**Symptom**: Server returns errors on state or delta operations.
+Common causes:
 
-- Ensure `PSM_STORAGE_PATH` and `PSM_METADATA_PATH` point to writable directories.
-- For Postgres: verify the connection string and that migrations have run (they run automatically on startup).
-- Check disk space — filesystem storage can grow with the number of accounts and deltas.
+- Account state has not canonicalized yet (the 10-second pass hasn't run).
+- The 10-minute submission grace period has not elapsed.
+- Metadata backend is not writable.
+- The pending-proposal count has hit `GUARDIAN_MAX_PENDING_PROPOSALS_PER_ACCOUNT` (default `20`); see [error code `pending_proposals_limit`](#common-error-codes).
 
-## Rate limiting
+## Rate limit errors
 
-**Symptom**: Clients receive `429 Too Many Requests`.
+If requests are rejected under load, tune:
 
-- Default limits: 10 requests/second (burst), 60 requests/minute (sustained).
-- Adjust via `PSM_RATE_BURST_PER_SEC` and `PSM_RATE_PER_MIN` environment variables.
-- The `Retry-After` header in the response indicates how long to wait.
+```bash
+GUARDIAN_RATE_BURST_PER_SEC      # default 10
+GUARDIAN_RATE_PER_MIN            # default 60
+GUARDIAN_MAX_REQUEST_BYTES       # default 1048576
+```
+
+The HTTP rate-limit middleware responds with `429 Too Many Requests` and a `Retry-After` header plus `retry_after_secs` in the body. **Note:** these middleware-level rejections do not include a `code` field — only the Guardian application-level `rate_limit_exceeded` error does. See the table below.
 
 ## Common error codes
 
-| Error | Meaning |
-|---|---|
-| `AccountNotFound` | No account configured with this ID |
-| `AuthenticationFailed` | Invalid signature, unknown key, or expired timestamp |
-| `InvalidDelta` | Delta fails validation against current state or network |
-| `CommitmentMismatch` | Delta's `prev_commitment` doesn't match current state |
-| `ConflictPendingDelta` | Another candidate delta is already pending for this account |
-| `TimestampExpired` | Request timestamp is outside the 300-second window |
-| `TimestampReplay` | Request timestamp is not greater than last accepted timestamp |
+The server emits structured error codes via `GuardianError::code()`. The most common ones operators will hit:
 
-## Links
-
-- [Server README](https://github.com/OpenZeppelin/guardian/tree/main/crates/server) — full server documentation
-- [Guardian Specification](https://github.com/OpenZeppelin/guardian/tree/main/spec) — protocol specification
+| Code                    | What it means                                                                                                         | First thing to check                                                                                |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `authentication_failed` | Auth headers missing or malformed, clock skew > 5 min, signature invalid, or the timestamp was already used.          | `x-pubkey` / `x-signature` / `x-timestamp` headers; client clock sync; the last timestamp you sent. |
+| `account_not_found`     | The metadata store has no record for that account ID.                                                                 | Account ID is correct and `/configure` actually completed against this server.                      |
+| `invalid_input`         | Generic 400 — request JSON, query parameters, or commitment shape failed validation.                                  | Request payload schema; commitment hex format.                                                      |
+| `rate_limit_exceeded`   | Application-level rate limit hit. (The HTTP middleware also emits `429` responses, but those have no `code` field.)   | Tune `GUARDIAN_RATE_BURST_PER_SEC` / `GUARDIAN_RATE_PER_MIN`; check `Retry-After` on the response.  |
+| `storage_error`         | The storage or metadata backend rejected an operation.                                                                | Filesystem permissions on the storage paths, or database health for Postgres mode.                  |

--- a/versioned_docs/version-0.14/builder/miden-guardian/operator-guide/deployment.md
+++ b/versioned_docs/version-0.14/builder/miden-guardian/operator-guide/deployment.md
@@ -3,95 +3,87 @@ title: Deployment
 sidebar_position: 2
 ---
 
-# How to Deploy
+# Deploying Miden Guardian
 
-This page covers Guardian server configuration for production deployments.
+The repository deploy script provisions and updates the AWS infrastructure used by the reference Guardian deployment. Operators on other platforms can run the same server binary with the same environment variables — adapt the surrounding services to taste.
+
+The reference AWS deployment uses:
+
+- ECS / Fargate
+- Application Load Balancer
+- RDS Postgres
+- Secrets Manager (env vars + ack keys)
+- ECR for container images
+- CloudWatch for logs
+
+## AWS deploy script
+
+```bash
+DEPLOY_STAGE=dev \
+GUARDIAN_NETWORK_TYPE=MidenTestnet \
+./scripts/aws-deploy.sh deploy
+```
+
+```bash
+DEPLOY_STAGE=dev ./scripts/aws-deploy.sh status
+DEPLOY_STAGE=dev ./scripts/aws-deploy.sh logs
+```
+
+Before serving production traffic, bootstrap the acknowledgement keys:
+
+```bash
+DEPLOY_STAGE=prod ./scripts/aws-deploy.sh bootstrap-ack-keys
+```
+
+`bootstrap-ack-keys` runs the `ack-keygen` binary to generate fresh Falcon and ECDSA secret keys, then writes them to AWS Secrets Manager as `guardian-prod/server/ack-falcon-secret-key` and `guardian-prod/server/ack-ecdsa-secret-key`. It refuses to overwrite either secret if it already exists, so re-running on a deployed environment is safe.
 
 ## Environment variables
 
-| Variable | Default | Description |
-|---|---|---|
-| `DATABASE_URL` | — | PostgreSQL connection URL (required for Postgres backend) |
-| `PSM_KEYSTORE_PATH` | `/var/psm/keystore` | Path for cryptographic key storage |
-| `PSM_STORAGE_PATH` | — | Storage backend path (states and deltas) |
-| `PSM_METADATA_PATH` | — | Metadata store path |
-| `PSM_ENV` | `dev` | Environment mode |
-| `RUST_LOG` | `info` | Log level (`debug`, `info`, `warn`, `error`) |
+### Core
 
-### Rate limiting
+| Var                       | Default                                                          | Notes                                                                                                       |
+| ------------------------- | ---------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `GUARDIAN_NETWORK_TYPE`   | `MidenDevnet` (binary) · `MidenTestnet` (deploy script)          | Set explicitly for production.                                                                              |
+| `GUARDIAN_ENV`            | unset                                                            | When `prod`, ack keys are loaded from AWS Secrets Manager; otherwise from the filesystem keystore.          |
+| `AWS_REGION`              | `us-east-1` (deploy script)                                      | Required at runtime when `GUARDIAN_ENV=prod`.                                                               |
+| `DATABASE_URL`            | none                                                             | Required for Postgres builds. Server panics on startup if missing.                                          |
+| `GUARDIAN_STORAGE_PATH`   | `/var/guardian/storage`                                          | Filesystem-mode account state.                                                                              |
+| `GUARDIAN_METADATA_PATH`  | `/var/guardian/metadata`                                         | Filesystem-mode metadata (auth timestamps, proposals).                                                      |
+| `GUARDIAN_KEYSTORE_PATH`  | `/var/guardian/keystore`                                         | Filesystem-mode key material when `GUARDIAN_ENV` ≠ `prod`.                                                  |
+| `RUST_LOG`                | `info` is a sensible baseline                                    | Standard `tracing-subscriber` filter syntax.                                                                |
 
-| Variable | Default | Description |
-|---|---|---|
-| `PSM_RATE_BURST_PER_SEC` | `10` | Max requests per second (burst) |
-| `PSM_RATE_PER_MIN` | `60` | Max requests per minute (sustained) |
+Filesystem storage is the default local backend; the `postgres` feature with a valid `DATABASE_URL` switches the storage and metadata stores to Postgres.
 
-Rate limits are applied per client IP, with enhanced keying when `x-pubkey` or `account_id` is present. Exceeded limits return `429 Too Many Requests` with a `Retry-After` header.
+### Limits and rate-limiting
 
-### Request size limits
+| Var                                          | Default     | AWS prod override |
+| -------------------------------------------- | ----------- | ----------------- |
+| `GUARDIAN_RATE_LIMIT_ENABLED`                | `true`      | —                 |
+| `GUARDIAN_RATE_BURST_PER_SEC`                | `10`        | `200`             |
+| `GUARDIAN_RATE_PER_MIN`                      | `60`        | `5000`            |
+| `GUARDIAN_MAX_REQUEST_BYTES`                 | `1048576`   | —                 |
+| `GUARDIAN_MAX_PENDING_PROPOSALS_PER_ACCOUNT` | `20`        | —                 |
+| `GUARDIAN_DB_POOL_MAX_SIZE`                  | `16`        | `32`              |
+| `GUARDIAN_METADATA_DB_POOL_MAX_SIZE`         | (matches storage pool) | —      |
 
-| Variable | Default | Description |
-|---|---|---|
-| `PSM_MAX_REQUEST_BYTES` | `1048576` (1 MB) | Maximum request body size |
+Rate limiting is on by default; pass `0`, `false`, `no`, or `off` to `GUARDIAN_RATE_LIMIT_ENABLED` to disable. Invalid values for `GUARDIAN_MAX_REQUEST_BYTES` are silently ignored — the default is used.
 
-Requests exceeding this limit receive `413 Payload Too Large`.
+### Operator allowlist + CORS
 
-## Storage backends
+| Var                                       | Notes                                                                                                              |
+| ----------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `GUARDIAN_OPERATOR_PUBLIC_KEYS_SECRET_ID` | AWS Secrets Manager secret ID containing the allowlist; requires `AWS_REGION`. Set automatically by the AWS Terraform. |
+| `GUARDIAN_OPERATOR_PUBLIC_KEYS_FILE`      | Filesystem alternative when not on AWS.                                                                            |
+| `GUARDIAN_CORS_ALLOWED_ORIGINS`           | Comma-separated origin list. Unset = allow any origin without credentials. Wildcard `*` is rejected when credentialed origins are configured. |
 
-Guardian uses a single storage backend per instance.
+## Canonicalization
 
-### Filesystem (default)
-
-Stores state and deltas on disk. No external dependencies. Used when the binary is built without the `postgres` feature.
-
-Ensure `PSM_STORAGE_PATH` points to a writable directory with sufficient disk space.
-
-### PostgreSQL (optional)
-
-Requires the `postgres` feature flag at build time. Migrations run automatically on startup.
-
-```bash
-DATABASE_URL=postgres://psm:password@localhost:5432/psm \
-  cargo run --features postgres --package guardian-server
-```
-
-## Metadata store
-
-The metadata store can be configured independently from the storage backend. It supports both filesystem and PostgreSQL backends.
-
-Ensure `PSM_METADATA_PATH` points to a writable directory (filesystem mode) or configure `DATABASE_URL` (Postgres mode).
-
-## Logging
-
-The server uses structured logging via the `tracing` crate.
-
-```bash
-# Debug level for entire server
-RUST_LOG=debug cargo run --package guardian-server
-
-# Trace only canonicalization jobs
-RUST_LOG=server::jobs::canonicalization=trace cargo run
-
-# Multiple modules
-RUST_LOG=server::jobs=debug,server::services=info cargo run
-```
-
-## Canonicalization configuration
-
-When canonicalization is enabled (default), configure the verification window:
-
-| Parameter | Default | Description |
-|---|---|---|
-| `delay_seconds` | 900 (15 min) | How long a candidate waits before verification |
-| `check_interval_seconds` | 60 (1 min) | How often the canonicalization worker runs |
-
-Set to **optimistic mode** to skip the verification window and mark deltas canonical immediately.
+The server runs a canonicalization pass every **10 seconds** with a **10-minute** submission grace period. Both values are hard-coded in `crates/server/src/main.rs` and are **not** configurable via environment variable — embedders that need different timing must call the builder API in code.
 
 ## Reproducible builds
 
-The server binary supports reproducible builds. Building from the same source code and target architecture produces bit-for-bit identical binaries:
-
 ```bash
-./crates/server/tests/verify-build-hash.sh
+./crates/server/verify-build-hash.sh
 ```
 
-This is useful for verifying published binaries match the source code.
+The script must run inside a git checkout of the repo with a `Dockerfile` at the root. It builds the server image, copies the resulting `/app/server` binary out, and prints its SHA256, size, and the source commit. Uncommitted local changes produce a warning but do not fail the script.

--- a/versioned_docs/version-0.14/builder/miden-guardian/operator-guide/running.md
+++ b/versioned_docs/version-0.14/builder/miden-guardian/operator-guide/running.md
@@ -3,84 +3,93 @@ title: Running
 sidebar_position: 1
 ---
 
-# How to Run
+# Running Miden Guardian
 
-This guide covers running a Guardian server locally for development or testing.
+Miden Guardian exposes:
 
-## Prerequisites
+- HTTP API on port `3000`
+- gRPC API on port `50051`
 
-- [Docker](https://docs.docker.com/get-docker/) and Docker Compose (recommended), or
-- Rust toolchain 1.90+ (to build from source)
+Both ports are hard-coded in the server binary and are not currently overridable via environment variable. Embedders calling the builder API directly can configure them in code.
 
-## Docker Compose (recommended)
-
-The repository includes a Docker Compose configuration with PostgreSQL:
+## Run with Docker Compose
 
 ```bash
-git clone https://github.com/OpenZeppelin/guardian.git
-cd guardian
-docker-compose up -d
+docker compose up --build -d
 ```
 
-This starts:
-
-| Service | Port | Description |
-|---|---|---|
-| Guardian HTTP API | `localhost:3000` | REST endpoints |
-| Guardian gRPC API | `localhost:50051` | gRPC service |
-| PostgreSQL | `localhost:5432` | Metadata and state storage |
-
-View logs:
-
-```bash
-docker-compose logs -f
-```
-
-Stop services:
-
-```bash
-docker-compose down
-```
-
-## Building from source
-
-```bash
-git clone https://github.com/OpenZeppelin/guardian.git
-cd guardian
-
-# With filesystem storage (default)
-cargo build --release --bin server
-cargo run --release --bin server
-
-# With PostgreSQL storage
-DATABASE_URL=postgres://psm:password@localhost:5432/psm \
-  cargo run --features postgres --package guardian-server
-```
-
-## Ports
-
-| Protocol | Default Port | Description |
-|---|---|---|
-| HTTP | `3000` | REST API |
-| gRPC | `50051` | gRPC service |
-
-Both can be configured programmatically via the `ServerBuilder`:
-
-```rust
-use server::builder::ServerBuilder;
-
-let builder = ServerBuilder::new()
-    .http(true, 3000)
-    .grpc(true, 50051);
-```
-
-## Verifying the server
-
-Once running, check the server's acknowledgment public key:
+Confirm the server is up by fetching its public key:
 
 ```bash
 curl http://localhost:3000/pubkey
-# Returns: { "pubkey": "0x..." }
 ```
 
-This endpoint is unauthenticated and confirms the server is operational.
+Expected shape:
+
+```json
+{ "commitment": "0x..." }
+```
+
+`/pubkey` is unauthenticated and is the canonical "is the server up + which key am I trusting" probe. Pass `?scheme=ecdsa` to also receive the ECDSA public key:
+
+```bash
+curl 'http://localhost:3000/pubkey?scheme=ecdsa'
+```
+
+```json
+{ "commitment": "0x...", "pubkey": "0x..." }
+```
+
+Stop the server:
+
+```bash
+docker compose down
+```
+
+## Run from source
+
+Requirements:
+
+- Rust `1.93+`
+- Docker, if using local Postgres
+
+Filesystem storage is the default local mode. The three paths are independent — there is no single root-path override:
+
+```bash
+mkdir -p /tmp/guardian/storage /tmp/guardian/metadata /tmp/guardian/keystore
+
+GUARDIAN_STORAGE_PATH=/tmp/guardian/storage \
+GUARDIAN_METADATA_PATH=/tmp/guardian/metadata \
+GUARDIAN_KEYSTORE_PATH=/tmp/guardian/keystore \
+cargo run -p guardian-server --bin server
+```
+
+If those env vars are omitted, the server falls back to `/var/guardian/storage`, `/var/guardian/metadata`, and `/var/guardian/keystore` respectively.
+
+Run with local Postgres (requires the `postgres` feature):
+
+```bash
+docker compose -f docker-compose.postgres.yml up -d
+
+DATABASE_URL=postgres://guardian:guardian_dev_password@localhost:5432/guardian \
+cargo run -p guardian-server --features postgres --bin server
+```
+
+## HTTP API surface
+
+| Endpoint                      | Auth              |
+| ----------------------------- | ----------------- |
+| `GET /`                       | Unauthenticated   |
+| `GET /pubkey`                 | Unauthenticated   |
+| `POST /configure`             | Signed headers    |
+| `POST /delta`                 | Signed headers    |
+| `GET /delta`                  | Signed headers    |
+| `GET /delta/since`            | Signed headers    |
+| `GET /state`                  | Signed headers    |
+| `POST /delta/proposal`        | Signed headers    |
+| `GET /delta/proposal`         | Signed headers    |
+| `GET /delta/proposal/single`  | Signed headers    |
+| `PUT /delta/proposal`         | Signed headers    |
+| `/dashboard/accounts*`        | Dashboard session |
+
+Signed requests carry three headers: `x-pubkey`, `x-signature`, and `x-timestamp`. Timestamps must be within ±5 minutes of server time and strictly greater than the last value the server saw for that public key — see [Authentication failures](./troubleshooting#authentication-failures) if requests are being rejected.

--- a/versioned_docs/version-0.14/builder/miden-guardian/operator-guide/troubleshooting.md
+++ b/versioned_docs/version-0.14/builder/miden-guardian/operator-guide/troubleshooting.md
@@ -3,72 +3,71 @@ title: Troubleshooting
 sidebar_position: 3
 ---
 
-# Troubleshooting
+# Troubleshooting Miden Guardian
 
-Common issues when operating a Guardian server and how to resolve them.
+## Server does not start
 
-## Server won't start
+Check that storage paths are writable:
 
-**Symptom**: Server exits immediately or fails to bind ports.
+```bash
+ls -ld /var/guardian/storage /var/guardian/metadata /var/guardian/keystore
+```
 
-- Check that ports 3000 (HTTP) and 50051 (gRPC) are not already in use.
-- If using Postgres, ensure `DATABASE_URL` is set and the database is reachable.
-- Check logs with `RUST_LOG=debug` for detailed error messages.
+For Postgres mode, confirm `DATABASE_URL` is set and reachable. The server panics on startup if it's missing.
 
-## Acknowledgment key mismatch
+## Public key changed unexpectedly
 
-**Symptom**: Clients report `ack_sig` verification failures.
+The Guardian key is loaded from the configured keystore path. Confirm the same `GUARDIAN_KEYSTORE_PATH` is used across restarts.
 
-- Verify the server's public key via `GET /pubkey` and compare with what clients expect.
-- If the keystore was regenerated (new `PSM_KEYSTORE_PATH`), clients need to re-fetch the server's public key.
-- Ensure `PSM_KEYSTORE_PATH` is persistent across restarts — a new key on every restart will break client verification.
+For production AWS deployments, confirm `GUARDIAN_ENV=prod` and `AWS_REGION` are set so acknowledgement keys are loaded from Secrets Manager rather than the filesystem.
 
 ## Authentication failures
 
-**Symptom**: Requests return `400 AuthenticationFailed`.
+Guardian requires signed requests. Each carries three headers — `x-pubkey`, `x-signature`, and `x-timestamp` — and the timestamp is validated against two rules:
 
-- **Clock skew**: Client timestamp must be within 300 seconds of the server's time. Ensure NTP synchronization.
-- **Replay rejection**: Each request's timestamp must be strictly greater than the account's `last_auth_timestamp`. Rapid-fire requests with the same timestamp will fail.
-- **Wrong key**: The `x-pubkey` commitment must be in the account's cosigner allowlist. Verify the account's auth configuration.
+- It must be within ±5 minutes of server time (`MAX_TIMESTAMP_SKEW_MS = 300_000`).
+- It must be **strictly greater** than the last timestamp the server saw for that public key. The metadata store enforces this with a CAS update; a request with a timestamp equal to or below the previous one is rejected even if otherwise valid.
 
-## Deltas stuck as candidates
+Common causes:
 
-**Symptom**: Deltas remain in `candidate` status and never become `canonical`.
+- Client clock is more than 5 minutes from server time.
+- Timestamp was reused (replay attempt or accidental retry without re-signing).
+- Request body changed after signing.
+- Client is using the wrong Guardian public key — re-fetch `/pubkey`.
 
-- Check that the canonicalization worker is running (default: checks every 60 seconds).
-- Deltas must wait at least `delay_seconds` (default: 15 minutes) before the worker processes them.
-- If the on-chain commitment doesn't match, deltas are `discarded`. Check that the transaction was actually submitted and confirmed on-chain.
-- Inspect canonicalization logs: `RUST_LOG=server::jobs::canonicalization=debug`
+## Proposal stays pending
 
-## Storage and metadata path issues
+```bash
+DEPLOY_STAGE=dev ./scripts/aws-deploy.sh logs
+```
 
-**Symptom**: Server returns errors on state or delta operations.
+Common causes:
 
-- Ensure `PSM_STORAGE_PATH` and `PSM_METADATA_PATH` point to writable directories.
-- For Postgres: verify the connection string and that migrations have run (they run automatically on startup).
-- Check disk space — filesystem storage can grow with the number of accounts and deltas.
+- Account state has not canonicalized yet (the 10-second pass hasn't run).
+- The 10-minute submission grace period has not elapsed.
+- Metadata backend is not writable.
+- The pending-proposal count has hit `GUARDIAN_MAX_PENDING_PROPOSALS_PER_ACCOUNT` (default `20`); see [error code `pending_proposals_limit`](#common-error-codes).
 
-## Rate limiting
+## Rate limit errors
 
-**Symptom**: Clients receive `429 Too Many Requests`.
+If requests are rejected under load, tune:
 
-- Default limits: 10 requests/second (burst), 60 requests/minute (sustained).
-- Adjust via `PSM_RATE_BURST_PER_SEC` and `PSM_RATE_PER_MIN` environment variables.
-- The `Retry-After` header in the response indicates how long to wait.
+```bash
+GUARDIAN_RATE_BURST_PER_SEC      # default 10
+GUARDIAN_RATE_PER_MIN            # default 60
+GUARDIAN_MAX_REQUEST_BYTES       # default 1048576
+```
+
+The HTTP rate-limit middleware responds with `429 Too Many Requests` and a `Retry-After` header plus `retry_after_secs` in the body. **Note:** these middleware-level rejections do not include a `code` field — only the Guardian application-level `rate_limit_exceeded` error does. See the table below.
 
 ## Common error codes
 
-| Error | Meaning |
-|---|---|
-| `AccountNotFound` | No account configured with this ID |
-| `AuthenticationFailed` | Invalid signature, unknown key, or expired timestamp |
-| `InvalidDelta` | Delta fails validation against current state or network |
-| `CommitmentMismatch` | Delta's `prev_commitment` doesn't match current state |
-| `ConflictPendingDelta` | Another candidate delta is already pending for this account |
-| `TimestampExpired` | Request timestamp is outside the 300-second window |
-| `TimestampReplay` | Request timestamp is not greater than last accepted timestamp |
+The server emits structured error codes via `GuardianError::code()`. The most common ones operators will hit:
 
-## Links
-
-- [Server README](https://github.com/OpenZeppelin/guardian/tree/main/crates/server) — full server documentation
-- [Guardian Specification](https://github.com/OpenZeppelin/guardian/tree/main/spec) — protocol specification
+| Code                    | What it means                                                                                                         | First thing to check                                                                                |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `authentication_failed` | Auth headers missing or malformed, clock skew > 5 min, signature invalid, or the timestamp was already used.          | `x-pubkey` / `x-signature` / `x-timestamp` headers; client clock sync; the last timestamp you sent. |
+| `account_not_found`     | The metadata store has no record for that account ID.                                                                 | Account ID is correct and `/configure` actually completed against this server.                      |
+| `invalid_input`         | Generic 400 — request JSON, query parameters, or commitment shape failed validation.                                  | Request payload schema; commitment hex format.                                                      |
+| `rate_limit_exceeded`   | Application-level rate limit hit. (The HTTP middleware also emits `429` responses, but those have no `code` field.)   | Tune `GUARDIAN_RATE_BURST_PER_SEC` / `GUARDIAN_RATE_PER_MIN`; check `Retry-After` on the response.  |
+| `storage_error`         | The storage or metadata backend rejected an operation.                                                                | Filesystem permissions on the storage paths, or database health for Postgres mode.                  |


### PR DESCRIPTION
Rewrites the three Miden Guardian operator-guide pages (\`running\`, \`deployment\`, \`troubleshooting\`) using content grounded in a fresh read of the \`OpenZeppelin/guardian\` codebase.

## Why

The existing pages were thin and had several factual mistakes — most notably three error codes in the troubleshooting list that the server never emits. Operators following the docs verbatim would get confused looking for codes that don't exist or env vars whose actual defaults differed from what was documented.

## What changed

### \`running.md\`
- Clarifies HTTP \`3000\` / gRPC \`50051\` are hard-coded (not env-configurable).
- Adds an HTTP API surface table with auth requirements per endpoint.
- Names the signed-header trio: \`x-pubkey\`, \`x-signature\`, \`x-timestamp\`.
- Notes the three storage paths are independent (no single root override).
- Documents the \`?scheme=ecdsa\` form of \`/pubkey\`.

### \`deployment.md\`
- Adds default values for every env var (core + rate-limit) plus an AWS-prod-override column for the rate-limit knobs.
- Explicit callout that the canonicalization timing (10s pass + 10min grace) is hard-coded in the server binary and not env-configurable.
- Explains what \`bootstrap-ack-keys\` actually does (runs \`ack-keygen\`, writes Falcon + ECDSA secrets to AWS Secrets Manager, idempotent).
- Documents \`verify-build-hash.sh\` prereqs and behavior.
- Adds two missing env vars: \`GUARDIAN_OPERATOR_PUBLIC_KEYS_{SECRET_ID,FILE}\` for the operator allowlist, and \`GUARDIAN_CORS_ALLOWED_ORIGINS\`.
- Clarifies \`GUARDIAN_NETWORK_TYPE\` defaults to \`MidenDevnet\` for the binary vs \`MidenTestnet\` via the deploy script.

### \`troubleshooting.md\`
- Replaces the flat error-code list with a 5-row reference table — each code has a "what it means" and "first thing to check" column.
- **Drops three codes that were never emitted by the server:**
  - \`invalid_request\` — actual code is \`invalid_input\`
  - \`rate_limited\` — actual code is \`rate_limit_exceeded\`
  - \`canonicalization_failed\` — no arm of \`GuardianError::code()\` returns this string
- Expands authentication-failures with the actual 5-minute clock-skew bound (\`MAX_TIMESTAMP_SKEW_MS = 300_000\`) and the strictly-monotonic timestamp rule enforced by the metadata CAS.

## Verification

- \`npm run build\` exits \`[SUCCESS]\` with no new broken-link warnings.
- Walked all three pages on the local preview at \`https://homelab.tail477b3c.ts.net:9000/builder/miden-guardian/operator-guide/{running,deployment,troubleshooting}\`.
- Every claim about default values, hard-coded behavior, and error code names is grounded in a specific file:line in \`OpenZeppelin/guardian\` at \`main\` (latest as of this PR).

## Test plan

- [ ] Click through the three pages on \`/next/\` after deploy.
- [ ] Confirm the troubleshooting table renders cleanly on mobile (3 columns).
- [ ] Confirm the deployment env-var tables render cleanly (4 + 3 columns).

Mirrors all changes into \`versioned_docs/version-0.14/\`.