### PR TITLE
docs(react-sdk): add account balance examples

### DIFF
--- a/docs/builder/tools/clients/react-sdk/account-state-and-balances.md
+++ b/docs/builder/tools/clients/react-sdk/account-state-and-balances.md
@@ -1,0 +1,335 @@
+---
+title: Account state and balances
+sidebar_position: 4
+---
+
+# Account state and balances
+
+This page shows the application flow most wallet and dApp frontends need:
+
+1. mount `MidenProvider`,
+2. resolve the active account,
+3. sync before reading fresh state,
+4. render fungible asset balances,
+5. refresh after submitted transactions, and
+6. run local view-call style reads with `useExecuteProgram()`.
+
+The important boundary is:
+
+- **Sync** pulls network state into the local client store.
+- **Query hooks** such as `useAccounts()` and `useAccount()` read from that local store.
+- **Mutation hooks** such as `useSend()`, `useMint()`, and `useConsume()` build, prove, and submit transactions.
+- **`useExecuteProgram()`** runs locally and does not prove, submit, or change state.
+
+For the full package README and source-level examples, see
+[`miden-client/packages/react-sdk/README.md`](https://github.com/0xMiden/miden-client/blob/v0.14.5/packages/react-sdk/README.md).
+
+## Provider setup
+
+Mount `MidenProvider` once above every component that calls React SDK hooks. Enable auto-sync for normal app usage, and keep a manual refresh button for user-driven state updates.
+
+```tsx
+import { MidenProvider } from "@miden-sdk/react";
+
+export function App() {
+  return (
+    <MidenProvider
+      config={{
+        rpcUrl: "testnet",
+        prover: "testnet",
+        noteTransportUrl: "testnet",
+        autoSyncInterval: 15_000,
+      }}
+      loadingComponent={<p>Loading Miden...</p>}
+      errorComponent={(error) => <p role="alert">{error.message}</p>}
+    >
+      <WalletHome />
+    </MidenProvider>
+  );
+}
+
+function WalletHome() {
+  return <p>Miden wallet ready.</p>;
+}
+```
+
+## Resolve the active account
+
+When an external signer is connected, `useMiden()` exposes `signerAccountId`. In local-keystore flows, pick the account from `useAccounts()` instead, usually from a user selection or the first wallet in the local store.
+
+```tsx
+import { useMemo } from "react";
+import { useAccounts, useMiden } from "@miden-sdk/react";
+
+export function useActiveAccountId(selectedAccountId?: string): string | undefined {
+  const { signerAccountId } = useMiden();
+  const { wallets } = useAccounts();
+
+  return useMemo(
+    () => selectedAccountId ?? signerAccountId ?? wallets[0]?.id().toString(),
+    [selectedAccountId, signerAccountId, wallets]
+  );
+}
+```
+
+If this returns `undefined`, the app has no connected signer and no local wallet yet. Render a connect/create-account state before calling transaction hooks.
+
+## Render all fungible balances
+
+`useAccount(accountId)` returns the full account plus `assets`, which are extracted from the account vault and decorated with token metadata when it is available.
+
+```tsx
+import {
+  formatAssetAmount,
+  useAccount,
+  useSyncState,
+} from "@miden-sdk/react";
+
+type BalancePanelProps = {
+  accountId?: string;
+  fallbackDecimals?: number;
+};
+
+export function BalancePanel({
+  accountId,
+  fallbackDecimals = 8,
+}: BalancePanelProps) {
+  const { account, assets, isLoading, error, refetch } = useAccount(accountId);
+  const { sync, isSyncing } = useSyncState();
+
+  const refresh = async () => {
+    await sync();
+    await refetch();
+  };
+
+  if (!accountId) return <p>Connect or create a wallet to see balances.</p>;
+  if (isLoading) return <p>Loading balances...</p>;
+  if (error) return <p role="alert">{error.message}</p>;
+  if (!account) return <p>Account not found in the local store.</p>;
+
+  return (
+    <section>
+      <header>
+        <p>{account.bech32id()}</p>
+        <button onClick={refresh} disabled={isSyncing}>
+          {isSyncing ? "Syncing..." : "Refresh"}
+        </button>
+      </header>
+
+      {assets.length === 0 ? (
+        <p>No fungible assets found for this account.</p>
+      ) : (
+        <ul>
+          {assets.map((asset) => {
+            const decimals = asset.decimals ?? fallbackDecimals;
+            const label = asset.symbol ?? asset.assetId;
+
+            return (
+              <li key={asset.assetId}>
+                {formatAssetAmount(asset.amount, decimals)} {label}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}
+```
+
+`sync()` updates the local store from the node. `refetch()` then re-reads the account details for the current component. `useAccount()` also refreshes after successful provider syncs, but explicit `refetch()` keeps button-driven UI immediate.
+
+## Render one token balance
+
+For a single known faucet, use the `getBalance(assetId)` helper. It returns `0n` when the account does not hold that asset.
+
+```tsx
+import { formatAssetAmount, useAccount } from "@miden-sdk/react";
+
+type TokenBalanceProps = {
+  accountId?: string;
+  faucetId: string;
+  symbol?: string;
+  decimals?: number;
+};
+
+export function TokenBalance({
+  accountId,
+  faucetId,
+  symbol = "TOKEN",
+  decimals = 8,
+}: TokenBalanceProps) {
+  const { getBalance, isLoading, error } = useAccount(accountId);
+  const balance = getBalance(faucetId);
+
+  if (!accountId) return <span>-</span>;
+  if (isLoading) return <span>Loading...</span>;
+  if (error) return <span>{error.message}</span>;
+
+  return (
+    <span>
+      {formatAssetAmount(balance, decimals)} {symbol}
+    </span>
+  );
+}
+```
+
+## Refresh after a submitted transaction
+
+`useSend()` returns `{ txId }`. `useMint()` and `useConsume()` return `{ transactionId }`. In all cases, wait for the transaction to commit, then sync the client so query hooks can read the updated local state.
+
+```tsx
+import {
+  useSend,
+  useSyncState,
+  useWaitForCommit,
+} from "@miden-sdk/react";
+
+type SendFormProps = {
+  from: string;
+  to: string;
+  faucetId: string;
+};
+
+export function SendForm({ from, to, faucetId }: SendFormProps) {
+  const { send, stage, isLoading, error } = useSend();
+  const { waitForCommit } = useWaitForCommit();
+  const { sync } = useSyncState();
+
+  const submit = async () => {
+    const result = await send({
+      from,
+      to,
+      assetId: faucetId,
+      amount: 100n,
+      noteType: "private",
+    });
+
+    await waitForCommit(result.txId);
+    await sync();
+  };
+
+  return (
+    <>
+      <button onClick={submit} disabled={isLoading}>
+        {isLoading ? stage : "Send 100"}
+      </button>
+      {error && <p role="alert">{error.message}</p>}
+    </>
+  );
+}
+```
+
+For `mint` and `consume`, the same pattern is:
+
+```tsx
+import {
+  useConsume,
+  useMint,
+  useSyncState,
+  useWaitForCommit,
+} from "@miden-sdk/react";
+
+type MintAndConsumeActionsProps = {
+  accountId: string;
+  faucetId: string;
+  noteIds: string[];
+};
+
+export function MintAndConsumeActions({
+  accountId,
+  faucetId,
+  noteIds,
+}: MintAndConsumeActionsProps) {
+  const { mint, stage: mintStage, isLoading: isMinting } = useMint();
+  const { consume, stage: consumeStage, isLoading: isConsuming } = useConsume();
+  const { waitForCommit } = useWaitForCommit();
+  const { sync } = useSyncState();
+
+  const mintNewTokens = async () => {
+    const result = await mint({
+      faucetId,
+      targetAccountId: accountId,
+      amount: 100n,
+    });
+
+    await waitForCommit(result.transactionId);
+    await sync();
+  };
+
+  const consumeNotes = async () => {
+    const result = await consume({
+      accountId,
+      notes: noteIds,
+    });
+
+    await waitForCommit(result.transactionId);
+    await sync();
+  };
+
+  return (
+    <>
+      <button onClick={mintNewTokens} disabled={isMinting}>
+        {isMinting ? mintStage : "Mint 100"}
+      </button>
+      <button onClick={consumeNotes} disabled={isConsuming || noteIds.length === 0}>
+        {isConsuming ? consumeStage : "Consume notes"}
+      </button>
+    </>
+  );
+}
+```
+
+If a transaction creates a private note for another account, the recipient still needs to receive/import the note and consume it before the recipient's balance changes.
+
+## Local view-call reads
+
+Use `useExecuteProgram()` for local, static-call style reads against account code. It runs a compiled transaction script locally, returns the stack output, and does not submit a transaction.
+
+```tsx
+import { useExecuteProgram } from "@miden-sdk/react";
+import type { TransactionScript } from "@miden-sdk/miden-sdk";
+
+type CounterReadProps = {
+  accountId: string;
+  script: TransactionScript;
+  foreignAccountId?: string;
+};
+
+export function CounterRead({
+  accountId,
+  script,
+  foreignAccountId,
+}: CounterReadProps) {
+  const { execute, result, isLoading, error } = useExecuteProgram();
+
+  const read = async () => {
+    await execute({
+      accountId,
+      script,
+      foreignAccounts: foreignAccountId ? [foreignAccountId] : [],
+    });
+  };
+
+  return (
+    <section>
+      <button onClick={read} disabled={isLoading}>
+        {isLoading ? "Reading..." : "Read counter"}
+      </button>
+      {error && <p role="alert">{error.message}</p>}
+      {result && <p>Counter: {result.stack[0]?.toString() ?? "0"}</p>}
+    </section>
+  );
+}
+```
+
+`foreignAccounts` is required only when the script reads another public account through foreign procedure invocation. View calls use the local client context, so set `skipSync: true` only when you intentionally want to read the current local snapshot without pulling fresh network state first.
+
+## Checklist
+
+- Wrap app code in `MidenProvider` before calling hooks.
+- Use `signerAccountId` for external signer apps and `useAccounts()` for local wallet selection.
+- Call `sync()` before user-visible reads that need fresh network state.
+- Read balances from `useAccount(accountId).assets` or `getBalance(faucetId)`.
+- After submitted transactions, wait for commit and sync again.
+- Use `useExecuteProgram()` only for local reads; it does not prove, submit, or mutate account state.

--- a/docs/builder/tools/clients/react-sdk/index.md
+++ b/docs/builder/tools/clients/react-sdk/index.md
@@ -27,6 +27,7 @@ You can always reach the underlying WASM client from any hook via `useMidenClien
 | [`useMiden()`](./setup.md#client-lifecycle) | Raw lifecycle hook (`isReady`, `sync`, `runExclusive`) |
 | [`useMidenClient()`](./setup.md#client-lifecycle) | Shortcut for the ready WASM `WebClient` |
 | [Query hooks](./query-hooks.md) | `useAccount(s)`, `useNotes`, `useNoteStream`, `useTransactionHistory`, `useSyncState`, `useAssetMetadata` |
+| [Account state and balances](./account-state-and-balances.md) | Active account selection, sync boundaries, balance rendering, and refresh-after-transaction patterns |
 | [Mutation hooks](./mutation-hooks.md) | `useCreateWallet`, `useCreateFaucet`, `useImportAccount`, `useSend`, `useMultiSend`, `useMint`, `useConsume`, `useSwap` |
 | [Advanced hooks](./advanced.md) | `useTransaction`, `useExecuteProgram`, `useCompile`, `useSessionAccount`, `useExportStore`, `useImportStore`, `useImportNote`, `useExportNote`, `useSyncControl`, `useWaitForCommit`, `useWaitForNotes` |
 | [External signers](./signers.md) | `MultiSignerProvider`, `SignerContext`, `useSigner`, `useMultiSigner` — pluggable wallet integrations (Para, Turnkey, MidenFi, custom) |
@@ -38,6 +39,7 @@ Each hook exports its own result interface — not a generic `{ data, isLoading,
 
 - [Setup](./setup.md) — install the package, wrap your app in `MidenProvider`, configure the network.
 - [Query hooks](./query-hooks.md) — read accounts, notes, sync state, and asset metadata.
+- [Account state and balances](./account-state-and-balances.md) — practical account selection, sync, balances, and refresh examples.
 - [Mutation hooks](./mutation-hooks.md) — create wallets and faucets, send, mint, consume, swap.
 - [Advanced](./advanced.md) — custom scripts, MASM compilation, session accounts, note import/export.
 - [Signers](./signers.md) — external wallets (Para, Turnkey, MidenFi) and custom signer providers.

--- a/docs/builder/tools/clients/react-sdk/mutation-hooks.md
+++ b/docs/builder/tools/clients/react-sdk/mutation-hooks.md
@@ -52,7 +52,7 @@ function NewWalletButton() {
     const account = await createWallet({
       storageMode: "private",        // "private" | "public" | "network" (default private)
       mutable: true,                 // default true — updatable code
-      authScheme: AuthScheme.AuthRpoFalcon512, // default
+      authScheme: AuthScheme.Falcon, // default
     });
     console.log("Created:", account.bech32id());
   };
@@ -69,7 +69,7 @@ function NewWalletButton() {
 | --- | --- | --- |
 | `storageMode` | `"private"` | `"private"` / `"public"` / `"network"` |
 | `mutable` | `true` | Whether code can be updated after deployment |
-| `authScheme` | `AuthScheme.AuthRpoFalcon512` | Signing scheme |
+| `authScheme` | `AuthScheme.Falcon` | Signing scheme |
 | `initSeed` | random | 32-byte seed for deterministic account-ID derivation |
 
 ## `useCreateFaucet`
@@ -106,7 +106,7 @@ function NewFaucetButton() {
 | `maxSupply` | required | `bigint \| number` |
 | `decimals` | `8` | Token decimals |
 | `storageMode` | `"private"` | Public faucets are discoverable/readable on-chain |
-| `authScheme` | `AuthScheme.AuthRpoFalcon512` | Signing scheme |
+| `authScheme` | `AuthScheme.Falcon` | Signing scheme |
 
 ## `useSend`
 
@@ -275,7 +275,7 @@ await importAccount({
   type: "seed",
   seed: initSeed,        // Uint8Array
   mutable: true,         // default true
-  authScheme: AuthScheme.AuthRpoFalcon512,
+  authScheme: AuthScheme.Falcon,
 });
 
 // By file — works for both public and private accounts

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -233,6 +233,7 @@ const sidebars: SidebarsConfig = {
               items: [
                 "builder/tools/clients/react-sdk/setup",
                 "builder/tools/clients/react-sdk/query-hooks",
+                "builder/tools/clients/react-sdk/account-state-and-balances",
                 "builder/tools/clients/react-sdk/mutation-hooks",
                 "builder/tools/clients/react-sdk/advanced",
                 "builder/tools/clients/react-sdk/signers",

--- a/versioned_docs/version-0.14/builder/tools/clients/react-sdk/account-state-and-balances.md
+++ b/versioned_docs/version-0.14/builder/tools/clients/react-sdk/account-state-and-balances.md
@@ -1,0 +1,335 @@
+---
+title: Account state and balances
+sidebar_position: 4
+---
+
+# Account state and balances
+
+This page shows the application flow most wallet and dApp frontends need:
+
+1. mount `MidenProvider`,
+2. resolve the active account,
+3. sync before reading fresh state,
+4. render fungible asset balances,
+5. refresh after submitted transactions, and
+6. run local view-call style reads with `useExecuteProgram()`.
+
+The important boundary is:
+
+- **Sync** pulls network state into the local client store.
+- **Query hooks** such as `useAccounts()` and `useAccount()` read from that local store.
+- **Mutation hooks** such as `useSend()`, `useMint()`, and `useConsume()` build, prove, and submit transactions.
+- **`useExecuteProgram()`** runs locally and does not prove, submit, or change state.
+
+For the full package README and source-level examples, see
+[`miden-client/packages/react-sdk/README.md`](https://github.com/0xMiden/miden-client/blob/v0.14.5/packages/react-sdk/README.md).
+
+## Provider setup
+
+Mount `MidenProvider` once above every component that calls React SDK hooks. Enable auto-sync for normal app usage, and keep a manual refresh button for user-driven state updates.
+
+```tsx
+import { MidenProvider } from "@miden-sdk/react";
+
+export function App() {
+  return (
+    <MidenProvider
+      config={{
+        rpcUrl: "testnet",
+        prover: "testnet",
+        noteTransportUrl: "testnet",
+        autoSyncInterval: 15_000,
+      }}
+      loadingComponent={<p>Loading Miden...</p>}
+      errorComponent={(error) => <p role="alert">{error.message}</p>}
+    >
+      <WalletHome />
+    </MidenProvider>
+  );
+}
+
+function WalletHome() {
+  return <p>Miden wallet ready.</p>;
+}
+```
+
+## Resolve the active account
+
+When an external signer is connected, `useMiden()` exposes `signerAccountId`. In local-keystore flows, pick the account from `useAccounts()` instead, usually from a user selection or the first wallet in the local store.
+
+```tsx
+import { useMemo } from "react";
+import { useAccounts, useMiden } from "@miden-sdk/react";
+
+export function useActiveAccountId(selectedAccountId?: string): string | undefined {
+  const { signerAccountId } = useMiden();
+  const { wallets } = useAccounts();
+
+  return useMemo(
+    () => selectedAccountId ?? signerAccountId ?? wallets[0]?.id().toString(),
+    [selectedAccountId, signerAccountId, wallets]
+  );
+}
+```
+
+If this returns `undefined`, the app has no connected signer and no local wallet yet. Render a connect/create-account state before calling transaction hooks.
+
+## Render all fungible balances
+
+`useAccount(accountId)` returns the full account plus `assets`, which are extracted from the account vault and decorated with token metadata when it is available.
+
+```tsx
+import {
+  formatAssetAmount,
+  useAccount,
+  useSyncState,
+} from "@miden-sdk/react";
+
+type BalancePanelProps = {
+  accountId?: string;
+  fallbackDecimals?: number;
+};
+
+export function BalancePanel({
+  accountId,
+  fallbackDecimals = 8,
+}: BalancePanelProps) {
+  const { account, assets, isLoading, error, refetch } = useAccount(accountId);
+  const { sync, isSyncing } = useSyncState();
+
+  const refresh = async () => {
+    await sync();
+    await refetch();
+  };
+
+  if (!accountId) return <p>Connect or create a wallet to see balances.</p>;
+  if (isLoading) return <p>Loading balances...</p>;
+  if (error) return <p role="alert">{error.message}</p>;
+  if (!account) return <p>Account not found in the local store.</p>;
+
+  return (
+    <section>
+      <header>
+        <p>{account.bech32id()}</p>
+        <button onClick={refresh} disabled={isSyncing}>
+          {isSyncing ? "Syncing..." : "Refresh"}
+        </button>
+      </header>
+
+      {assets.length === 0 ? (
+        <p>No fungible assets found for this account.</p>
+      ) : (
+        <ul>
+          {assets.map((asset) => {
+            const decimals = asset.decimals ?? fallbackDecimals;
+            const label = asset.symbol ?? asset.assetId;
+
+            return (
+              <li key={asset.assetId}>
+                {formatAssetAmount(asset.amount, decimals)} {label}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}
+```
+
+`sync()` updates the local store from the node. `refetch()` then re-reads the account details for the current component. `useAccount()` also refreshes after successful provider syncs, but explicit `refetch()` keeps button-driven UI immediate.
+
+## Render one token balance
+
+For a single known faucet, use the `getBalance(assetId)` helper. It returns `0n` when the account does not hold that asset.
+
+```tsx
+import { formatAssetAmount, useAccount } from "@miden-sdk/react";
+
+type TokenBalanceProps = {
+  accountId?: string;
+  faucetId: string;
+  symbol?: string;
+  decimals?: number;
+};
+
+export function TokenBalance({
+  accountId,
+  faucetId,
+  symbol = "TOKEN",
+  decimals = 8,
+}: TokenBalanceProps) {
+  const { getBalance, isLoading, error } = useAccount(accountId);
+  const balance = getBalance(faucetId);
+
+  if (!accountId) return <span>-</span>;
+  if (isLoading) return <span>Loading...</span>;
+  if (error) return <span>{error.message}</span>;
+
+  return (
+    <span>
+      {formatAssetAmount(balance, decimals)} {symbol}
+    </span>
+  );
+}
+```
+
+## Refresh after a submitted transaction
+
+`useSend()` returns `{ txId }`. `useMint()` and `useConsume()` return `{ transactionId }`. In all cases, wait for the transaction to commit, then sync the client so query hooks can read the updated local state.
+
+```tsx
+import {
+  useSend,
+  useSyncState,
+  useWaitForCommit,
+} from "@miden-sdk/react";
+
+type SendFormProps = {
+  from: string;
+  to: string;
+  faucetId: string;
+};
+
+export function SendForm({ from, to, faucetId }: SendFormProps) {
+  const { send, stage, isLoading, error } = useSend();
+  const { waitForCommit } = useWaitForCommit();
+  const { sync } = useSyncState();
+
+  const submit = async () => {
+    const result = await send({
+      from,
+      to,
+      assetId: faucetId,
+      amount: 100n,
+      noteType: "private",
+    });
+
+    await waitForCommit(result.txId);
+    await sync();
+  };
+
+  return (
+    <>
+      <button onClick={submit} disabled={isLoading}>
+        {isLoading ? stage : "Send 100"}
+      </button>
+      {error && <p role="alert">{error.message}</p>}
+    </>
+  );
+}
+```
+
+For `mint` and `consume`, the same pattern is:
+
+```tsx
+import {
+  useConsume,
+  useMint,
+  useSyncState,
+  useWaitForCommit,
+} from "@miden-sdk/react";
+
+type MintAndConsumeActionsProps = {
+  accountId: string;
+  faucetId: string;
+  noteIds: string[];
+};
+
+export function MintAndConsumeActions({
+  accountId,
+  faucetId,
+  noteIds,
+}: MintAndConsumeActionsProps) {
+  const { mint, stage: mintStage, isLoading: isMinting } = useMint();
+  const { consume, stage: consumeStage, isLoading: isConsuming } = useConsume();
+  const { waitForCommit } = useWaitForCommit();
+  const { sync } = useSyncState();
+
+  const mintNewTokens = async () => {
+    const result = await mint({
+      faucetId,
+      targetAccountId: accountId,
+      amount: 100n,
+    });
+
+    await waitForCommit(result.transactionId);
+    await sync();
+  };
+
+  const consumeNotes = async () => {
+    const result = await consume({
+      accountId,
+      notes: noteIds,
+    });
+
+    await waitForCommit(result.transactionId);
+    await sync();
+  };
+
+  return (
+    <>
+      <button onClick={mintNewTokens} disabled={isMinting}>
+        {isMinting ? mintStage : "Mint 100"}
+      </button>
+      <button onClick={consumeNotes} disabled={isConsuming || noteIds.length === 0}>
+        {isConsuming ? consumeStage : "Consume notes"}
+      </button>
+    </>
+  );
+}
+```
+
+If a transaction creates a private note for another account, the recipient still needs to receive/import the note and consume it before the recipient's balance changes.
+
+## Local view-call reads
+
+Use `useExecuteProgram()` for local, static-call style reads against account code. It runs a compiled transaction script locally, returns the stack output, and does not submit a transaction.
+
+```tsx
+import { useExecuteProgram } from "@miden-sdk/react";
+import type { TransactionScript } from "@miden-sdk/miden-sdk";
+
+type CounterReadProps = {
+  accountId: string;
+  script: TransactionScript;
+  foreignAccountId?: string;
+};
+
+export function CounterRead({
+  accountId,
+  script,
+  foreignAccountId,
+}: CounterReadProps) {
+  const { execute, result, isLoading, error } = useExecuteProgram();
+
+  const read = async () => {
+    await execute({
+      accountId,
+      script,
+      foreignAccounts: foreignAccountId ? [foreignAccountId] : [],
+    });
+  };
+
+  return (
+    <section>
+      <button onClick={read} disabled={isLoading}>
+        {isLoading ? "Reading..." : "Read counter"}
+      </button>
+      {error && <p role="alert">{error.message}</p>}
+      {result && <p>Counter: {result.stack[0]?.toString() ?? "0"}</p>}
+    </section>
+  );
+}
+```
+
+`foreignAccounts` is required only when the script reads another public account through foreign procedure invocation. View calls use the local client context, so set `skipSync: true` only when you intentionally want to read the current local snapshot without pulling fresh network state first.
+
+## Checklist
+
+- Wrap app code in `MidenProvider` before calling hooks.
+- Use `signerAccountId` for external signer apps and `useAccounts()` for local wallet selection.
+- Call `sync()` before user-visible reads that need fresh network state.
+- Read balances from `useAccount(accountId).assets` or `getBalance(faucetId)`.
+- After submitted transactions, wait for commit and sync again.
+- Use `useExecuteProgram()` only for local reads; it does not prove, submit, or mutate account state.

--- a/versioned_docs/version-0.14/builder/tools/clients/react-sdk/index.md
+++ b/versioned_docs/version-0.14/builder/tools/clients/react-sdk/index.md
@@ -27,6 +27,7 @@ You can always reach the underlying WASM client from any hook via `useMidenClien
 | [`useMiden()`](./setup.md#client-lifecycle) | Raw lifecycle hook (`isReady`, `sync`, `runExclusive`) |
 | [`useMidenClient()`](./setup.md#client-lifecycle) | Shortcut for the ready WASM `WebClient` |
 | [Query hooks](./query-hooks.md) | `useAccount(s)`, `useNotes`, `useNoteStream`, `useTransactionHistory`, `useSyncState`, `useAssetMetadata` |
+| [Account state and balances](./account-state-and-balances.md) | Active account selection, sync boundaries, balance rendering, and refresh-after-transaction patterns |
 | [Mutation hooks](./mutation-hooks.md) | `useCreateWallet`, `useCreateFaucet`, `useImportAccount`, `useSend`, `useMultiSend`, `useMint`, `useConsume`, `useSwap` |
 | [Advanced hooks](./advanced.md) | `useTransaction`, `useExecuteProgram`, `useCompile`, `useSessionAccount`, `useExportStore`, `useImportStore`, `useImportNote`, `useExportNote`, `useSyncControl`, `useWaitForCommit`, `useWaitForNotes` |
 | [External signers](./signers.md) | `MultiSignerProvider`, `SignerContext`, `useSigner`, `useMultiSigner` — pluggable wallet integrations (Para, Turnkey, MidenFi, custom) |
@@ -38,6 +39,7 @@ Each hook exports its own result interface — not a generic `{ data, isLoading,
 
 - [Setup](./setup.md) — install the package, wrap your app in `MidenProvider`, configure the network.
 - [Query hooks](./query-hooks.md) — read accounts, notes, sync state, and asset metadata.
+- [Account state and balances](./account-state-and-balances.md) — practical account selection, sync, balances, and refresh examples.
 - [Mutation hooks](./mutation-hooks.md) — create wallets and faucets, send, mint, consume, swap.
 - [Advanced](./advanced.md) — custom scripts, MASM compilation, session accounts, note import/export.
 - [Signers](./signers.md) — external wallets (Para, Turnkey, MidenFi) and custom signer providers.

--- a/versioned_docs/version-0.14/builder/tools/clients/react-sdk/mutation-hooks.md
+++ b/versioned_docs/version-0.14/builder/tools/clients/react-sdk/mutation-hooks.md
@@ -52,7 +52,7 @@ function NewWalletButton() {
     const account = await createWallet({
       storageMode: "private",        // "private" | "public" | "network" (default private)
       mutable: true,                 // default true — updatable code
-      authScheme: AuthScheme.AuthRpoFalcon512, // default
+      authScheme: AuthScheme.Falcon, // default
     });
     console.log("Created:", account.bech32id());
   };
@@ -69,7 +69,7 @@ function NewWalletButton() {
 | --- | --- | --- |
 | `storageMode` | `"private"` | `"private"` / `"public"` / `"network"` |
 | `mutable` | `true` | Whether code can be updated after deployment |
-| `authScheme` | `AuthScheme.AuthRpoFalcon512` | Signing scheme |
+| `authScheme` | `AuthScheme.Falcon` | Signing scheme |
 | `initSeed` | random | 32-byte seed for deterministic account-ID derivation |
 
 ## `useCreateFaucet`
@@ -106,7 +106,7 @@ function NewFaucetButton() {
 | `maxSupply` | required | `bigint \| number` |
 | `decimals` | `8` | Token decimals |
 | `storageMode` | `"private"` | Public faucets are discoverable/readable on-chain |
-| `authScheme` | `AuthScheme.AuthRpoFalcon512` | Signing scheme |
+| `authScheme` | `AuthScheme.Falcon` | Signing scheme |
 
 ## `useSend`
 
@@ -275,7 +275,7 @@ await importAccount({
   type: "seed",
   seed: initSeed,        // Uint8Array
   mutable: true,         // default true
-  authScheme: AuthScheme.AuthRpoFalcon512,
+  authScheme: AuthScheme.Falcon,
 });
 
 // By file — works for both public and private accounts

--- a/versioned_sidebars/version-0.14-sidebars.json
+++ b/versioned_sidebars/version-0.14-sidebars.json
@@ -262,6 +262,7 @@
               "items": [
                 "builder/tools/clients/react-sdk/setup",
                 "builder/tools/clients/react-sdk/query-hooks",
+                "builder/tools/clients/react-sdk/account-state-and-balances",
                 "builder/tools/clients/react-sdk/mutation-hooks",
                 "builder/tools/clients/react-sdk/advanced",
                 "builder/tools/clients/react-sdk/signers",


### PR DESCRIPTION
## Summary
Adds a practical React SDK account state and balances guide for current docs and v0.14 versioned docs. The page covers provider setup, active-account resolution, sync boundaries, balance rendering, refresh-after-transaction flows, and local view-call reads.

## Changes
- Adds `account-state-and-balances.md` under current React SDK docs and `versioned_docs/version-0.14`.
- Links the new page from both React SDK overview pages and both sidebars.
- Updates React SDK mutation examples to use `AuthScheme.Falcon`, matching the published `@miden-sdk/react@0.14.5` / `@miden-sdk/miden-sdk@0.14.5` types.

Closes #275.

## Verification
- `npm view @miden-sdk/react version` -> `0.14.5`
- `npm view @miden-sdk/miden-sdk version` -> `0.14.5`
- `npm run typecheck:strict` in `Projects/docs-tests/react/react-sdk-demo`
- Docker clean-env typecheck with `node:20-bookworm`, fresh `npm ci`, and `npm run typecheck:strict`
- `npm ci` in docs worktree
- `NODE_OPTIONS=--max-old-space-size=8192 npm run build`

Known unrelated build warnings remain from pre-existing old-version/tutorial/core-lib links and anchors.