### PR TITLE
docs: replace stale miden-vm debugger references

### DIFF
--- a/docs/core-concepts/index.md
+++ b/docs/core-concepts/index.md
@@ -163,7 +163,7 @@ The compiler toolchain enables writing Miden programs in high-level languages.
 
 - **cargo-miden** — Cargo extension for building Miden projects
 - **midenc** — core compiler from WebAssembly to Miden Assembly
-- **Debugger** — interactive debugging with breakpoints and state inspection
+- **[Debugger](https://github.com/0xMiden/miden-debug)** — interactive debugging with breakpoints and state inspection
 
 ### Compilation pipeline
 

--- a/versioned_docs/version-0.13/core-concepts/miden-vm/tools/debugger.md
+++ b/versioned_docs/version-0.13/core-concepts/miden-vm/tools/debugger.md
@@ -5,58 +5,7 @@ sidebar_position: 2
 
 # Miden Debugger
 
-The Miden debugger is a command-line interface (CLI) application, inspired by [GNU gdb](https://sourceware.org/gdb/), which allows debugging of Miden assembly (MASM) programs. The debugger allows the user to step through the execution of the program, both forward and backward, either per clock cycle tick, or via breakpoints.
+The interactive Miden debugger is no longer part of the `miden-vm` CLI. It now lives in its own repository.
 
-The Miden debugger supports the following commands:
-
-| Command | Shortcut | Arguments | Description |
-| --- | --- | --- | --- |
-| next | n | count? | Steps `count` clock cycles. Will step `1` cycle of `count` is omitted. |
-| continue | c | - | Executes the program until completion, failure or a breakpoint. |
-| back | b | count? | Backward step `count` clock cycles. Will back-step `1` cycle of `count` is omitted. |
-| rewind | r | - | Executes the program backwards until the beginning, failure or a breakpoint. |
-| print | p | - | Displays the complete state of the virtual machine. |
-| print mem | p m | address? | Displays the memory value at `address`. If `address` is omitted, didisplays all the memory values. |
-| print stack | p s | index? | Displays the stack value at `index`. If `index` is omitted, displays all the stack values. |
-| clock | c | - | Displays the current clock cycle. |
-| quit | q | - | Quits the debugger. |
-| help | h | - | Displays the help message. |
-
-In order to start debugging, the user should provide a `MASM` program:
-
-```shell
-cargo run --features executable -- debug --assembly miden-vm/masm-examples/nprime/nprime.masm
-```
-
-The expected output is:
-
-```
-============================================================
-Debug program
-============================================================
-Reading program file `miden-vm/masm-examples/nprime/nprime.masm`
-Compiling program... done (16 ms)
-Debugging program with hash 11dbbddff27e26e48be3198133df8cbed6c5875d0fb
-606c9f037c7893fde4118...
-Reading input file `miden-vm/masm-examples/nprime/nprime.inputs`
-Welcome! Enter `h` for help.
->>
-```
-
-In order to add a breakpoint, the user should insert a `breakpoint` instruction into the MASM file. This will generate a `Noop` operation that will be decorated with the debug break configuration. This is a provisory solution until the source mapping is implemented.
-
-The following example will halt on the third instruction of `foo`:
-
-```
-proc foo
-    dup
-    dup.2
-    breakpoint
-    swap
-    add.1
-end
-
-begin
-    exec.foo
-end
-```
+- **Standalone debugger:** [github.com/0xMiden/miden-debug](https://github.com/0xMiden/miden-debug). See its README for installation and invocation.
+- **Compiler-driven debugging** (Rust → Wasm → MASM programs): use `midenc debug`, documented in [Debugging programs](../../compiler/guides/debugger.md).

--- a/versioned_docs/version-0.13/core-concepts/miden-vm/tools/index.md
+++ b/versioned_docs/version-0.13/core-concepts/miden-vm/tools/index.md
@@ -9,8 +9,9 @@ The following tools are available for interacting with Miden VM:
 
 - Via the [miden-vm](https://crates.io/crates/miden-vm) crate (or within the Miden VM repo):
   - [CLI](../usage.md#cli-interface)
-  - [Debugger](./debugger.md)
   - [REPL](./repl.md)
+- For interactive debugging:
+  - [Debugger](./debugger.md) — the standalone debugger now lives in its own repository, with `midenc debug` available for compiler-driven flows.
 - Via your browser:
   - The interactive [Miden VM Playground](https://0xMiden.github.io/examples/) for writing, executing, proving, and verifying programs from your browser.
 

--- a/versioned_docs/version-0.13/core-concepts/miden-vm/usage.md
+++ b/versioned_docs/version-0.13/core-concepts/miden-vm/usage.md
@@ -87,7 +87,6 @@ Currently, Miden VM can be executed with the following subcommands:
 - `prove` - this will execute a Miden assembly program, and will also generate a STARK proof of execution.
 - `verify` - this will verify a previously generated proof of execution for a given program.
 - `compile` - this will compile a Miden assembly program (i.e., build a program [MAST](./design/programs.md)) and outputs stats about the compilation process.
-- `debug` - this will instantiate a [Miden debugger](./tools/debugger.md) against the specified Miden assembly program and inputs.
 - `analyze` - this will run a Miden assembly program against specific inputs and will output stats about its execution.
 - `repl` - this will initiate the [Miden REPL](./tools/repl.md) tool.
 - `example` - this will execute a Miden assembly example program, generate a STARK proof of execution and verify it. Currently, it is possible to run `blake3` and `fibonacci` examples.


### PR DESCRIPTION
## Summary

Cleanup of stale references to the old `cargo run --features executable -- debug` flow that no longer exists in the VM.

Per @bobbinth on miden-vm#699:
> We don't have any references in the current docs to the old debug infrastructure.
> We have a link to the new debugger and a brief explanation on how to use it.

## Changes

- v0.13 `miden-vm/tools/debugger.md` — rewritten as a short pointer page to `miden-debug` repo + `midenc debug` for compiler-side flows
- v0.13 `miden-vm/tools/index.md` — updated Debugger description
- v0.13 `miden-vm/usage.md` — dropped `debug` subcommand line
- `docs/core-concepts/index.md` — added link to `0xMiden/miden-debug` next to existing Debugger bullet

## Out of scope

- Inline `debug.*` MASM ops in `miden-vm/user_docs/assembly/debugging.md` (decided separately in miden-vm#3069)
- Older versioned snapshots (v0.11, v0.12) — historical, untouched
- Rust-contract debugging in `docs/builder/` — separate workflow, out of scope of miden-vm#699

Closes #699 (docs portion).