### PR TITLE
docs(guardian): link repository from running guide

### DIFF
--- a/docs/builder/miden-guardian/operator-guide/running.md
+++ b/docs/builder/miden-guardian/operator-guide/running.md
@@ -12,6 +12,17 @@ Miden Guardian exposes:
 
 Both ports are hard-coded in the server binary and are not currently overridable via environment variable. Embedders calling the builder API directly can configure them in code.
 
+## Get the code
+
+The Guardian server, client SDKs, multisig client libraries, and specification live in the [OpenZeppelin Guardian repository](https://github.com/OpenZeppelin/guardian).
+
+Clone the repository and run the commands on this page from its root:
+
+```bash
+git clone https://github.com/OpenZeppelin/guardian.git
+cd guardian
+```
+
 ## Run with Docker Compose
 
 ```bash


### PR DESCRIPTION
## Summary

Adds a short Get the code section to the Miden Guardian running guide so operators can find the OpenZeppelin Guardian repository before using the Docker Compose or source commands.

## Verification

- npm ci
- NODE_OPTIONS=--max-old-space-size=8192 npm run build

Build completed successfully. Existing broken-link and broken-anchor warnings remain in versioned and ingested docs; this change does not add a new internal docs link.

## Test plan

- Confirm the running guide links to https://github.com/OpenZeppelin/guardian
- Confirm the clone commands appear before Docker Compose and source-run instructions