### PR TITLE
docs(v0.14): wrap asset callback table cells

### DIFF
--- a/versioned_docs/version-0.14/core-concepts/protocol/asset.md
+++ b/versioned_docs/version-0.14/core-concepts/protocol/asset.md
@@ -84,8 +84,8 @@ It is recommended that faucets issue all of their assets with the same flag to e
 
 | Callback | Storage slot name | Triggered when |
 |---|---|---|
-| `on_before_asset_added_to_account` | `miden::protocol::faucet::callback::on_before_asset_added_to_account` | The asset is added to an account's vault (via `native_account::add_asset`). |
-| `on_before_asset_added_to_note` | `miden::protocol::faucet::callback::on_before_asset_added_to_note` | The asset is added to an output note (via `output_note::add_asset`). |
+| `on_before_asset_added_to_account` | <code>miden::protocol::faucet::callback::<wbr />on_before_asset_added_to_account</code> | Added to an account vault via `native_account::add_asset`. |
+| `on_before_asset_added_to_note` | <code>miden::protocol::faucet::callback::<wbr />on_before_asset_added_to_note</code> | Added to an output note via `output_note::add_asset`. |
 
 Account components that need to add callbacks to an account's storage should use the `AssetCallbacks` type, which provides an easy-to-use abstraction over these details.
 


### PR DESCRIPTION
## Summary
- add wrap opportunities to the long callback storage-slot identifiers on the v0.14 asset page
- shorten the callback descriptions slightly so the table fits more cleanly beside the right-hand sidebar

## Why
The asset callbacks table currently overflows horizontally because the storage-slot names are too wide for the content column. Giving those identifiers explicit wrap points keeps the content readable without changing the meaning.

## Testing
- `git diff --check`
- did not run a full Docusaurus build locally; change is limited to one versioned markdown table row layout

Closes #261
