### PR TITLE
docs(node): clarify v0.14 network note diagnostics

### DIFF
--- a/versioned_docs/version-0.14/core-concepts/node/operator/architecture.md
+++ b/versioned_docs/version-0.14/core-concepts/node/operator/architecture.md
@@ -66,3 +66,8 @@ number of failures, preventing resource exhaustion. The threshold can be set wit
 The builder also exposes an internal gRPC server that the RPC component uses to proxy debugging endpoints such as
 `GetNoteError`. In bundled mode this is wired automatically; in distributed mode operators must set
 `--ntx-builder.url` (or `MIDEN_NODE_NTX_BUILDER_URL`) on the RPC component.
+
+Network transactions can read public foreign account state through foreign procedure invocation (FPI) while consuming a
+network note. The foreign account must be public and retrievable from the store at the transaction's reference block. If
+the foreign account is missing, private, or otherwise unavailable, the note execution can fail and the latest failure is
+reported through [`GetNoteError`](../rpc#getnoteerror).

--- a/versioned_docs/version-0.14/core-concepts/node/rpc.md
+++ b/versioned_docs/version-0.14/core-concepts/node/rpc.md
@@ -234,9 +234,14 @@ Request the status of the node components. The response contains the current ver
 
 ### GetNoteError
 
-Returns the latest execution error for a network note, if any. This is useful for debugging notes that are failing to be consumed by the network transaction builder.
+Returns the latest execution error for a network note, if any. This is the v0.14 endpoint for debugging notes that are
+failing to be consumed by the network transaction builder.
 
 This endpoint is only available when the network transaction builder is enabled and connected. If it is not configured, the endpoint returns `UNAVAILABLE`.
+
+Use this endpoint when a network note appears stuck or is repeatedly failing. For example, if a network account consumes
+a note whose script performs FPI into another account, missing or unavailable foreign account data can surface here as
+the latest execution error.
 
 #### Request
 


### PR DESCRIPTION
## Summary

Clarifies the v0.14 node docs for network-note diagnostics and FPI-related failure modes. The original issue assumed v0.14 should document `GetNetworkNoteStatus`, but release verification shows v0.14.10 still exposes `GetNoteError`; `GetNetworkNoteStatus` is a `next` endpoint.

## Changes

- Adds v0.14 network transaction builder guidance that network-note execution can perform FPI into public foreign accounts when the target is retrievable from store at the reference block.
- Clarifies that v0.14 operators should use `GetNoteError` to inspect latest network-note execution failures.
- Keeps the versioned docs aligned with the v0.14 node API instead of copying current/next endpoint names into the old version.

## Verification

- npm ci
- NODE_OPTIONS=--max-old-space-size=8192 npm run build

Build completed successfully. Existing broken-link and broken-anchor warnings remain in unrelated versioned/ingested docs.

Refs #277