### PR TITLE
docs: expand Guardian architecture docs

### DIFF
--- a/docs/builder/miden-guardian/core-concepts/architecture.md
+++ b/docs/builder/miden-guardian/core-concepts/architecture.md
@@ -5,24 +5,52 @@ sidebar_position: 1
 
 # Architecture
 
-Guardian sits between Miden clients and the Miden network, providing an off-chain coordination layer for private account state.
+Guardian sits between Miden clients and the Miden network. It is an off-chain coordination layer for private account state, not the canonical source of account validity. Miden remains authoritative for account commitments; Guardian helps authorized clients keep the private state behind those commitments available, fresh, and synchronized.
 
 ## System overview
 
 ```mermaid
 graph LR
-    A["Miden Client A<br/>(Desktop)"] <-->|"gRPC / HTTP"| Guardian["Guardian Server"]
-    B["Miden Client B<br/>(Mobile)"] <-->|"gRPC / HTTP"| Guardian
-    Guardian <-->|"Validates state"| Node["Miden Node"]
+    Clients["Clients<br/>(apps and devices)"]
+    Guardian["Guardian<br/>(state, deltas, acknowledgements)"]
+    Network["Miden network<br/>(canonical account commitment)"]
+
+    Clients <-->|"signed state and delta requests"| Guardian
+    Clients -->|"proven account updates"| Network
+    Guardian -->|"commitment checks"| Network
 ```
 
-- **Miden Client** handles transaction execution, proving, and local state management.
-- **Guardian Server** stores state snapshots and deltas, authenticates requests, validates changes against the network, and coordinates multi-party workflows.
-- **Miden Node** is the network's RPC endpoint that Guardian validates state against.
+- **Clients** execute transactions, prove account updates, manage local state, sign Guardian requests, and verify any state returned by Guardian.
+- **Guardian** authenticates clients, stores state snapshots and deltas, acknowledges accepted deltas, and coordinates proposals.
+- **Miden network** remains the source of truth for account commitments and accepts the proven account updates submitted by clients.
 
-Each account is independently configured on Guardian with its own authentication policy and storage. Clients interact with Guardian through either gRPC or HTTP — both interfaces expose the same semantics.
+Each account is independently configured on Guardian with its own authentication policy and storage. Clients interact with Guardian through either gRPC or HTTP - both interfaces expose the same semantics.
 
-## End-to-end transaction flow
+## Design goals and non-goals
+
+| Category | Guardian does | Guardian does not |
+|---|---|---|
+| **State availability** | Stores state snapshots and replayable deltas for authorized clients. | Publish private state to Miden or make it globally readable. |
+| **Synchronization** | Helps clients converge on the latest canonical state. | Replace local client verification. |
+| **Integrity** | Links deltas with commitments and signs accepted updates. | Make the server's database authoritative if it conflicts with Miden. |
+| **Custody** | May participate as one configured key in a threshold account. | Move funds by itself. |
+| **Privacy** | Restricts API access to authenticated clients. | Hide submitted payloads from the server operator by default. |
+
+This distinction matters: Guardian improves recovery and coordination for Miden's private-account model, while preserving the core rule that account updates are valid only when the Miden network accepts the resulting commitment.
+
+## Data and trust boundaries
+
+| Boundary | Data crossing it | Protection |
+|---|---|---|
+| Client -> Guardian | Initial state, deltas, proposal payloads, signatures, timestamps. | Per-account signatures, replay protection, request-size limits, and rate limits. |
+| Guardian -> Client | Latest state, merged deltas, proposals, acknowledgement signatures. | Client verifies the Guardian acknowledgement key and commitment chain. |
+| Client -> Miden network | Proven account updates and resulting commitments. | Miden verification and account-update rules. |
+| Guardian -> Miden network | Account identifiers and commitment queries. | Network verification through a configured RPC endpoint. |
+| Inside Guardian | Metadata, state snapshots, deltas, proposals, auth timestamps. | Backend access control, deployment security, and commitment-chain verification by clients. |
+
+The Guardian operator is trusted for availability and for protecting its infrastructure. The operator is not trusted with unilateral custody, and clients should not treat the database as authoritative unless the returned commitments and acknowledgments verify.
+
+## State lifecycle
 
 Transactions proceed through a step-by-step process to ensure consistency and verifiability:
 
@@ -32,13 +60,14 @@ sequenceDiagram
     participant Guardian as Guardian Server
     participant Chain as Miden Network
 
-    Client->>Client: 1. Execute transaction locally<br/>Generate delta
-    Client->>Guardian: 2. Submit delta for acknowledgment
-    Guardian->>Guardian: 3. Validate delta against policies
-    Guardian->>Guardian: Co-sign as "candidate"
-    Guardian-->>Client: Return ack signature
-    Client->>Chain: 4. Submit ZK proof + state update
-    Chain-->>Guardian: 5. Guardian monitors on-chain commitment
+    Client->>Client: Execute transaction locally<br/>generate state delta
+    Client->>Guardian: push_delta + signed request
+    Guardian->>Guardian: Authenticate request<br/>verify delta against stored state
+    Guardian->>Guardian: Sign new commitment<br/>store as candidate
+    Guardian-->>Client: Return ack_sig + candidate delta
+    Client->>Chain: Submit ZK proof + account update
+    Guardian->>Chain: Poll commitment through configured RPC
+    Chain-->>Guardian: Return latest account commitment
     alt Commitment matches candidate
         Guardian->>Guardian: Promote to "canonical"
         Guardian-->>Client: Propagate confirmed delta
@@ -49,10 +78,10 @@ sequenceDiagram
 ```
 
 1. **Local execution**: The user computes a transaction locally, generating a delta (state change).
-2. **Delta submission**: The user sends the delta to Guardian for acknowledgment.
-3. **Guardian acknowledgment**: Guardian validates the delta and co-signs it, designating it as a "candidate" state.
-4. **Proof submission**: The user generates the ZK proof and submits it to the chain.
-5. **Canonical confirmation**: Guardian monitors the chain. If the on-chain commitment matches the candidate, the state becomes "canonical" and is propagated to other devices or signers.
+2. **Delta submission**: The client signs the request and submits the delta to Guardian.
+3. **Guardian acknowledgment**: Guardian validates the request, applies the delta to the stored state, computes the new commitment, and signs the accepted commitment.
+4. **Proof submission**: The client submits the proven account update to Miden.
+5. **Canonical confirmation**: Guardian checks the network commitment. If it matches the candidate, the delta becomes canonical and can be served to other clients.
 
 ## Multi-device sync
 
@@ -62,20 +91,29 @@ For users with multiple devices, Guardian keeps state synchronized seamlessly:
 sequenceDiagram
     participant Desktop as Desktop
     participant Guardian as Guardian Server
+    participant Network as Miden Network
     participant Mobile as Mobile
 
     Desktop->>Desktop: Execute transaction
     Desktop->>Guardian: Push delta
     Guardian->>Guardian: Validate & acknowledge
-    Desktop->>Desktop: Submit proof to chain
-    Guardian->>Guardian: Confirm canonical
+    Desktop->>Network: Submit proof + account update
+    Guardian->>Network: Poll commitment
+    Network-->>Guardian: Return latest account commitment
+    Guardian->>Guardian: Mark delta canonical
     Mobile->>Guardian: Get state
     Guardian-->>Mobile: Return latest state
     Mobile->>Mobile: Replay delta locally
     Note over Mobile: State now matches Desktop
 ```
 
-The desktop executes a transaction and pushes the delta to Guardian. After on-chain confirmation, Guardian propagates the canonical delta to the mobile device, which replays it locally — all without querying the chain directly.
+The desktop executes a transaction and pushes the delta to Guardian. After the account update is accepted by Miden and Guardian confirms the commitment, Guardian propagates the canonical delta to the mobile client, which replays it locally without querying the network directly.
+
+The receiving device should still verify:
+
+- the returned state or delta chain links to the expected commitment,
+- the Guardian acknowledgement signature is from the expected server key,
+- the local account state after replay matches the commitment it expects to use.
 
 ## Account management
 
@@ -85,7 +123,7 @@ For each request, the client signs a payload with one of those keys and the serv
 
 ## Canonicalization
 
-Canonicalization is the process of validating that a state transition (delta) is valid against the on-chain commitment. It is optional and mainly used in multi-user setups.
+Canonicalization is the process of validating that a candidate delta matches the account commitment accepted by Miden. It is optional and mainly used in multi-user setups.
 
 ```mermaid
 stateDiagram-v2
@@ -96,13 +134,26 @@ stateDiagram-v2
     discarded --> [*]
 ```
 
-- **Candidate mode** (default): A background worker promotes or discards deltas after a configurable delay and network verification.
+- **Candidate mode** (default): A background worker polls for candidate deltas, checks them against the Miden network, and promotes or discards them based on verification results.
 - **Optimistic mode**: Deltas become canonical immediately, skipping the verification window.
 
-| Parameter | Default | Description |
+| Parameter | Builder API default | Description |
 |---|---|---|
-| `delay_seconds` | 900 (15 min) | How long a candidate waits before the worker checks it. |
-| `check_interval_seconds` | 60 (1 min) | How often the worker runs. |
+| `check_interval_seconds` | 10 | How often the worker scans for candidate deltas. |
+| `max_retries` | 18 | Verification attempts before discarding a candidate after the grace period. |
+| `submission_grace_period_seconds` | 600 (10 min) | Minimum candidate age before verification failures consume retry budget. |
+
+The reference server binary uses a 10-second check interval, 48 retries, and a 10-minute submission grace period. Embedders using the builder API can configure canonicalization directly in code.
+
+## Failure and recovery model
+
+| Failure | Effect | Recovery path |
+|---|---|---|
+| Guardian unavailable | Clients cannot fetch backups, sync deltas, or gather Guardian-assisted signatures. | Use local state if available, retry later, or rotate to another provider with recovery keys. |
+| Candidate does not match Miden commitment | Guardian marks the candidate as discarded. | Client resyncs from the latest canonical state and rebuilds the transaction. |
+| Client submits stale delta | Guardian rejects the delta because `prev_commitment` does not match the active chain. | Client fetches state or `delta/since`, replays canonical deltas, then retries. |
+| Guardian withholds updates | Other clients may see stale state. | Compare against Miden commitment and use recovery/provider-rotation flow if needed. |
+| Guardian database is corrupted | Returned state may fail commitment or acknowledgement checks. | Client rejects unverifiable data and recovers from another backup or provider. |
 
 ## Common use cases
 

--- a/docs/builder/miden-guardian/core-concepts/components.md
+++ b/docs/builder/miden-guardian/core-concepts/components.md
@@ -7,9 +7,21 @@ sidebar_position: 3
 
 The Guardian server is composed of several pluggable components that handle different responsibilities.
 
+## Component map
+
+| Component | Responsibility | Operator concern |
+|---|---|---|
+| **API** | Exposes HTTP and gRPC routes for state, deltas, proposals, and server key discovery. | Transport exposure, CORS, request limits, rate limits. |
+| **Auth** | Verifies per-account signatures and prevents replay. | Clock sync, key rotation, account metadata integrity. |
+| **Acknowledger** | Signs accepted Miden deltas with the server acknowledgement key. | Keystore configuration, key persistence, key backup, `/pubkey` monitoring. |
+| **Network** | Applies and verifies deltas against Miden network rules. | Correct network selection and configured RPC connectivity. |
+| **Storage** | Persists state snapshots, deltas, and proposals. | Backend durability, access control, backups, migrations. |
+| **Metadata** | Stores account config, auth policy, timestamps, and network config. | Consistency with account auth state and replay-protection durability. |
+| **Operator dashboard** | Exposes operator-only views over accounts, deltas, proposals, and service status. | Operator authentication, session security, and access control. |
+
 ## API
 
-The API exposes a consistent interface for operating on states and deltas over HTTP and gRPC. Behavior is identical across transports, so clients can switch between them without semantic changes.
+The Miden state/delta API is exposed over HTTP and gRPC. The two transports use the same state, delta, proposal, and lookup semantics, so clients can switch between them without changing the underlying workflow.
 
 **HTTP endpoints** (default port 3000):
 
@@ -18,38 +30,73 @@ The API exposes a consistent interface for operating on states and deltas over H
 | `POST` | `/configure` | Create account with auth policy and initial state |
 | `POST` | `/delta` | Push a delta (server validates, signs, sets status) |
 | `GET` | `/delta?account_id&nonce` | Fetch delta by nonce |
-| `GET` | `/delta/since?account_id&from_nonce` | Merged canonical snapshot since a nonce |
+| `GET` | `/delta/since?account_id&nonce` | Merged canonical snapshot since a nonce |
 | `GET` | `/state?account_id` | Latest account state |
+| `GET` | `/state/lookup?key_commitment` | Find accounts whose auth policy contains a key commitment |
 | `POST` | `/delta/proposal` | Create pending proposal for multi-party signing |
 | `GET` | `/delta/proposal?account_id` | List pending proposals |
-| `PUT` | `/delta/proposal` | Append cosigner signature to a proposal |
+| `GET` | `/delta/proposal/single?account_id&commitment` | Fetch one proposal |
+| `PUT` | `/delta/proposal` | Append an authorized signature to a proposal |
 | `GET` | `/pubkey` | Server acknowledgment public key (unauthenticated) |
 
-**gRPC** (default port 50051) mirrors all HTTP endpoints with the same semantics. Credentials are provided via metadata headers.
+`GET /state/lookup` returns `{ accounts: [{ account_id }] }`. A single key commitment may be authorized on multiple accounts, and an empty list is a successful "no matching account" response.
+
+**gRPC** (default port 50051) mirrors the Miden state/delta surface above, including account lookup. Credentials are provided via metadata headers.
 
 For the full API specification, see the [spec/api.md](https://github.com/OpenZeppelin/guardian/blob/main/spec/api.md) in the repository.
 
+:::note
+The Guardian repository also contains EVM proposal routes under `/evm/*`. Those routes are separate from the Miden state/delta flow described here, are HTTP-only, and are registered only when the server is built with the `evm` Cargo feature.
+:::
+
 ## Auth
 
-Request authentication is configured per account. All endpoints except `/pubkey` require authentication.
+Request authentication is configured per account. All client-facing endpoints except `/pubkey` require authentication.
 
-### Falcon RPO
+### Miden request signing
 
-The current authentication policy uses Miden Falcon RPO signatures with an allowlist of **cosigner commitments** — hashes of authorized public keys.
+The current Miden authentication policies use an allowlist of authorized public-key commitments (`cosigner_commitments` in Guardian metadata). Guardian supports Miden Falcon RPO and Miden ECDSA commitments.
 
 Every authenticated request includes three headers:
 
 | Header | Description |
 |---|---|
 | `x-pubkey` | Signer's public key (full serialized key or 32-byte commitment hex) |
-| `x-signature` | Falcon RPO signature over the request digest |
+| `x-signature` | Signature over the Guardian request digest |
 | `x-timestamp` | Unix timestamp in milliseconds |
 
-The signature is computed over:
+For HTTP requests, the request payload digest is `RPO256` over canonical JSON bytes:
+
+- `POST` and `PUT` sign the request body.
+- `GET` signs the query object.
+
+For gRPC requests, the request payload digest is `RPO256` over the protobuf-encoded request bytes.
+
+The signed Miden message format is:
 
 ```
-RPO256_hash([account_id_prefix, account_id_suffix, timestamp_ms, 0])
+RPO256_hash([
+  account_id_prefix,
+  account_id_suffix,
+  timestamp_ms,
+  payload_hash_0,
+  payload_hash_1,
+  payload_hash_2,
+  payload_hash_3
+])
 ```
+
+This binds the signature to the account, the timestamp, and the exact request payload.
+
+### Lookup signing
+
+`GET /state/lookup` is account-less because the caller is trying to discover which account IDs authorize a key commitment. It uses a dedicated domain-separated message:
+
+```
+RPO256_hash([DOMAIN_TAG_w0..w3, timestamp_ms, key_commitment_w0..w3])
+```
+
+The caller proves possession of the queried key commitment. The endpoint uses the same 300-second timestamp skew window, but it does not maintain a monotonic timestamp anchor because there is no account yet. The regular Miden request path tracks `last_auth_timestamp` per account.
 
 ### Verification flow
 
@@ -64,7 +111,7 @@ sequenceDiagram
     Guardian->>Guardian: 2. Check commitment is in account allowlist
     Guardian->>Guardian: 3. Verify timestamp within 300s window
     Guardian->>Guardian: 4. Check timestamp > last_auth_timestamp
-    Guardian->>Guardian: 5. Verify Falcon signature over<br/>(account_id, timestamp) digest
+    Guardian->>Guardian: 5. Verify signature over<br/>(account_id, timestamp, payload_hash)
 
     alt All checks pass
         Guardian->>Guardian: Update last_auth_timestamp (CAS)
@@ -87,8 +134,15 @@ The Acknowledger produces tamper-evident acknowledgments for accepted deltas:
 
 - Signs the digest of `new_commitment` and returns the signature as `ack_sig`.
 - The server's acknowledgment key is exposed via the `/pubkey` endpoint for clients to cache and verify against.
+- `/configure` returns both `ack_pubkey` and `ack_commitment` so clients can bind an account setup to the Guardian key they expect.
+
+On first boot, Guardian creates the acknowledgement key if the configured keystore is empty. Operators still need to choose the keystore backend, persist it, back it up, and define a rotation playbook.
 
 Clients should verify `ack_sig` after every `push_delta` to confirm the server processed the change correctly.
+
+## Operator dashboard
+
+Guardian also includes an operator dashboard API and TypeScript client for operational visibility into configured accounts, delta status, in-flight proposals, and service health. This surface is not part of the client state/delta API and should be protected as an operator-only interface.
 
 ## Network
 
@@ -97,7 +151,9 @@ The Network component handles interactions with the Miden blockchain:
 - Computes commitments and validates deltas against the target network's rules.
 - Validates account identifiers and request credentials against network-owned state.
 - Merges multiple deltas into a single snapshot payload (for `get_delta_since`).
-- Surfaces suggested auth updates (e.g., rotated cosigner commitments) so metadata remains aligned with the network.
+- Surfaces suggested auth updates (e.g., rotated authorized key commitments) so metadata remains aligned with the network.
+
+Guardian does not trust client-provided network endpoints. Network identity is stored in account metadata, and operators configure the runtime network that Guardian validates against.
 
 ## Storage
 
@@ -111,10 +167,12 @@ Available backends:
 - **Filesystem** (default): Stores data on disk. Suitable for **testing and development**. No external dependencies.
 - **PostgreSQL** (optional): Recommended for **production** deployments. Requires the `postgres` feature flag at build time. Migrations run automatically on startup.
 
+Because storage contains account state and delta payloads, operators should treat it as sensitive infrastructure. Use normal database controls: encrypted disks or managed database encryption, least-privilege credentials, backups, retention limits, and audit logging.
+
 ## Metadata
 
 The Metadata store holds per-account configuration:
 
-- `account_id`, authentication policy, storage backend type, timestamps, and `last_auth_timestamp` for replay protection.
+- `account_id`, authentication policy, `network_config`, storage backend type, timestamps, and `last_auth_timestamp` for replay protection.
 - Supports CRUD operations and list iteration over accounts.
 - Can use filesystem or PostgreSQL as its backing store, independent of the Storage backend choice.

--- a/docs/builder/miden-guardian/core-concepts/data-structures.md
+++ b/docs/builder/miden-guardian/core-concepts/data-structures.md
@@ -7,47 +7,78 @@ sidebar_position: 2
 
 Guardian models account state as an append-only chain of snapshots and changes.
 
+The key design idea is simple: Guardian can help clients recover and synchronize state, but the state remains verifiable because each delta links to the previous commitment and produces a new commitment.
+
 ## State
 
-A **state** is a canonical snapshot of an account at a point in time. It includes the account's ID, commitment, nonce, vault (assets), storage, and other account data.
+A **state** is a snapshot of an account at a point in time. Guardian treats the account payload as client-supplied state data and tracks it with the account ID, commitment, timestamps, and auth scheme.
+
+Guardian's HTTP representation is a `StateObject`:
 
 ```json
 {
-  "account_id": "0xabc123...",
-  "commitment": "0xdef456...",
-  "nonce": 10,
-  "assets": [
-    { "balance": 12000, "asset_id": "USDC" },
-    { "balance": 2, "asset_id": "ETH" }
-  ]
+  "account_id": "0xabc123",
+  "state_json": {
+    "data": "<base64-encoded serialized account state>"
+  },
+  "commitment": "0xdef456",
+  "created_at": "2026-05-16T00:00:00Z",
+  "updated_at": "2026-05-16T00:00:00Z",
+  "auth_scheme": "falcon"
 }
 ```
 
-When you first register an account with Guardian, you provide an **initial state** — the baseline from which all subsequent changes are tracked.
+The `state_json` object is opaque to Guardian. For Miden accounts, the client SDK typically packs serialized account state into a `data` field; other examples in this section are illustrative unless called out as exact API shapes.
+
+When you first register an account with Guardian, you provide an **initial state** - the baseline from which all subsequent changes are tracked.
 
 ## Delta
 
-A **delta** represents a set of changes applied to a state. Deltas are append-only — each delta references the commitment of the state it was applied to, forming an unbroken chain.
+A **delta** represents a set of changes applied to a state. Deltas are append-only. Each delta references the commitment of the state it was applied to, forming an unbroken chain.
 
 ```json
 {
-  "account_id": "0xabc123...",
+  "account_id": "0xabc123",
   "nonce": 11,
-  "prev_commitment": "0xdef456...",
+  "prev_commitment": "0xdef456",
+  "new_commitment": "0x789abc",
   "delta_payload": {
     "data": "<base64-encoded TransactionSummary>"
+  },
+  "ack_sig": "0x...",
+  "ack_pubkey": "0x...",
+  "ack_scheme": "falcon",
+  "status": {
+    "status": "candidate",
+    "timestamp": "2026-05-16T00:00:00Z",
+    "retry_count": 0
   }
 }
 ```
 
 A useful mental model: a delta is a compact, replayable description of "what changed" in an account's local state. Deltas can sync, back up, and reconstruct state without shipping full snapshots.
 
+`new_commitment` is present once Guardian has acknowledged a delta. Pending proposals do not have a resulting commitment yet, so the field is omitted on the wire.
+
 Key properties:
 
 - **Ordered**: Each delta has a nonce that determines its position in the chain.
-- **Linked**: The `prev_commitment` field references the state the delta was applied to. This prevents forks — if two deltas reference different base states, the server rejects the conflicting one.
-- **Validated**: The server verifies each delta against the Miden network before accepting it.
+- **Linked**: The `prev_commitment` field references the state the delta was applied to. This prevents forks - if two deltas reference different base states, the server rejects the conflicting one.
+- **Validated**: The server validates each delta against the current stored state. In candidate mode, canonicalization later checks the resulting commitment against the Miden network before marking the delta canonical.
 - **Acknowledged**: Once accepted, the server signs the delta's `new_commitment`, providing cryptographic proof that it was processed.
+
+## Visibility
+
+Guardian stores the state and delta payloads submitted by clients. These records are private from unauthorized API callers, but they are sensitive server-side data.
+
+| Record | Who can request it through Guardian | What the operator may observe |
+|---|---|---|
+| `StateObject` | Authorized account participants. | Full submitted `state_json`, account ID, commitment, timestamps, auth scheme. |
+| `DeltaObject` | Authorized account participants. | Delta payload, nonce, previous and new commitments, status, ack metadata. |
+| Delta proposal | Authorized account participants. | Transaction summary payload, signer commitments, signatures, proposal metadata. |
+| Metadata | Server internals and operator tooling. | Auth policy, network config, last auth timestamp, account identifiers. |
+
+Do not treat Guardian storage as public data. Operators should apply production database controls, and clients should verify commitments before trusting returned state.
 
 ### Delta status lifecycle
 
@@ -70,6 +101,8 @@ stateDiagram-v2
 
 In **optimistic mode**, deltas skip the `candidate` stage and are immediately marked `canonical`.
 
+Discarded deltas must not be returned by default sync APIs. A client that sees a discarded candidate should resync from the latest canonical state before constructing a new transaction.
+
 ## Commitments
 
 A **commitment** is a cryptographic hash that uniquely identifies a particular version of an account's state. Commitments are the integrity backbone of Guardian:
@@ -83,32 +116,32 @@ graph LR
 
 - Each state snapshot has a commitment.
 - Each delta includes a `prev_commitment` (the base state) and produces a `new_commitment` (the resulting state).
-- The chain ensures that any tampering — inserting, reordering, or dropping deltas — is detectable by any client that tracks commitments.
+- The chain ensures that any tampering - inserting, reordering, or dropping deltas - is detectable by any client that tracks commitments.
 
 ## Delta proposals
 
 A **delta proposal** is a coordination mechanism for multi-party accounts. When multiple signers must agree on a transaction:
 
 1. **Propose**: One signer creates a delta proposal containing a `TransactionSummary`. Guardian validates the proposal against the current account state.
-2. **Sign**: Other authorized cosigners fetch the pending proposal, verify it locally, and submit their signatures.
-3. **Execute**: Once enough signatures are collected (meeting the threshold), any cosigner can promote the proposal to a canonical delta via `push_delta`.
+2. **Sign**: Other authorized account participants fetch the pending proposal, verify it locally, and submit their signatures.
+3. **Execute**: Once enough signatures are collected (meeting the threshold), any authorized participant can promote the proposal to a delta via `push_delta`.
 
 ```mermaid
 sequenceDiagram
     participant P as Proposer
     participant Guardian as Guardian Server
-    participant C as Cosigner
+    participant S as Signer
 
     P->>Guardian: push_delta_proposal<br/>(tx_summary + initial signature)
     Guardian->>Guardian: Validate against current state
     Guardian-->>P: Return proposal with commitment
 
-    C->>Guardian: get_delta_proposals
-    Guardian-->>C: Return pending proposals
+    S->>Guardian: get_delta_proposals
+    Guardian-->>S: Return pending proposals
 
-    C->>C: Verify proposal details locally
-    C->>Guardian: sign_delta_proposal<br/>(commitment + signature)
-    Guardian-->>C: Updated proposal with signatures
+    S->>S: Verify proposal details locally
+    S->>Guardian: sign_delta_proposal<br/>(commitment + signature)
+    Guardian-->>S: Updated proposal with signatures
 
     P->>Guardian: push_delta<br/>(with all collected signatures)
     Guardian->>Guardian: Validate & acknowledge
@@ -118,3 +151,13 @@ sequenceDiagram
 Proposals remain in `pending` status until promoted. Once the corresponding delta becomes canonical, the proposal is automatically cleaned up.
 
 Delta proposals have their own commitment, derived from `(account_id, nonce, tx_summary)`, used as a stable identifier.
+
+## Invariants
+
+Clients and operators should preserve these invariants:
+
+- A delta must reference the active previous commitment for the account.
+- A canonical delta must match the commitment accepted by Miden.
+- A proposal remains pending until enough authorized signatures are collected and the payload is promoted through `push_delta`.
+- A matching proposal is deleted once its delta becomes canonical.
+- A client should reject state that does not replay to the expected commitment.

--- a/docs/builder/miden-guardian/core-concepts/security.md
+++ b/docs/builder/miden-guardian/core-concepts/security.md
@@ -1,55 +1,59 @@
 ---
 title: Security
 sidebar_position: 4
+hide_title: true
 ---
 
-# Edge Cases & Security Considerations
-
-Guardian is designed around a clear trust model with well-defined security boundaries.
+Guardian stores and relays account state for clients. It is not a custodian, and it is not a private execution environment.
 
 ## Trust model
 
-The right threat model for Guardian is **honest-but-curious**: the server is expected to follow the protocol and availability guarantees, but may try to learn as much as it can from any data it is given.
+Guardian is an availability and coordination service. Miden remains authoritative for account commitments, and users keep the keys required to recover or rotate providers.
 
-Guardian is non-custodial. The provider holds no keys that can unilaterally move funds.
+| Area | Guardian role | Client or user responsibility |
+|---|---|---|
+| State sync | Stores and relays submitted state, deltas, proposals, metadata, and timestamps. | Verify returned commitments before relying on state. |
+| Request auth | Authenticates account requests and rejects stale or conflicting deltas. | Keep user signing keys secure and resync before signing stale state. |
+| Acknowledgements | Signs accepted deltas with the Guardian acknowledgement key. | Verify `/pubkey`, `ack_sig`, and delta ordering. |
+| Account policy | May participate as one signer in a multi-key account policy. | Keep a user-controlled recovery path that can remove or replace Guardian. |
+| Privacy and availability | Can see submitted payloads and access patterns, and can deny or delay service. | Treat Guardian as an operator-visible availability service. |
 
-### What Guardian can do
+Guardian should not be trusted to move funds on its own, change the account commitment accepted by Miden, hide submitted data from the operator, or guarantee availability.
 
-- **Store and relay** state snapshots and deltas.
-- **Validate** deltas against the Miden network before acknowledging them.
-- **Co-sign** transactions as one party in a threshold scheme.
-- **Enforce policies** (rate limits, timelocks) at the co-signing layer.
+:::important
+**User-controlled rotation.** Users can rotate Guardian at any time through their own recovery path. The current Guardian does not sign the rotation and does not need to serve an API response for it.
+:::
 
-### What Guardian cannot do
+## User control and provider rotation
 
-- **Forge state**: Every delta references the previous commitment. Inserting, reordering, or dropping deltas breaks the commitment chain, detectable by any client.
-- **Move funds unilaterally**: Guardian holds at most one key in a multi-key setup. It always needs the user's key to complete a transaction.
-- **Tamper silently**: The server signs each accepted delta with its acknowledgment key. Clients can verify these signatures to detect any tampering.
+In the standard assisted-custody setup, the account policy includes a user-controlled recovery path, such as user hot key + user cold key. This lets the user remove or replace Guardian without the current Guardian participating.
 
-### What Guardian can do adversarially
+The current Guardian does not sign the rotation and does not need to serve an API response for it. The user updates the account policy to remove the old Guardian key commitment, adds the new Guardian if needed, and configures the new provider with a verified state snapshot.
 
-- **Deny service**: The server can refuse to serve data or accept deltas. This is a liveness issue, not a safety issue — users can recover using their own keys.
-- **Withhold updates**: The server could delay propagating deltas to other devices. Clients should verify state freshness against on-chain commitments.
+```mermaid
+sequenceDiagram
+    participant User as User keys
+    participant Old as Current Guardian
+    participant Network as Miden Network
+    participant New as New Guardian
 
-## Integrity guarantees
+    User->>Network: Update account policy<br/>remove old Guardian key
+    Network-->>User: Return accepted account commitment
+    User->>New: Configure provider<br/>with verified state snapshot
+    Note over Old: No signature or API response required
+```
 
-### Commitment chain
+## Client checks
 
-Every delta includes a `prev_commitment` referencing the base state. This creates an unbroken chain:
+Clients should verify:
 
-- If the server drops a delta, subsequent deltas won't validate because their `prev_commitment` won't match.
-- If the server inserts a fake delta, the commitment chain diverges from the on-chain state.
-- Clients can verify the chain independently by tracking commitments locally.
+1. The expected Guardian acknowledgement key from `/pubkey`.
+2. `ack_sig` on accepted deltas.
+3. Delta ordering through `prev_commitment` and `new_commitment`.
+4. The latest account commitment against Miden before recovery, provider rotation, or high-value signing.
+5. Fresh state before signing if another client or authorized signer may have advanced the account.
 
-### Server acknowledgment
-
-After accepting a delta, the server signs the `new_commitment` with its acknowledgment key. Clients should:
-
-1. Retrieve the server's public key via `/pubkey`.
-2. Verify `ack_sig` on every `push_delta` response.
-3. Alert on verification failure — it indicates the server may have been compromised or is not processing deltas correctly.
-
-## 2-of-3 key setup
+## Common 2-of-3 setup
 
 A common Guardian configuration uses a **2-of-3** threshold embedded in the account's authentication code:
 
@@ -61,41 +65,15 @@ A common Guardian configuration uses a **2-of-3** threshold embedded in the acco
 
 ```mermaid
 graph TD
-    subgraph "Normal operation (Hot + Guardian)"
-        Hot["User Hot Key"] --> TX["Transaction"]
-        GuardianKey["Guardian Service Key"] --> TX
+    subgraph "Normal operation"
+        Hot["User hot key"] --> TX["Transaction"]
+        GuardianKey["Guardian service key"] --> TX
     end
 
-    subgraph "Emergency override (Hot + Cold)"
-        Hot2["User Hot Key"] --> Override["Rotate Guardian / Adjust policies<br/>Switch providers"]
-        Cold["User Cold Key"] --> Override
+    subgraph "Emergency override"
+        Hot2["User hot key"] --> Override["Rotate Guardian<br/>or adjust policy"]
+        Cold["User cold key"] --> Override
     end
 ```
 
-- **Normal operations**: Hot key + Guardian's co-signature suffice. Guardian verifies the signer is working from the latest state.
-- **Emergency override**: Hot + cold keys alone can rotate out Guardian, adjust policies, or switch providers.
-- **Recovery**: If the Guardian provider disappears, the user's hot + cold keys provide full independent control.
-
-## Device recovery
-
-**Without Guardian**: A lost device means falling back to a cold backup. Any state changes since the last checkpoint are lost. If an attacker has the device PIN, funds may be at risk.
-
-**With Guardian**: The remaining device already has the latest state (synced through Guardian). The user initiates a hot key rotation using their cold key. The stolen device's keys become invalid. Recovery takes minutes.
-
-## Edge cases
-
-### State divergence
-
-If two devices submit deltas referencing different base states, Guardian rejects the conflicting one (commitment mismatch). The rejected device must resync from Guardian before retrying.
-
-### Stale candidates
-
-If a candidate delta's on-chain commitment doesn't match during canonicalization, it is marked `discarded`. Clients are signaled to resync. This is not a rollback of the chain — it prevents clients from drifting onto an invalid local branch.
-
-### Clock skew
-
-Authentication requires timestamps within a 300-second window. Devices with significantly drifting clocks will fail authentication. Ensure NTP synchronization on client devices.
-
-### Provider rotation
-
-Users can switch Guardian providers at any time using their hot + cold keys. The new provider is configured with the account's current state and a fresh cosigner allowlist. The old provider's key is rotated out of the account's authentication policy.
+Normal transactions can use the hot key plus Guardian. Emergency actions can use the hot key plus cold key, without Guardian involvement.

--- a/docs/builder/miden-guardian/index.md
+++ b/docs/builder/miden-guardian/index.md
@@ -5,34 +5,58 @@ sidebar_position: 0
 
 # Miden Guardian
 
-Miden Guardian is a system built by [OpenZeppelin](https://www.openzeppelin.com/) that allows Miden accounts to back up and sync their private state securely without trust assumptions about other participants or the server operator.
+Miden Guardian is an off-chain coordination service built by [OpenZeppelin](https://www.openzeppelin.com/) for Miden accounts. It helps clients back up private account state, synchronize that state across devices, and coordinate multi-signer workflows without giving the Guardian provider unilateral control over the account.
+
+:::warning
+Guardian is a work in progress. Use the docs and the [OpenZeppelin Guardian repository](https://github.com/OpenZeppelin/guardian) as the current operator and integration reference, and expect interfaces and operational defaults to evolve.
+:::
 
 ## The problem
 
-Miden's execution model requires clients to manage their own private state — accounts, notes, storage — locally on-device. While this provides strong privacy and scalability, it introduces real challenges:
+Miden's execution model requires clients to manage their own private state - accounts, notes, storage - locally on-device. While this provides strong privacy and scalability, it introduces real challenges:
 
 - **Solo-account users** risk losing access if local state is not backed up. Losing any part of the account state means losing access to the account itself.
 - **Shared-account users** risk having stale state due to a faulty or malicious participant withholding updates.
 - **Multi-device users** need all devices to see the same account state, but there is no public ledger to read from.
 
-On a public chain, the ledger is a universally readable source of truth — every device and every signer can independently observe the latest state. In Miden's private account model, the canonical state is defined by the on-chain commitment, but it isn't readable in a way that keeps devices and signers automatically up to date. The coordination surface moves off-chain.
+On a public chain, the ledger is a universally readable source of truth. Every device and every signer can independently observe the latest state. In Miden's private account model, the canonical state is defined by the on-chain commitment, but the full private state is not publicly readable. The coordination surface moves off-chain.
 
 ## What Guardian provides
 
 Guardian addresses these challenges by acting as an off-chain coordination layer:
 
-- **Backup and recovery** — Account state is stored on Guardian, recoverable even if a device is lost.
-- **Multi-device sync** — Multiple devices push and pull state through Guardian, staying in sync with the latest canonical state.
-- **Multi-party coordination** — Shared accounts use delta proposals to coordinate threshold signing across participants.
-- **Integrity verification** — Every state change is validated against the Miden network and acknowledged with a cryptographic signature.
+- **Backup and recovery** - Account state is stored on Guardian, recoverable even if a device is lost.
+- **Multi-device sync** - Multiple devices push and pull state through Guardian, staying in sync with the latest canonical state.
+- **Multi-party coordination** - Shared accounts use delta proposals to coordinate threshold signing across participants.
+- **Integrity verification** - State changes are linked by commitments, validated against the Miden network, and acknowledged with a cryptographic signature.
 
-Guardian is non-custodial. The provider cannot move funds unilaterally — it stores state and coordinates changes, but users retain cryptographic control over their accounts at all times.
+Guardian is not a private execution environment, a sequencer, or a rollup. Clients still execute transactions locally and submit proofs to Miden. Guardian stores and coordinates the state data that authorized clients submit to it.
+
+## Architecture at a glance
+
+| Layer | Responsibility | What remains authoritative |
+|---|---|---|
+| **Miden network** | Stores commitments and verifies account updates. | The canonical account commitment. |
+| **Miden client** | Executes transactions, manages local state, proves updates, and signs Guardian requests. | The user's keys and local verification logic. |
+| **Guardian server** | Stores snapshots, stores deltas, authenticates readers/writers, acknowledges accepted deltas, and coordinates proposals. | Only the data it has accepted and signed. |
+| **Storage backend** | Persists metadata, state snapshots, deltas, and pending proposals. | The append-only commitment chain, as verified by clients and the network. |
+
+Guardian is non-custodial. The provider cannot move funds unilaterally - it stores state and coordinates changes, but users retain cryptographic control over their accounts at all times.
+
+## Trust model summary
+
+Guardian has an explicit trust boundary:
+
+- **Safety**: The provider cannot forge account state, silently rewrite the commitment chain, or move assets without the required account signatures.
+- **Liveness**: The provider can delay, censor, or refuse requests. Users should keep recovery keys and provider-rotation paths available.
+- **Privacy**: Guardian protects state from unauthorized API callers, but the server stores the account state and delta payloads it receives. Treat the operator as able to observe submitted payloads unless your deployment adds a separate encryption layer or you operate the service yourself.
+- **Freshness**: Clients should verify acknowledgments and compare local state against the latest on-chain commitment when freshness matters.
 
 ## Learn more
 
 <CardGrid cols={2}>
   <Card title="Architecture" href="./core-concepts/architecture" eyebrow="Core concepts">
-    How Guardian fits between clients and the Miden network.
+    Roles, trust boundaries, state flow, and failure behavior.
   </Card>
   <Card title="Data structures" href="./core-concepts/data-structures" eyebrow="Core concepts">
     State, deltas, commitments, and delta proposals.
@@ -53,4 +77,4 @@ Guardian is non-custodial. The provider cannot move funds unilaterally — it st
 
 ## Repository
 
-- [Miden Guardian](https://github.com/OpenZeppelin/guardian) — Guardian server, client SDKs, multisig client libraries, and specification
+- [Miden Guardian](https://github.com/OpenZeppelin/guardian) - Guardian server, client SDKs, multisig client libraries, and specification

--- a/docs/builder/miden-guardian/operator-guide/deployment.md
+++ b/docs/builder/miden-guardian/operator-guide/deployment.md
@@ -5,7 +5,11 @@ sidebar_position: 2
 
 # Deploying Miden Guardian
 
-The repository deploy script provisions and updates the AWS infrastructure used by the reference Guardian deployment. Operators on other platforms can run the same server binary with the same environment variables — adapt the surrounding services to taste.
+The repository deploy script provisions and updates the AWS infrastructure used by the reference Guardian deployment. Operators on other platforms can run the same server binary with the same environment variables - adapt the surrounding services to taste.
+
+:::warning
+Guardian stores private account state and delta payloads submitted by clients. Treat the deployment like sensitive wallet infrastructure even though Guardian is non-custodial.
+:::
 
 The reference AWS deployment uses:
 
@@ -15,6 +19,29 @@ The reference AWS deployment uses:
 - Secrets Manager (env vars + ack keys)
 - ECR for container images
 - CloudWatch for logs
+
+## Deployment architecture
+
+```mermaid
+graph LR
+    Client["Authorized clients"] --> ALB["TLS load balancer"]
+    ALB --> Server["Guardian server"]
+    Server --> DB["Postgres<br/>state, deltas, metadata"]
+    Server --> Secrets["Secrets Manager<br/>ack keys, operator allowlist"]
+    Server --> Node["Miden node RPC"]
+    Server --> Logs["Logs / metrics"]
+```
+
+Production deployments should make the trust boundary explicit:
+
+| Boundary | Production expectation |
+|---|---|
+| Client traffic | TLS termination, explicit CORS allowlist for browser clients, request-size limits, rate limits. |
+| Guardian server | Reproducible build hash recorded, minimal IAM permissions, no shell access for normal operation. |
+| Database | Managed Postgres, encrypted storage, backups, migration visibility, least-privilege credentials. |
+| Ack keys | Generated once per environment, stored in Secrets Manager, monitored for unexpected rotation. |
+| Node RPC | Explicit network target; do not accept client-provided RPC endpoints. |
+| Logs | Avoid logging full state or delta payloads. Retain enough metadata for debugging canonicalization failures. |
 
 ## AWS deploy script
 
@@ -58,15 +85,15 @@ Filesystem storage is the default local backend; the `postgres` feature with a v
 
 | Var                                          | Default     | AWS prod override |
 | -------------------------------------------- | ----------- | ----------------- |
-| `GUARDIAN_RATE_LIMIT_ENABLED`                | `true`      | —                 |
+| `GUARDIAN_RATE_LIMIT_ENABLED`                | `true`      | -                 |
 | `GUARDIAN_RATE_BURST_PER_SEC`                | `10`        | `200`             |
 | `GUARDIAN_RATE_PER_MIN`                      | `60`        | `5000`            |
-| `GUARDIAN_MAX_REQUEST_BYTES`                 | `1048576`   | —                 |
-| `GUARDIAN_MAX_PENDING_PROPOSALS_PER_ACCOUNT` | `20`        | —                 |
+| `GUARDIAN_MAX_REQUEST_BYTES`                 | `1048576`   | -                 |
+| `GUARDIAN_MAX_PENDING_PROPOSALS_PER_ACCOUNT` | `20`        | -                 |
 | `GUARDIAN_DB_POOL_MAX_SIZE`                  | `16`        | `32`              |
-| `GUARDIAN_METADATA_DB_POOL_MAX_SIZE`         | (matches storage pool) | —      |
+| `GUARDIAN_METADATA_DB_POOL_MAX_SIZE`         | (matches storage pool) | -      |
 
-Rate limiting is on by default; pass `0`, `false`, `no`, or `off` to `GUARDIAN_RATE_LIMIT_ENABLED` to disable. Invalid values for `GUARDIAN_MAX_REQUEST_BYTES` are silently ignored — the default is used.
+Rate limiting is on by default; pass `0`, `false`, `no`, or `off` to `GUARDIAN_RATE_LIMIT_ENABLED` to disable. Invalid values for `GUARDIAN_MAX_REQUEST_BYTES` are silently ignored - the default is used.
 
 ### Operator allowlist + CORS
 
@@ -78,7 +105,16 @@ Rate limiting is on by default; pass `0`, `false`, `no`, or `off` to `GUARDIAN_R
 
 ## Canonicalization
 
-The server runs a canonicalization pass every **10 seconds** with a **10-minute** submission grace period. Both values are hard-coded in `crates/server/src/main.rs` and are **not** configurable via environment variable — embedders that need different timing must call the builder API in code.
+The server runs a canonicalization pass every **10 seconds** with a **10-minute** submission grace period. Both values are hard-coded in `crates/server/src/main.rs` and are **not** configurable via environment variable - embedders that need different timing must call the builder API in code.
+
+Operators should monitor:
+
+- candidate deltas older than the grace period,
+- discarded deltas,
+- repeated canonicalization failures for the same account,
+- Miden node RPC failures,
+- acknowledgement key changes,
+- database write latency and migration failures.
 
 ## Reproducible builds
 
@@ -87,3 +123,5 @@ The server runs a canonicalization pass every **10 seconds** with a **10-minute*
 ```
 
 The script must run inside a git checkout of the repo with a `Dockerfile` at the root. It builds the server image, copies the resulting `/app/server` binary out, and prints its SHA256, size, and the source commit. Uncommitted local changes produce a warning but do not fail the script.
+
+Record the output with the deployment change. It gives operators and integrators a concrete artifact to compare when debugging or auditing a running Guardian instance.

--- a/docs/builder/miden-guardian/operator-guide/troubleshooting.md
+++ b/docs/builder/miden-guardian/operator-guide/troubleshooting.md
@@ -21,9 +21,11 @@ The Guardian key is loaded from the configured keystore path. Confirm the same `
 
 For production AWS deployments, confirm `GUARDIAN_ENV=prod` and `AWS_REGION` are set so acknowledgement keys are loaded from Secrets Manager rather than the filesystem.
 
+Clients should treat an unexpected `/pubkey` change as a trust-boundary event. New acknowledgement signatures should not be accepted until the operator confirms an intentional key rotation.
+
 ## Authentication failures
 
-Guardian requires signed requests. Each carries three headers — `x-pubkey`, `x-signature`, and `x-timestamp` — and the timestamp is validated against two rules:
+Guardian requires signed requests. Each carries three headers - `x-pubkey`, `x-signature`, and `x-timestamp` - and the timestamp is validated against two rules:
 
 - It must be within ±5 minutes of server time (`MAX_TIMESTAMP_SKEW_MS = 300_000`).
 - It must be **strictly greater** than the last timestamp the server saw for that public key. The metadata store enforces this with a CAS update; a request with a timestamp equal to or below the previous one is rejected even if otherwise valid.
@@ -33,7 +35,7 @@ Common causes:
 - Client clock is more than 5 minutes from server time.
 - Timestamp was reused (replay attempt or accidental retry without re-signing).
 - Request body changed after signing.
-- Client is using the wrong Guardian public key — re-fetch `/pubkey`.
+- Client is using the wrong Guardian public key - re-fetch `/pubkey`.
 
 ## Proposal stays pending
 
@@ -48,6 +50,36 @@ Common causes:
 - Metadata backend is not writable.
 - The pending-proposal count has hit `GUARDIAN_MAX_PENDING_PROPOSALS_PER_ACCOUNT` (default `20`); see [error code `pending_proposals_limit`](#common-error-codes).
 
+## Candidate delta is discarded
+
+A discarded delta means Guardian could not verify that the candidate's `new_commitment` matches the commitment accepted by Miden.
+
+First checks:
+
+- The client submitted the Miden transaction proof after receiving the Guardian acknowledgement.
+- The client submitted the exact transaction that produced the acknowledged `new_commitment`.
+- The Miden node RPC endpoint is pointed at the expected network.
+- No other device advanced the account state first.
+
+Client recovery path:
+
+1. Fetch the latest canonical state or `delta/since`.
+2. Replay locally and verify the resulting commitment.
+3. Rebuild the transaction from the fresh state.
+4. Submit a new delta.
+
+## Client receives stale state
+
+Guardian can be unavailable, delayed, or serving data from a lagging backend. The client should compare the recovered local commitment against the latest commitment accepted by Miden before relying on restored state.
+
+Operator checks:
+
+- Canonicalization worker is running.
+- Miden node RPC is healthy and on the expected network.
+- Database writes are succeeding.
+- Candidate deltas are not stuck beyond the grace period.
+- Logs do not show repeated `storage_error`, `network_error`, or canonicalization failures.
+
 ## Rate limit errors
 
 If requests are rejected under load, tune:
@@ -58,7 +90,7 @@ GUARDIAN_RATE_PER_MIN            # default 60
 GUARDIAN_MAX_REQUEST_BYTES       # default 1048576
 ```
 
-The HTTP rate-limit middleware responds with `429 Too Many Requests` and a `Retry-After` header plus `retry_after_secs` in the body. **Note:** these middleware-level rejections do not include a `code` field — only the Guardian application-level `rate_limit_exceeded` error does. See the table below.
+The HTTP rate-limit middleware responds with `429 Too Many Requests` and a `Retry-After` header plus `retry_after_secs` in the body. **Note:** these middleware-level rejections do not include a `code` field - only the Guardian application-level `rate_limit_exceeded` error does. See the table below.
 
 ## Common error codes
 
@@ -68,6 +100,7 @@ The server emits structured error codes via `GuardianError::code()`. The most co
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `authentication_failed` | Auth headers missing or malformed, clock skew > 5 min, signature invalid, or the timestamp was already used.          | `x-pubkey` / `x-signature` / `x-timestamp` headers; client clock sync; the last timestamp you sent. |
 | `account_not_found`     | The metadata store has no record for that account ID.                                                                 | Account ID is correct and `/configure` actually completed against this server.                      |
-| `invalid_input`         | Generic 400 — request JSON, query parameters, or commitment shape failed validation.                                  | Request payload schema; commitment hex format.                                                      |
+| `invalid_input`         | Generic 400 - request JSON, query parameters, or commitment shape failed validation.                                  | Request payload schema; commitment hex format.                                                      |
 | `rate_limit_exceeded`   | Application-level rate limit hit. (The HTTP middleware also emits `429` responses, but those have no `code` field.)   | Tune `GUARDIAN_RATE_BURST_PER_SEC` / `GUARDIAN_RATE_PER_MIN`; check `Retry-After` on the response.  |
 | `storage_error`         | The storage or metadata backend rejected an operation.                                                                | Filesystem permissions on the storage paths, or database health for Postgres mode.                  |
+| `pending_proposals_limit` | The account already has the maximum number of pending proposals.                                                    | Resolve, cancel, or clean old proposals; raise `GUARDIAN_MAX_PENDING_PROPOSALS_PER_ACCOUNT` if appropriate. |

--- a/versioned_docs/version-0.14/builder/miden-guardian/core-concepts/architecture.md
+++ b/versioned_docs/version-0.14/builder/miden-guardian/core-concepts/architecture.md
@@ -5,24 +5,52 @@ sidebar_position: 1
 
 # Architecture
 
-Guardian sits between Miden clients and the Miden network, providing an off-chain coordination layer for private account state.
+Guardian sits between Miden clients and the Miden network. It is an off-chain coordination layer for private account state, not the canonical source of account validity. Miden remains authoritative for account commitments; Guardian helps authorized clients keep the private state behind those commitments available, fresh, and synchronized.
 
 ## System overview
 
 ```mermaid
 graph LR
-    A["Miden Client A<br/>(Desktop)"] <-->|"gRPC / HTTP"| Guardian["Guardian Server"]
-    B["Miden Client B<br/>(Mobile)"] <-->|"gRPC / HTTP"| Guardian
-    Guardian <-->|"Validates state"| Node["Miden Node"]
+    Clients["Clients<br/>(apps and devices)"]
+    Guardian["Guardian<br/>(state, deltas, acknowledgements)"]
+    Network["Miden network<br/>(canonical account commitment)"]
+
+    Clients <-->|"signed state and delta requests"| Guardian
+    Clients -->|"proven account updates"| Network
+    Guardian -->|"commitment checks"| Network
 ```
 
-- **Miden Client** handles transaction execution, proving, and local state management.
-- **Guardian Server** stores state snapshots and deltas, authenticates requests, validates changes against the network, and coordinates multi-party workflows.
-- **Miden Node** is the network's RPC endpoint that Guardian validates state against.
+- **Clients** execute transactions, prove account updates, manage local state, sign Guardian requests, and verify any state returned by Guardian.
+- **Guardian** authenticates clients, stores state snapshots and deltas, acknowledges accepted deltas, and coordinates proposals.
+- **Miden network** remains the source of truth for account commitments and accepts the proven account updates submitted by clients.
 
-Each account is independently configured on Guardian with its own authentication policy and storage. Clients interact with Guardian through either gRPC or HTTP — both interfaces expose the same semantics.
+Each account is independently configured on Guardian with its own authentication policy and storage. Clients interact with Guardian through either gRPC or HTTP - both interfaces expose the same semantics.
 
-## End-to-end transaction flow
+## Design goals and non-goals
+
+| Category | Guardian does | Guardian does not |
+|---|---|---|
+| **State availability** | Stores state snapshots and replayable deltas for authorized clients. | Publish private state to Miden or make it globally readable. |
+| **Synchronization** | Helps clients converge on the latest canonical state. | Replace local client verification. |
+| **Integrity** | Links deltas with commitments and signs accepted updates. | Make the server's database authoritative if it conflicts with Miden. |
+| **Custody** | May participate as one configured key in a threshold account. | Move funds by itself. |
+| **Privacy** | Restricts API access to authenticated clients. | Hide submitted payloads from the server operator by default. |
+
+This distinction matters: Guardian improves recovery and coordination for Miden's private-account model, while preserving the core rule that account updates are valid only when the Miden network accepts the resulting commitment.
+
+## Data and trust boundaries
+
+| Boundary | Data crossing it | Protection |
+|---|---|---|
+| Client -> Guardian | Initial state, deltas, proposal payloads, signatures, timestamps. | Per-account signatures, replay protection, request-size limits, and rate limits. |
+| Guardian -> Client | Latest state, merged deltas, proposals, acknowledgement signatures. | Client verifies the Guardian acknowledgement key and commitment chain. |
+| Client -> Miden network | Proven account updates and resulting commitments. | Miden verification and account-update rules. |
+| Guardian -> Miden network | Account identifiers and commitment queries. | Network verification through a configured RPC endpoint. |
+| Inside Guardian | Metadata, state snapshots, deltas, proposals, auth timestamps. | Backend access control, deployment security, and commitment-chain verification by clients. |
+
+The Guardian operator is trusted for availability and for protecting its infrastructure. The operator is not trusted with unilateral custody, and clients should not treat the database as authoritative unless the returned commitments and acknowledgments verify.
+
+## State lifecycle
 
 Transactions proceed through a step-by-step process to ensure consistency and verifiability:
 
@@ -32,13 +60,14 @@ sequenceDiagram
     participant Guardian as Guardian Server
     participant Chain as Miden Network
 
-    Client->>Client: 1. Execute transaction locally<br/>Generate delta
-    Client->>Guardian: 2. Submit delta for acknowledgment
-    Guardian->>Guardian: 3. Validate delta against policies
-    Guardian->>Guardian: Co-sign as "candidate"
-    Guardian-->>Client: Return ack signature
-    Client->>Chain: 4. Submit ZK proof + state update
-    Chain-->>Guardian: 5. Guardian monitors on-chain commitment
+    Client->>Client: Execute transaction locally<br/>generate state delta
+    Client->>Guardian: push_delta + signed request
+    Guardian->>Guardian: Authenticate request<br/>verify delta against stored state
+    Guardian->>Guardian: Sign new commitment<br/>store as candidate
+    Guardian-->>Client: Return ack_sig + candidate delta
+    Client->>Chain: Submit ZK proof + account update
+    Guardian->>Chain: Poll commitment through configured RPC
+    Chain-->>Guardian: Return latest account commitment
     alt Commitment matches candidate
         Guardian->>Guardian: Promote to "canonical"
         Guardian-->>Client: Propagate confirmed delta
@@ -49,10 +78,10 @@ sequenceDiagram
 ```
 
 1. **Local execution**: The user computes a transaction locally, generating a delta (state change).
-2. **Delta submission**: The user sends the delta to Guardian for acknowledgment.
-3. **Guardian acknowledgment**: Guardian validates the delta and co-signs it, designating it as a "candidate" state.
-4. **Proof submission**: The user generates the ZK proof and submits it to the chain.
-5. **Canonical confirmation**: Guardian monitors the chain. If the on-chain commitment matches the candidate, the state becomes "canonical" and is propagated to other devices or signers.
+2. **Delta submission**: The client signs the request and submits the delta to Guardian.
+3. **Guardian acknowledgment**: Guardian validates the request, applies the delta to the stored state, computes the new commitment, and signs the accepted commitment.
+4. **Proof submission**: The client submits the proven account update to Miden.
+5. **Canonical confirmation**: Guardian checks the network commitment. If it matches the candidate, the delta becomes canonical and can be served to other clients.
 
 ## Multi-device sync
 
@@ -62,20 +91,29 @@ For users with multiple devices, Guardian keeps state synchronized seamlessly:
 sequenceDiagram
     participant Desktop as Desktop
     participant Guardian as Guardian Server
+    participant Network as Miden Network
     participant Mobile as Mobile
 
     Desktop->>Desktop: Execute transaction
     Desktop->>Guardian: Push delta
     Guardian->>Guardian: Validate & acknowledge
-    Desktop->>Desktop: Submit proof to chain
-    Guardian->>Guardian: Confirm canonical
+    Desktop->>Network: Submit proof + account update
+    Guardian->>Network: Poll commitment
+    Network-->>Guardian: Return latest account commitment
+    Guardian->>Guardian: Mark delta canonical
     Mobile->>Guardian: Get state
     Guardian-->>Mobile: Return latest state
     Mobile->>Mobile: Replay delta locally
     Note over Mobile: State now matches Desktop
 ```
 
-The desktop executes a transaction and pushes the delta to Guardian. After on-chain confirmation, Guardian propagates the canonical delta to the mobile device, which replays it locally — all without querying the chain directly.
+The desktop executes a transaction and pushes the delta to Guardian. After the account update is accepted by Miden and Guardian confirms the commitment, Guardian propagates the canonical delta to the mobile client, which replays it locally without querying the network directly.
+
+The receiving device should still verify:
+
+- the returned state or delta chain links to the expected commitment,
+- the Guardian acknowledgement signature is from the expected server key,
+- the local account state after replay matches the commitment it expects to use.
 
 ## Account management
 
@@ -85,7 +123,7 @@ For each request, the client signs a payload with one of those keys and the serv
 
 ## Canonicalization
 
-Canonicalization is the process of validating that a state transition (delta) is valid against the on-chain commitment. It is optional and mainly used in multi-user setups.
+Canonicalization is the process of validating that a candidate delta matches the account commitment accepted by Miden. It is optional and mainly used in multi-user setups.
 
 ```mermaid
 stateDiagram-v2
@@ -96,13 +134,26 @@ stateDiagram-v2
     discarded --> [*]
 ```
 
-- **Candidate mode** (default): A background worker promotes or discards deltas after a configurable delay and network verification.
+- **Candidate mode** (default): A background worker polls for candidate deltas, checks them against the Miden network, and promotes or discards them based on verification results.
 - **Optimistic mode**: Deltas become canonical immediately, skipping the verification window.
 
-| Parameter | Default | Description |
+| Parameter | Builder API default | Description |
 |---|---|---|
-| `delay_seconds` | 900 (15 min) | How long a candidate waits before the worker checks it. |
-| `check_interval_seconds` | 60 (1 min) | How often the worker runs. |
+| `check_interval_seconds` | 10 | How often the worker scans for candidate deltas. |
+| `max_retries` | 18 | Verification attempts before discarding a candidate after the grace period. |
+| `submission_grace_period_seconds` | 600 (10 min) | Minimum candidate age before verification failures consume retry budget. |
+
+The reference server binary uses a 10-second check interval, 48 retries, and a 10-minute submission grace period. Embedders using the builder API can configure canonicalization directly in code.
+
+## Failure and recovery model
+
+| Failure | Effect | Recovery path |
+|---|---|---|
+| Guardian unavailable | Clients cannot fetch backups, sync deltas, or gather Guardian-assisted signatures. | Use local state if available, retry later, or rotate to another provider with recovery keys. |
+| Candidate does not match Miden commitment | Guardian marks the candidate as discarded. | Client resyncs from the latest canonical state and rebuilds the transaction. |
+| Client submits stale delta | Guardian rejects the delta because `prev_commitment` does not match the active chain. | Client fetches state or `delta/since`, replays canonical deltas, then retries. |
+| Guardian withholds updates | Other clients may see stale state. | Compare against Miden commitment and use recovery/provider-rotation flow if needed. |
+| Guardian database is corrupted | Returned state may fail commitment or acknowledgement checks. | Client rejects unverifiable data and recovers from another backup or provider. |
 
 ## Common use cases
 

--- a/versioned_docs/version-0.14/builder/miden-guardian/core-concepts/components.md
+++ b/versioned_docs/version-0.14/builder/miden-guardian/core-concepts/components.md
@@ -7,9 +7,21 @@ sidebar_position: 3
 
 The Guardian server is composed of several pluggable components that handle different responsibilities.
 
+## Component map
+
+| Component | Responsibility | Operator concern |
+|---|---|---|
+| **API** | Exposes HTTP and gRPC routes for state, deltas, proposals, and server key discovery. | Transport exposure, CORS, request limits, rate limits. |
+| **Auth** | Verifies per-account signatures and prevents replay. | Clock sync, key rotation, account metadata integrity. |
+| **Acknowledger** | Signs accepted Miden deltas with the server acknowledgement key. | Keystore configuration, key persistence, key backup, `/pubkey` monitoring. |
+| **Network** | Applies and verifies deltas against Miden network rules. | Correct network selection and configured RPC connectivity. |
+| **Storage** | Persists state snapshots, deltas, and proposals. | Backend durability, access control, backups, migrations. |
+| **Metadata** | Stores account config, auth policy, timestamps, and network config. | Consistency with account auth state and replay-protection durability. |
+| **Operator dashboard** | Exposes operator-only views over accounts, deltas, proposals, and service status. | Operator authentication, session security, and access control. |
+
 ## API
 
-The API exposes a consistent interface for operating on states and deltas over HTTP and gRPC. Behavior is identical across transports, so clients can switch between them without semantic changes.
+The Miden state/delta API is exposed over HTTP and gRPC. The two transports use the same state, delta, proposal, and lookup semantics, so clients can switch between them without changing the underlying workflow.
 
 **HTTP endpoints** (default port 3000):
 
@@ -18,38 +30,73 @@ The API exposes a consistent interface for operating on states and deltas over H
 | `POST` | `/configure` | Create account with auth policy and initial state |
 | `POST` | `/delta` | Push a delta (server validates, signs, sets status) |
 | `GET` | `/delta?account_id&nonce` | Fetch delta by nonce |
-| `GET` | `/delta/since?account_id&from_nonce` | Merged canonical snapshot since a nonce |
+| `GET` | `/delta/since?account_id&nonce` | Merged canonical snapshot since a nonce |
 | `GET` | `/state?account_id` | Latest account state |
+| `GET` | `/state/lookup?key_commitment` | Find accounts whose auth policy contains a key commitment |
 | `POST` | `/delta/proposal` | Create pending proposal for multi-party signing |
 | `GET` | `/delta/proposal?account_id` | List pending proposals |
-| `PUT` | `/delta/proposal` | Append cosigner signature to a proposal |
+| `GET` | `/delta/proposal/single?account_id&commitment` | Fetch one proposal |
+| `PUT` | `/delta/proposal` | Append an authorized signature to a proposal |
 | `GET` | `/pubkey` | Server acknowledgment public key (unauthenticated) |
 
-**gRPC** (default port 50051) mirrors all HTTP endpoints with the same semantics. Credentials are provided via metadata headers.
+`GET /state/lookup` returns `{ accounts: [{ account_id }] }`. A single key commitment may be authorized on multiple accounts, and an empty list is a successful "no matching account" response.
+
+**gRPC** (default port 50051) mirrors the Miden state/delta surface above, including account lookup. Credentials are provided via metadata headers.
 
 For the full API specification, see the [spec/api.md](https://github.com/OpenZeppelin/guardian/blob/main/spec/api.md) in the repository.
 
+:::note
+The Guardian repository also contains EVM proposal routes under `/evm/*`. Those routes are separate from the Miden state/delta flow described here, are HTTP-only, and are registered only when the server is built with the `evm` Cargo feature.
+:::
+
 ## Auth
 
-Request authentication is configured per account. All endpoints except `/pubkey` require authentication.
+Request authentication is configured per account. All client-facing endpoints except `/pubkey` require authentication.
 
-### Falcon RPO
+### Miden request signing
 
-The current authentication policy uses Miden Falcon RPO signatures with an allowlist of **cosigner commitments** — hashes of authorized public keys.
+The current Miden authentication policies use an allowlist of authorized public-key commitments (`cosigner_commitments` in Guardian metadata). Guardian supports Miden Falcon RPO and Miden ECDSA commitments.
 
 Every authenticated request includes three headers:
 
 | Header | Description |
 |---|---|
 | `x-pubkey` | Signer's public key (full serialized key or 32-byte commitment hex) |
-| `x-signature` | Falcon RPO signature over the request digest |
+| `x-signature` | Signature over the Guardian request digest |
 | `x-timestamp` | Unix timestamp in milliseconds |
 
-The signature is computed over:
+For HTTP requests, the request payload digest is `RPO256` over canonical JSON bytes:
+
+- `POST` and `PUT` sign the request body.
+- `GET` signs the query object.
+
+For gRPC requests, the request payload digest is `RPO256` over the protobuf-encoded request bytes.
+
+The signed Miden message format is:
 
 ```
-RPO256_hash([account_id_prefix, account_id_suffix, timestamp_ms, 0])
+RPO256_hash([
+  account_id_prefix,
+  account_id_suffix,
+  timestamp_ms,
+  payload_hash_0,
+  payload_hash_1,
+  payload_hash_2,
+  payload_hash_3
+])
 ```
+
+This binds the signature to the account, the timestamp, and the exact request payload.
+
+### Lookup signing
+
+`GET /state/lookup` is account-less because the caller is trying to discover which account IDs authorize a key commitment. It uses a dedicated domain-separated message:
+
+```
+RPO256_hash([DOMAIN_TAG_w0..w3, timestamp_ms, key_commitment_w0..w3])
+```
+
+The caller proves possession of the queried key commitment. The endpoint uses the same 300-second timestamp skew window, but it does not maintain a monotonic timestamp anchor because there is no account yet. The regular Miden request path tracks `last_auth_timestamp` per account.
 
 ### Verification flow
 
@@ -64,7 +111,7 @@ sequenceDiagram
     Guardian->>Guardian: 2. Check commitment is in account allowlist
     Guardian->>Guardian: 3. Verify timestamp within 300s window
     Guardian->>Guardian: 4. Check timestamp > last_auth_timestamp
-    Guardian->>Guardian: 5. Verify Falcon signature over<br/>(account_id, timestamp) digest
+    Guardian->>Guardian: 5. Verify signature over<br/>(account_id, timestamp, payload_hash)
 
     alt All checks pass
         Guardian->>Guardian: Update last_auth_timestamp (CAS)
@@ -87,8 +134,15 @@ The Acknowledger produces tamper-evident acknowledgments for accepted deltas:
 
 - Signs the digest of `new_commitment` and returns the signature as `ack_sig`.
 - The server's acknowledgment key is exposed via the `/pubkey` endpoint for clients to cache and verify against.
+- `/configure` returns both `ack_pubkey` and `ack_commitment` so clients can bind an account setup to the Guardian key they expect.
+
+On first boot, Guardian creates the acknowledgement key if the configured keystore is empty. Operators still need to choose the keystore backend, persist it, back it up, and define a rotation playbook.
 
 Clients should verify `ack_sig` after every `push_delta` to confirm the server processed the change correctly.
+
+## Operator dashboard
+
+Guardian also includes an operator dashboard API and TypeScript client for operational visibility into configured accounts, delta status, in-flight proposals, and service health. This surface is not part of the client state/delta API and should be protected as an operator-only interface.
 
 ## Network
 
@@ -97,7 +151,9 @@ The Network component handles interactions with the Miden blockchain:
 - Computes commitments and validates deltas against the target network's rules.
 - Validates account identifiers and request credentials against network-owned state.
 - Merges multiple deltas into a single snapshot payload (for `get_delta_since`).
-- Surfaces suggested auth updates (e.g., rotated cosigner commitments) so metadata remains aligned with the network.
+- Surfaces suggested auth updates (e.g., rotated authorized key commitments) so metadata remains aligned with the network.
+
+Guardian does not trust client-provided network endpoints. Network identity is stored in account metadata, and operators configure the runtime network that Guardian validates against.
 
 ## Storage
 
@@ -111,10 +167,12 @@ Available backends:
 - **Filesystem** (default): Stores data on disk. Suitable for **testing and development**. No external dependencies.
 - **PostgreSQL** (optional): Recommended for **production** deployments. Requires the `postgres` feature flag at build time. Migrations run automatically on startup.
 
+Because storage contains account state and delta payloads, operators should treat it as sensitive infrastructure. Use normal database controls: encrypted disks or managed database encryption, least-privilege credentials, backups, retention limits, and audit logging.
+
 ## Metadata
 
 The Metadata store holds per-account configuration:
 
-- `account_id`, authentication policy, storage backend type, timestamps, and `last_auth_timestamp` for replay protection.
+- `account_id`, authentication policy, `network_config`, storage backend type, timestamps, and `last_auth_timestamp` for replay protection.
 - Supports CRUD operations and list iteration over accounts.
 - Can use filesystem or PostgreSQL as its backing store, independent of the Storage backend choice.

--- a/versioned_docs/version-0.14/builder/miden-guardian/core-concepts/data-structures.md
+++ b/versioned_docs/version-0.14/builder/miden-guardian/core-concepts/data-structures.md
@@ -7,47 +7,78 @@ sidebar_position: 2
 
 Guardian models account state as an append-only chain of snapshots and changes.
 
+The key design idea is simple: Guardian can help clients recover and synchronize state, but the state remains verifiable because each delta links to the previous commitment and produces a new commitment.
+
 ## State
 
-A **state** is a canonical snapshot of an account at a point in time. It includes the account's ID, commitment, nonce, vault (assets), storage, and other account data.
+A **state** is a snapshot of an account at a point in time. Guardian treats the account payload as client-supplied state data and tracks it with the account ID, commitment, timestamps, and auth scheme.
+
+Guardian's HTTP representation is a `StateObject`:
 
 ```json
 {
-  "account_id": "0xabc123...",
-  "commitment": "0xdef456...",
-  "nonce": 10,
-  "assets": [
-    { "balance": 12000, "asset_id": "USDC" },
-    { "balance": 2, "asset_id": "ETH" }
-  ]
+  "account_id": "0xabc123",
+  "state_json": {
+    "data": "<base64-encoded serialized account state>"
+  },
+  "commitment": "0xdef456",
+  "created_at": "2026-05-16T00:00:00Z",
+  "updated_at": "2026-05-16T00:00:00Z",
+  "auth_scheme": "falcon"
 }
 ```
 
-When you first register an account with Guardian, you provide an **initial state** — the baseline from which all subsequent changes are tracked.
+The `state_json` object is opaque to Guardian. For Miden accounts, the client SDK typically packs serialized account state into a `data` field; other examples in this section are illustrative unless called out as exact API shapes.
+
+When you first register an account with Guardian, you provide an **initial state** - the baseline from which all subsequent changes are tracked.
 
 ## Delta
 
-A **delta** represents a set of changes applied to a state. Deltas are append-only — each delta references the commitment of the state it was applied to, forming an unbroken chain.
+A **delta** represents a set of changes applied to a state. Deltas are append-only. Each delta references the commitment of the state it was applied to, forming an unbroken chain.
 
 ```json
 {
-  "account_id": "0xabc123...",
+  "account_id": "0xabc123",
   "nonce": 11,
-  "prev_commitment": "0xdef456...",
+  "prev_commitment": "0xdef456",
+  "new_commitment": "0x789abc",
   "delta_payload": {
     "data": "<base64-encoded TransactionSummary>"
+  },
+  "ack_sig": "0x...",
+  "ack_pubkey": "0x...",
+  "ack_scheme": "falcon",
+  "status": {
+    "status": "candidate",
+    "timestamp": "2026-05-16T00:00:00Z",
+    "retry_count": 0
   }
 }
 ```
 
 A useful mental model: a delta is a compact, replayable description of "what changed" in an account's local state. Deltas can sync, back up, and reconstruct state without shipping full snapshots.
 
+`new_commitment` is present once Guardian has acknowledged a delta. Pending proposals do not have a resulting commitment yet, so the field is omitted on the wire.
+
 Key properties:
 
 - **Ordered**: Each delta has a nonce that determines its position in the chain.
-- **Linked**: The `prev_commitment` field references the state the delta was applied to. This prevents forks — if two deltas reference different base states, the server rejects the conflicting one.
-- **Validated**: The server verifies each delta against the Miden network before accepting it.
+- **Linked**: The `prev_commitment` field references the state the delta was applied to. This prevents forks - if two deltas reference different base states, the server rejects the conflicting one.
+- **Validated**: The server validates each delta against the current stored state. In candidate mode, canonicalization later checks the resulting commitment against the Miden network before marking the delta canonical.
 - **Acknowledged**: Once accepted, the server signs the delta's `new_commitment`, providing cryptographic proof that it was processed.
+
+## Visibility
+
+Guardian stores the state and delta payloads submitted by clients. These records are private from unauthorized API callers, but they are sensitive server-side data.
+
+| Record | Who can request it through Guardian | What the operator may observe |
+|---|---|---|
+| `StateObject` | Authorized account participants. | Full submitted `state_json`, account ID, commitment, timestamps, auth scheme. |
+| `DeltaObject` | Authorized account participants. | Delta payload, nonce, previous and new commitments, status, ack metadata. |
+| Delta proposal | Authorized account participants. | Transaction summary payload, signer commitments, signatures, proposal metadata. |
+| Metadata | Server internals and operator tooling. | Auth policy, network config, last auth timestamp, account identifiers. |
+
+Do not treat Guardian storage as public data. Operators should apply production database controls, and clients should verify commitments before trusting returned state.
 
 ### Delta status lifecycle
 
@@ -70,6 +101,8 @@ stateDiagram-v2
 
 In **optimistic mode**, deltas skip the `candidate` stage and are immediately marked `canonical`.
 
+Discarded deltas must not be returned by default sync APIs. A client that sees a discarded candidate should resync from the latest canonical state before constructing a new transaction.
+
 ## Commitments
 
 A **commitment** is a cryptographic hash that uniquely identifies a particular version of an account's state. Commitments are the integrity backbone of Guardian:
@@ -83,32 +116,32 @@ graph LR
 
 - Each state snapshot has a commitment.
 - Each delta includes a `prev_commitment` (the base state) and produces a `new_commitment` (the resulting state).
-- The chain ensures that any tampering — inserting, reordering, or dropping deltas — is detectable by any client that tracks commitments.
+- The chain ensures that any tampering - inserting, reordering, or dropping deltas - is detectable by any client that tracks commitments.
 
 ## Delta proposals
 
 A **delta proposal** is a coordination mechanism for multi-party accounts. When multiple signers must agree on a transaction:
 
 1. **Propose**: One signer creates a delta proposal containing a `TransactionSummary`. Guardian validates the proposal against the current account state.
-2. **Sign**: Other authorized cosigners fetch the pending proposal, verify it locally, and submit their signatures.
-3. **Execute**: Once enough signatures are collected (meeting the threshold), any cosigner can promote the proposal to a canonical delta via `push_delta`.
+2. **Sign**: Other authorized account participants fetch the pending proposal, verify it locally, and submit their signatures.
+3. **Execute**: Once enough signatures are collected (meeting the threshold), any authorized participant can promote the proposal to a delta via `push_delta`.
 
 ```mermaid
 sequenceDiagram
     participant P as Proposer
     participant Guardian as Guardian Server
-    participant C as Cosigner
+    participant S as Signer
 
     P->>Guardian: push_delta_proposal<br/>(tx_summary + initial signature)
     Guardian->>Guardian: Validate against current state
     Guardian-->>P: Return proposal with commitment
 
-    C->>Guardian: get_delta_proposals
-    Guardian-->>C: Return pending proposals
+    S->>Guardian: get_delta_proposals
+    Guardian-->>S: Return pending proposals
 
-    C->>C: Verify proposal details locally
-    C->>Guardian: sign_delta_proposal<br/>(commitment + signature)
-    Guardian-->>C: Updated proposal with signatures
+    S->>S: Verify proposal details locally
+    S->>Guardian: sign_delta_proposal<br/>(commitment + signature)
+    Guardian-->>S: Updated proposal with signatures
 
     P->>Guardian: push_delta<br/>(with all collected signatures)
     Guardian->>Guardian: Validate & acknowledge
@@ -118,3 +151,13 @@ sequenceDiagram
 Proposals remain in `pending` status until promoted. Once the corresponding delta becomes canonical, the proposal is automatically cleaned up.
 
 Delta proposals have their own commitment, derived from `(account_id, nonce, tx_summary)`, used as a stable identifier.
+
+## Invariants
+
+Clients and operators should preserve these invariants:
+
+- A delta must reference the active previous commitment for the account.
+- A canonical delta must match the commitment accepted by Miden.
+- A proposal remains pending until enough authorized signatures are collected and the payload is promoted through `push_delta`.
+- A matching proposal is deleted once its delta becomes canonical.
+- A client should reject state that does not replay to the expected commitment.

--- a/versioned_docs/version-0.14/builder/miden-guardian/core-concepts/security.md
+++ b/versioned_docs/version-0.14/builder/miden-guardian/core-concepts/security.md
@@ -1,55 +1,59 @@
 ---
 title: Security
 sidebar_position: 4
+hide_title: true
 ---
 
-# Edge Cases & Security Considerations
-
-Guardian is designed around a clear trust model with well-defined security boundaries.
+Guardian stores and relays account state for clients. It is not a custodian, and it is not a private execution environment.
 
 ## Trust model
 
-The right threat model for Guardian is **honest-but-curious**: the server is expected to follow the protocol and availability guarantees, but may try to learn as much as it can from any data it is given.
+Guardian is an availability and coordination service. Miden remains authoritative for account commitments, and users keep the keys required to recover or rotate providers.
 
-Guardian is non-custodial. The provider holds no keys that can unilaterally move funds.
+| Area | Guardian role | Client or user responsibility |
+|---|---|---|
+| State sync | Stores and relays submitted state, deltas, proposals, metadata, and timestamps. | Verify returned commitments before relying on state. |
+| Request auth | Authenticates account requests and rejects stale or conflicting deltas. | Keep user signing keys secure and resync before signing stale state. |
+| Acknowledgements | Signs accepted deltas with the Guardian acknowledgement key. | Verify `/pubkey`, `ack_sig`, and delta ordering. |
+| Account policy | May participate as one signer in a multi-key account policy. | Keep a user-controlled recovery path that can remove or replace Guardian. |
+| Privacy and availability | Can see submitted payloads and access patterns, and can deny or delay service. | Treat Guardian as an operator-visible availability service. |
 
-### What Guardian can do
+Guardian should not be trusted to move funds on its own, change the account commitment accepted by Miden, hide submitted data from the operator, or guarantee availability.
 
-- **Store and relay** state snapshots and deltas.
-- **Validate** deltas against the Miden network before acknowledging them.
-- **Co-sign** transactions as one party in a threshold scheme.
-- **Enforce policies** (rate limits, timelocks) at the co-signing layer.
+:::important
+**User-controlled rotation.** Users can rotate Guardian at any time through their own recovery path. The current Guardian does not sign the rotation and does not need to serve an API response for it.
+:::
 
-### What Guardian cannot do
+## User control and provider rotation
 
-- **Forge state**: Every delta references the previous commitment. Inserting, reordering, or dropping deltas breaks the commitment chain, detectable by any client.
-- **Move funds unilaterally**: Guardian holds at most one key in a multi-key setup. It always needs the user's key to complete a transaction.
-- **Tamper silently**: The server signs each accepted delta with its acknowledgment key. Clients can verify these signatures to detect any tampering.
+In the standard assisted-custody setup, the account policy includes a user-controlled recovery path, such as user hot key + user cold key. This lets the user remove or replace Guardian without the current Guardian participating.
 
-### What Guardian can do adversarially
+The current Guardian does not sign the rotation and does not need to serve an API response for it. The user updates the account policy to remove the old Guardian key commitment, adds the new Guardian if needed, and configures the new provider with a verified state snapshot.
 
-- **Deny service**: The server can refuse to serve data or accept deltas. This is a liveness issue, not a safety issue — users can recover using their own keys.
-- **Withhold updates**: The server could delay propagating deltas to other devices. Clients should verify state freshness against on-chain commitments.
+```mermaid
+sequenceDiagram
+    participant User as User keys
+    participant Old as Current Guardian
+    participant Network as Miden Network
+    participant New as New Guardian
 
-## Integrity guarantees
+    User->>Network: Update account policy<br/>remove old Guardian key
+    Network-->>User: Return accepted account commitment
+    User->>New: Configure provider<br/>with verified state snapshot
+    Note over Old: No signature or API response required
+```
 
-### Commitment chain
+## Client checks
 
-Every delta includes a `prev_commitment` referencing the base state. This creates an unbroken chain:
+Clients should verify:
 
-- If the server drops a delta, subsequent deltas won't validate because their `prev_commitment` won't match.
-- If the server inserts a fake delta, the commitment chain diverges from the on-chain state.
-- Clients can verify the chain independently by tracking commitments locally.
+1. The expected Guardian acknowledgement key from `/pubkey`.
+2. `ack_sig` on accepted deltas.
+3. Delta ordering through `prev_commitment` and `new_commitment`.
+4. The latest account commitment against Miden before recovery, provider rotation, or high-value signing.
+5. Fresh state before signing if another client or authorized signer may have advanced the account.
 
-### Server acknowledgment
-
-After accepting a delta, the server signs the `new_commitment` with its acknowledgment key. Clients should:
-
-1. Retrieve the server's public key via `/pubkey`.
-2. Verify `ack_sig` on every `push_delta` response.
-3. Alert on verification failure — it indicates the server may have been compromised or is not processing deltas correctly.
-
-## 2-of-3 key setup
+## Common 2-of-3 setup
 
 A common Guardian configuration uses a **2-of-3** threshold embedded in the account's authentication code:
 
@@ -61,41 +65,15 @@ A common Guardian configuration uses a **2-of-3** threshold embedded in the acco
 
 ```mermaid
 graph TD
-    subgraph "Normal operation (Hot + Guardian)"
-        Hot["User Hot Key"] --> TX["Transaction"]
-        GuardianKey["Guardian Service Key"] --> TX
+    subgraph "Normal operation"
+        Hot["User hot key"] --> TX["Transaction"]
+        GuardianKey["Guardian service key"] --> TX
     end
 
-    subgraph "Emergency override (Hot + Cold)"
-        Hot2["User Hot Key"] --> Override["Rotate Guardian / Adjust policies<br/>Switch providers"]
-        Cold["User Cold Key"] --> Override
+    subgraph "Emergency override"
+        Hot2["User hot key"] --> Override["Rotate Guardian<br/>or adjust policy"]
+        Cold["User cold key"] --> Override
     end
 ```
 
-- **Normal operations**: Hot key + Guardian's co-signature suffice. Guardian verifies the signer is working from the latest state.
-- **Emergency override**: Hot + cold keys alone can rotate out Guardian, adjust policies, or switch providers.
-- **Recovery**: If the Guardian provider disappears, the user's hot + cold keys provide full independent control.
-
-## Device recovery
-
-**Without Guardian**: A lost device means falling back to a cold backup. Any state changes since the last checkpoint are lost. If an attacker has the device PIN, funds may be at risk.
-
-**With Guardian**: The remaining device already has the latest state (synced through Guardian). The user initiates a hot key rotation using their cold key. The stolen device's keys become invalid. Recovery takes minutes.
-
-## Edge cases
-
-### State divergence
-
-If two devices submit deltas referencing different base states, Guardian rejects the conflicting one (commitment mismatch). The rejected device must resync from Guardian before retrying.
-
-### Stale candidates
-
-If a candidate delta's on-chain commitment doesn't match during canonicalization, it is marked `discarded`. Clients are signaled to resync. This is not a rollback of the chain — it prevents clients from drifting onto an invalid local branch.
-
-### Clock skew
-
-Authentication requires timestamps within a 300-second window. Devices with significantly drifting clocks will fail authentication. Ensure NTP synchronization on client devices.
-
-### Provider rotation
-
-Users can switch Guardian providers at any time using their hot + cold keys. The new provider is configured with the account's current state and a fresh cosigner allowlist. The old provider's key is rotated out of the account's authentication policy.
+Normal transactions can use the hot key plus Guardian. Emergency actions can use the hot key plus cold key, without Guardian involvement.

--- a/versioned_docs/version-0.14/builder/miden-guardian/index.md
+++ b/versioned_docs/version-0.14/builder/miden-guardian/index.md
@@ -5,34 +5,58 @@ sidebar_position: 0
 
 # Miden Guardian
 
-Miden Guardian is a system built by [OpenZeppelin](https://www.openzeppelin.com/) that allows Miden accounts to back up and sync their private state securely without trust assumptions about other participants or the server operator.
+Miden Guardian is an off-chain coordination service built by [OpenZeppelin](https://www.openzeppelin.com/) for Miden accounts. It helps clients back up private account state, synchronize that state across devices, and coordinate multi-signer workflows without giving the Guardian provider unilateral control over the account.
+
+:::warning
+Guardian is a work in progress. Use the docs and the [OpenZeppelin Guardian repository](https://github.com/OpenZeppelin/guardian) as the current operator and integration reference, and expect interfaces and operational defaults to evolve.
+:::
 
 ## The problem
 
-Miden's execution model requires clients to manage their own private state — accounts, notes, storage — locally on-device. While this provides strong privacy and scalability, it introduces real challenges:
+Miden's execution model requires clients to manage their own private state - accounts, notes, storage - locally on-device. While this provides strong privacy and scalability, it introduces real challenges:
 
 - **Solo-account users** risk losing access if local state is not backed up. Losing any part of the account state means losing access to the account itself.
 - **Shared-account users** risk having stale state due to a faulty or malicious participant withholding updates.
 - **Multi-device users** need all devices to see the same account state, but there is no public ledger to read from.
 
-On a public chain, the ledger is a universally readable source of truth — every device and every signer can independently observe the latest state. In Miden's private account model, the canonical state is defined by the on-chain commitment, but it isn't readable in a way that keeps devices and signers automatically up to date. The coordination surface moves off-chain.
+On a public chain, the ledger is a universally readable source of truth. Every device and every signer can independently observe the latest state. In Miden's private account model, the canonical state is defined by the on-chain commitment, but the full private state is not publicly readable. The coordination surface moves off-chain.
 
 ## What Guardian provides
 
 Guardian addresses these challenges by acting as an off-chain coordination layer:
 
-- **Backup and recovery** — Account state is stored on Guardian, recoverable even if a device is lost.
-- **Multi-device sync** — Multiple devices push and pull state through Guardian, staying in sync with the latest canonical state.
-- **Multi-party coordination** — Shared accounts use delta proposals to coordinate threshold signing across participants.
-- **Integrity verification** — Every state change is validated against the Miden network and acknowledged with a cryptographic signature.
+- **Backup and recovery** - Account state is stored on Guardian, recoverable even if a device is lost.
+- **Multi-device sync** - Multiple devices push and pull state through Guardian, staying in sync with the latest canonical state.
+- **Multi-party coordination** - Shared accounts use delta proposals to coordinate threshold signing across participants.
+- **Integrity verification** - State changes are linked by commitments, validated against the Miden network, and acknowledged with a cryptographic signature.
 
-Guardian is non-custodial. The provider cannot move funds unilaterally — it stores state and coordinates changes, but users retain cryptographic control over their accounts at all times.
+Guardian is not a private execution environment, a sequencer, or a rollup. Clients still execute transactions locally and submit proofs to Miden. Guardian stores and coordinates the state data that authorized clients submit to it.
+
+## Architecture at a glance
+
+| Layer | Responsibility | What remains authoritative |
+|---|---|---|
+| **Miden network** | Stores commitments and verifies account updates. | The canonical account commitment. |
+| **Miden client** | Executes transactions, manages local state, proves updates, and signs Guardian requests. | The user's keys and local verification logic. |
+| **Guardian server** | Stores snapshots, stores deltas, authenticates readers/writers, acknowledges accepted deltas, and coordinates proposals. | Only the data it has accepted and signed. |
+| **Storage backend** | Persists metadata, state snapshots, deltas, and pending proposals. | The append-only commitment chain, as verified by clients and the network. |
+
+Guardian is non-custodial. The provider cannot move funds unilaterally - it stores state and coordinates changes, but users retain cryptographic control over their accounts at all times.
+
+## Trust model summary
+
+Guardian has an explicit trust boundary:
+
+- **Safety**: The provider cannot forge account state, silently rewrite the commitment chain, or move assets without the required account signatures.
+- **Liveness**: The provider can delay, censor, or refuse requests. Users should keep recovery keys and provider-rotation paths available.
+- **Privacy**: Guardian protects state from unauthorized API callers, but the server stores the account state and delta payloads it receives. Treat the operator as able to observe submitted payloads unless your deployment adds a separate encryption layer or you operate the service yourself.
+- **Freshness**: Clients should verify acknowledgments and compare local state against the latest on-chain commitment when freshness matters.
 
 ## Learn more
 
 <CardGrid cols={2}>
   <Card title="Architecture" href="./core-concepts/architecture" eyebrow="Core concepts">
-    How Guardian fits between clients and the Miden network.
+    Roles, trust boundaries, state flow, and failure behavior.
   </Card>
   <Card title="Data structures" href="./core-concepts/data-structures" eyebrow="Core concepts">
     State, deltas, commitments, and delta proposals.
@@ -53,4 +77,4 @@ Guardian is non-custodial. The provider cannot move funds unilaterally — it st
 
 ## Repository
 
-- [Miden Guardian](https://github.com/OpenZeppelin/guardian) — Guardian server, client SDKs, multisig client libraries, and specification
+- [Miden Guardian](https://github.com/OpenZeppelin/guardian) - Guardian server, client SDKs, multisig client libraries, and specification

--- a/versioned_docs/version-0.14/builder/miden-guardian/operator-guide/deployment.md
+++ b/versioned_docs/version-0.14/builder/miden-guardian/operator-guide/deployment.md
@@ -5,7 +5,11 @@ sidebar_position: 2
 
 # Deploying Miden Guardian
 
-The repository deploy script provisions and updates the AWS infrastructure used by the reference Guardian deployment. Operators on other platforms can run the same server binary with the same environment variables — adapt the surrounding services to taste.
+The repository deploy script provisions and updates the AWS infrastructure used by the reference Guardian deployment. Operators on other platforms can run the same server binary with the same environment variables - adapt the surrounding services to taste.
+
+:::warning
+Guardian stores private account state and delta payloads submitted by clients. Treat the deployment like sensitive wallet infrastructure even though Guardian is non-custodial.
+:::
 
 The reference AWS deployment uses:
 
@@ -15,6 +19,29 @@ The reference AWS deployment uses:
 - Secrets Manager (env vars + ack keys)
 - ECR for container images
 - CloudWatch for logs
+
+## Deployment architecture
+
+```mermaid
+graph LR
+    Client["Authorized clients"] --> ALB["TLS load balancer"]
+    ALB --> Server["Guardian server"]
+    Server --> DB["Postgres<br/>state, deltas, metadata"]
+    Server --> Secrets["Secrets Manager<br/>ack keys, operator allowlist"]
+    Server --> Node["Miden node RPC"]
+    Server --> Logs["Logs / metrics"]
+```
+
+Production deployments should make the trust boundary explicit:
+
+| Boundary | Production expectation |
+|---|---|
+| Client traffic | TLS termination, explicit CORS allowlist for browser clients, request-size limits, rate limits. |
+| Guardian server | Reproducible build hash recorded, minimal IAM permissions, no shell access for normal operation. |
+| Database | Managed Postgres, encrypted storage, backups, migration visibility, least-privilege credentials. |
+| Ack keys | Generated once per environment, stored in Secrets Manager, monitored for unexpected rotation. |
+| Node RPC | Explicit network target; do not accept client-provided RPC endpoints. |
+| Logs | Avoid logging full state or delta payloads. Retain enough metadata for debugging canonicalization failures. |
 
 ## AWS deploy script
 
@@ -58,15 +85,15 @@ Filesystem storage is the default local backend; the `postgres` feature with a v
 
 | Var                                          | Default     | AWS prod override |
 | -------------------------------------------- | ----------- | ----------------- |
-| `GUARDIAN_RATE_LIMIT_ENABLED`                | `true`      | —                 |
+| `GUARDIAN_RATE_LIMIT_ENABLED`                | `true`      | -                 |
 | `GUARDIAN_RATE_BURST_PER_SEC`                | `10`        | `200`             |
 | `GUARDIAN_RATE_PER_MIN`                      | `60`        | `5000`            |
-| `GUARDIAN_MAX_REQUEST_BYTES`                 | `1048576`   | —                 |
-| `GUARDIAN_MAX_PENDING_PROPOSALS_PER_ACCOUNT` | `20`        | —                 |
+| `GUARDIAN_MAX_REQUEST_BYTES`                 | `1048576`   | -                 |
+| `GUARDIAN_MAX_PENDING_PROPOSALS_PER_ACCOUNT` | `20`        | -                 |
 | `GUARDIAN_DB_POOL_MAX_SIZE`                  | `16`        | `32`              |
-| `GUARDIAN_METADATA_DB_POOL_MAX_SIZE`         | (matches storage pool) | —      |
+| `GUARDIAN_METADATA_DB_POOL_MAX_SIZE`         | (matches storage pool) | -      |
 
-Rate limiting is on by default; pass `0`, `false`, `no`, or `off` to `GUARDIAN_RATE_LIMIT_ENABLED` to disable. Invalid values for `GUARDIAN_MAX_REQUEST_BYTES` are silently ignored — the default is used.
+Rate limiting is on by default; pass `0`, `false`, `no`, or `off` to `GUARDIAN_RATE_LIMIT_ENABLED` to disable. Invalid values for `GUARDIAN_MAX_REQUEST_BYTES` are silently ignored - the default is used.
 
 ### Operator allowlist + CORS
 
@@ -78,7 +105,16 @@ Rate limiting is on by default; pass `0`, `false`, `no`, or `off` to `GUARDIAN_R
 
 ## Canonicalization
 
-The server runs a canonicalization pass every **10 seconds** with a **10-minute** submission grace period. Both values are hard-coded in `crates/server/src/main.rs` and are **not** configurable via environment variable — embedders that need different timing must call the builder API in code.
+The server runs a canonicalization pass every **10 seconds** with a **10-minute** submission grace period. Both values are hard-coded in `crates/server/src/main.rs` and are **not** configurable via environment variable - embedders that need different timing must call the builder API in code.
+
+Operators should monitor:
+
+- candidate deltas older than the grace period,
+- discarded deltas,
+- repeated canonicalization failures for the same account,
+- Miden node RPC failures,
+- acknowledgement key changes,
+- database write latency and migration failures.
 
 ## Reproducible builds
 
@@ -87,3 +123,5 @@ The server runs a canonicalization pass every **10 seconds** with a **10-minute*
 ```
 
 The script must run inside a git checkout of the repo with a `Dockerfile` at the root. It builds the server image, copies the resulting `/app/server` binary out, and prints its SHA256, size, and the source commit. Uncommitted local changes produce a warning but do not fail the script.
+
+Record the output with the deployment change. It gives operators and integrators a concrete artifact to compare when debugging or auditing a running Guardian instance.

--- a/versioned_docs/version-0.14/builder/miden-guardian/operator-guide/troubleshooting.md
+++ b/versioned_docs/version-0.14/builder/miden-guardian/operator-guide/troubleshooting.md
@@ -21,9 +21,11 @@ The Guardian key is loaded from the configured keystore path. Confirm the same `
 
 For production AWS deployments, confirm `GUARDIAN_ENV=prod` and `AWS_REGION` are set so acknowledgement keys are loaded from Secrets Manager rather than the filesystem.
 
+Clients should treat an unexpected `/pubkey` change as a trust-boundary event. New acknowledgement signatures should not be accepted until the operator confirms an intentional key rotation.
+
 ## Authentication failures
 
-Guardian requires signed requests. Each carries three headers — `x-pubkey`, `x-signature`, and `x-timestamp` — and the timestamp is validated against two rules:
+Guardian requires signed requests. Each carries three headers - `x-pubkey`, `x-signature`, and `x-timestamp` - and the timestamp is validated against two rules:
 
 - It must be within ±5 minutes of server time (`MAX_TIMESTAMP_SKEW_MS = 300_000`).
 - It must be **strictly greater** than the last timestamp the server saw for that public key. The metadata store enforces this with a CAS update; a request with a timestamp equal to or below the previous one is rejected even if otherwise valid.
@@ -33,7 +35,7 @@ Common causes:
 - Client clock is more than 5 minutes from server time.
 - Timestamp was reused (replay attempt or accidental retry without re-signing).
 - Request body changed after signing.
-- Client is using the wrong Guardian public key — re-fetch `/pubkey`.
+- Client is using the wrong Guardian public key - re-fetch `/pubkey`.
 
 ## Proposal stays pending
 
@@ -48,6 +50,36 @@ Common causes:
 - Metadata backend is not writable.
 - The pending-proposal count has hit `GUARDIAN_MAX_PENDING_PROPOSALS_PER_ACCOUNT` (default `20`); see [error code `pending_proposals_limit`](#common-error-codes).
 
+## Candidate delta is discarded
+
+A discarded delta means Guardian could not verify that the candidate's `new_commitment` matches the commitment accepted by Miden.
+
+First checks:
+
+- The client submitted the Miden transaction proof after receiving the Guardian acknowledgement.
+- The client submitted the exact transaction that produced the acknowledged `new_commitment`.
+- The Miden node RPC endpoint is pointed at the expected network.
+- No other device advanced the account state first.
+
+Client recovery path:
+
+1. Fetch the latest canonical state or `delta/since`.
+2. Replay locally and verify the resulting commitment.
+3. Rebuild the transaction from the fresh state.
+4. Submit a new delta.
+
+## Client receives stale state
+
+Guardian can be unavailable, delayed, or serving data from a lagging backend. The client should compare the recovered local commitment against the latest commitment accepted by Miden before relying on restored state.
+
+Operator checks:
+
+- Canonicalization worker is running.
+- Miden node RPC is healthy and on the expected network.
+- Database writes are succeeding.
+- Candidate deltas are not stuck beyond the grace period.
+- Logs do not show repeated `storage_error`, `network_error`, or canonicalization failures.
+
 ## Rate limit errors
 
 If requests are rejected under load, tune:
@@ -58,7 +90,7 @@ GUARDIAN_RATE_PER_MIN            # default 60
 GUARDIAN_MAX_REQUEST_BYTES       # default 1048576
 ```
 
-The HTTP rate-limit middleware responds with `429 Too Many Requests` and a `Retry-After` header plus `retry_after_secs` in the body. **Note:** these middleware-level rejections do not include a `code` field — only the Guardian application-level `rate_limit_exceeded` error does. See the table below.
+The HTTP rate-limit middleware responds with `429 Too Many Requests` and a `Retry-After` header plus `retry_after_secs` in the body. **Note:** these middleware-level rejections do not include a `code` field - only the Guardian application-level `rate_limit_exceeded` error does. See the table below.
 
 ## Common error codes
 
@@ -68,6 +100,7 @@ The server emits structured error codes via `GuardianError::code()`. The most co
 | ----------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
 | `authentication_failed` | Auth headers missing or malformed, clock skew > 5 min, signature invalid, or the timestamp was already used.          | `x-pubkey` / `x-signature` / `x-timestamp` headers; client clock sync; the last timestamp you sent. |
 | `account_not_found`     | The metadata store has no record for that account ID.                                                                 | Account ID is correct and `/configure` actually completed against this server.                      |
-| `invalid_input`         | Generic 400 — request JSON, query parameters, or commitment shape failed validation.                                  | Request payload schema; commitment hex format.                                                      |
+| `invalid_input`         | Generic 400 - request JSON, query parameters, or commitment shape failed validation.                                  | Request payload schema; commitment hex format.                                                      |
 | `rate_limit_exceeded`   | Application-level rate limit hit. (The HTTP middleware also emits `429` responses, but those have no `code` field.)   | Tune `GUARDIAN_RATE_BURST_PER_SEC` / `GUARDIAN_RATE_PER_MIN`; check `Retry-After` on the response.  |
 | `storage_error`         | The storage or metadata backend rejected an operation.                                                                | Filesystem permissions on the storage paths, or database health for Postgres mode.                  |
+| `pending_proposals_limit` | The account already has the maximum number of pending proposals.                                                    | Resolve, cancel, or clean old proposals; raise `GUARDIAN_MAX_PENDING_PROPOSALS_PER_ACCOUNT` if appropriate. |


### PR DESCRIPTION
## Summary

Expands the Guardian docs with a more explicit architecture and trust-model treatment, using Tempo Zones' docs as a structural benchmark for clarity around roles, boundaries, failure modes, and operator responsibilities.

Refs #265.

## What changed

- Adds a WIP/status warning and clearer framing for what Guardian is and is not.
- Expands the architecture page with system boundaries, design goals/non-goals, lifecycle, canonicalization, and failure recovery tables.
- Updates components docs with a component map, more precise request signing, lookup signing, ack-key binding, and storage sensitivity notes.
- Expands data-structure docs with current `StateObject` / `DeltaObject` shapes, visibility boundaries, and invariants.
- Strengthens security docs around operator visibility, liveness risk, freshness checks, provider rotation, and key-loss scenarios.
- Adds production deployment architecture, monitoring guidance, and troubleshooting paths for discarded deltas and stale state.
- Mirrors the updates into `versioned_docs/version-0.14`.

## Verification

- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=12288 npm run build` after local deploy-style ingestion of external docs

## Notes

The production build succeeds, but still reports existing broken-link, broken-anchor, KaTeX, and Browserslist warnings from ingested/versioned docs. `npm run typecheck` still fails on existing Docusaurus `@theme/*` alias/type issues and existing `PageMetadata` prop typing errors; this PR does not touch those files.
