### PR TITLE
Fix FAQ grammar

### DIFF
--- a/docs/builder/faq.md
+++ b/docs/builder/faq.md
@@ -92,10 +92,10 @@ A Miden operator is an entity that maintains the infrastructure necessary for th
 4. Maintaining Data Availability
 5. Participating in the Consensus Mechanism
 
-## How does bridging works in Miden?
+## How does bridging work in Miden?
 
-Miden does not yet have a fully operational bridge, work in progress.
+Miden does not yet have a fully operational bridge; it is a work in progress.
 
 ## What does the gas fee model of Miden look like?
 
-Miden does not yet have a fully implemented fee model, work in progress.
+Miden does not yet have a fully implemented fee model; it is a work in progress.


### PR DESCRIPTION
## Summary
- fix the FAQ question about bridging
- clean up two short work-in-progress sentences in the FAQ

## Validation
- checked the old wording no longer appears in `docs/builder/faq.md`