### PR TITLE
docs: add bridging tutorial sidebar entry + Bridging DocCard

### DIFF
--- a/docs/builder/tutorials/index.md
+++ b/docs/builder/tutorials/index.md
@@ -20,6 +20,9 @@ Hands-on walkthroughs for building on Miden. Every tutorial pairs with runnable 
   <Card title="Miden node setup" href="./miden_node_setup" eyebrow="Operator">
     Run a Miden node locally or on testnet with `midenup` and the node binary.
   </Card>
+  <Card title="Bridging" href="./recipes/web/bridging_with_epoch_tutorial" eyebrow="Recipe · TypeScript">
+    Bridge assets between Miden and EVM chains (Sepolia testnet) with the Epoch protocol intent SDK.
+  </Card>
 </CardGrid>
 
 ## Development helpers

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -149,6 +149,7 @@ const sidebars: SidebarsConfig = {
                 "builder/tutorials/recipes/web/unauthenticated_note_how_to",
                 "builder/tutorials/recipes/web/foreign_procedure_invocation_tutorial",
                 "builder/tutorials/recipes/web/react_wallet_tutorial",
+                "builder/tutorials/recipes/web/bridging_with_epoch_tutorial",
               ],
             },
           ],


### PR DESCRIPTION
## Summary

This PR wires the bridging tutorial into the docs site: one sidebar entry under Web/TypeScript recipes (after `react_wallet_tutorial`) and a 4th `<Card>` ("Bridging") in `<CardGrid>` on `docs/builder/tutorials/index.md`. The tutorial content itself ships in [`0xMiden/tutorials#199`](https://github.com/0xMiden/tutorials/pull/199), which the existing `deploy-docs.yml` workflow ingests into this repo at build time.

## Key Changes

- `sidebars.ts` — one inserted line for the bridging tutorial slug.
- `docs/builder/tutorials/index.md` — three inserted lines for the Bridging Card.

## Out of scope

- No Agglayer cross-link (a web-Agglayer tutorial will land in its own PR after a feasibility pass).

## Open Questions

1. **Card placement:** Bridging is the 4th card in the grid — happy to move it earlier in the order if you'd prefer.
