### PR TITLE
docs: add testnet bridging section

### DIFF
--- a/docs/builder/tools/bridging/_category_.yml
+++ b/docs/builder/tools/bridging/_category_.yml
@@ -1,0 +1,3 @@
+label: "Bridging"
+position: 6
+collapsed: true

--- a/docs/builder/tools/bridging/api-reference.md
+++ b/docs/builder/tools/bridging/api-reference.md
@@ -1,0 +1,165 @@
+---
+sidebar_position: 4
+title: API reference
+description: "Mock 1Click Bridge API endpoints used by the testnet bridge sandbox."
+---
+
+# API reference
+
+The sandbox exposes a small `/v0/*` API shaped for 1Click-style bridge testing.
+Use these endpoints from builder apps. Do not build app integrations against
+local `/demo/*` helpers.
+
+<Callout variant="info" title="Mock API">
+This API is a testnet mock for app development. It is not a production bridge
+API contract and does not define mainnet behavior.
+</Callout>
+
+## `GET /v0/tokens`
+
+Returns supported assets for the active runtime profile.
+
+```bash
+curl -s http://localhost:8080/v0/tokens | jq .
+```
+
+For the Sepolia profile, assets use IDs such as:
+
+```text
+eth-sepolia:eth
+miden-testnet:eth
+```
+
+## `POST /v0/quote`
+
+Creates an inbound or outbound quote.
+
+### Inbound quote
+
+Sepolia native ETH to Miden testnet:
+
+```bash
+curl -s http://localhost:8080/v0/quote \
+  -H 'content-type: application/json' \
+  -d '{
+    "dry": false,
+    "depositMode": "SIMPLE",
+    "swapType": "EXACT_INPUT",
+    "slippageTolerance": 100.0,
+    "originAsset": "eth-sepolia:eth",
+    "depositType": "ORIGIN_CHAIN",
+    "destinationAsset": "miden-testnet:eth",
+    "amount": "1000000000000",
+    "refundTo": "<sepolia-refund-address>",
+    "refundType": "ORIGIN_CHAIN",
+    "recipient": "<miden-recipient-address>",
+    "recipientType": "DESTINATION_CHAIN",
+    "deadline": "2027-01-01T00:00:00Z"
+  }' | jq .
+```
+
+Important response fields:
+
+| Field | Meaning |
+| --- | --- |
+| `correlationId` | Quote identifier used for evidence and flow lookup. |
+| `quote.depositAddress` | Sepolia deposit address for this quote. |
+| `quote.amountIn` | Required origin-chain amount. |
+| `quote.amountOut` | Quoted destination amount. |
+
+### Outbound quote
+
+Miden testnet to Sepolia native ETH:
+
+```bash
+curl -s http://localhost:8080/v0/quote \
+  -H 'content-type: application/json' \
+  -d '{
+    "dry": false,
+    "depositMode": "SIMPLE",
+    "swapType": "EXACT_INPUT",
+    "slippageTolerance": 100.0,
+    "originAsset": "miden-testnet:eth",
+    "depositType": "ORIGIN_CHAIN",
+    "destinationAsset": "eth-sepolia:eth",
+    "amount": "1000000000000",
+    "refundTo": "<miden-refund-address>",
+    "refundType": "ORIGIN_CHAIN",
+    "recipient": "<sepolia-recipient-address>",
+    "recipientType": "DESTINATION_CHAIN",
+    "deadline": "2027-01-01T00:00:00Z"
+  }' | jq .
+```
+
+Important response fields:
+
+| Field | Meaning |
+| --- | --- |
+| `correlationId` | Quote identifier used for evidence and flow lookup. |
+| `quote.depositAddress` | Stable Miden bridge account for public-note deposits. |
+| `quote.depositMemo` | `BridgeOutV1` instruction payload. |
+| `quote.amountIn` | Required Miden asset amount. |
+| `quote.amountOut` | Quoted Sepolia release amount. |
+
+The user creates a public Miden note carrying the quoted asset and
+`quote.depositMemo`, targeted to `quote.depositAddress`.
+
+## `POST /v0/deposit/submit`
+
+Submits a landed Sepolia transaction hash for an inbound quote.
+
+```bash
+curl -s http://localhost:8080/v0/deposit/submit \
+  -H 'content-type: application/json' \
+  -d '{
+    "txHash": "0x...",
+    "depositAddress": "<quote.depositAddress>"
+  }' | jq .
+```
+
+Sepolia mode requires this explicit tx-hash submit step. The bridge verifies
+that the transaction paid the quoted deposit address with the quoted amount
+before it starts Miden settlement.
+
+## `GET /v0/status`
+
+Polls quote lifecycle status.
+
+For inbound quotes, query by Sepolia deposit address:
+
+```bash
+curl -s "http://localhost:8080/v0/status?depositAddress=<sepolia-deposit-address>" | jq .
+```
+
+For outbound quotes, query by the Miden bridge account and memo or quote hash:
+
+```bash
+curl -G http://localhost:8080/v0/status \
+  --data-urlencode "depositAddress=<miden-bridge-account-address>" \
+  --data-urlencode "depositMemo=<bridge-out-v1-memo>" | jq .
+```
+
+Status responses include the current lifecycle status and, after settlement,
+evidence fields such as Miden mint or consume transaction IDs and Sepolia
+release transaction hashes.
+
+## Lifecycle statuses
+
+| Status | Meaning |
+| --- | --- |
+| `PENDING_DEPOSIT` | Quote exists and is waiting for a deposit. |
+| `KNOWN_DEPOSIT_TX` | A deposit transaction hash was submitted and is being verified. |
+| `PROCESSING` | The origin deposit is verified and destination settlement is running. |
+| `SUCCESS` | Bridge-side settlement completed. |
+| `REFUNDED` | Funds were returned instead of settled. |
+| `FAILED` | The quote could not settle or refund. |
+
+## Endpoint boundaries
+
+| Endpoint family | Intended use |
+| --- | --- |
+| `/v0/*` | Public integration surface for builder apps. |
+| `/demo/*` | Local sandbox helpers for manual demos and Anvil flows. |
+| `/lab` | Local clickable UI for sandbox testing. |
+
+Third-party apps should depend on `/v0/*` only.

--- a/docs/builder/tools/bridging/flows.md
+++ b/docs/builder/tools/bridging/flows.md
@@ -1,0 +1,125 @@
+---
+sidebar_position: 3
+title: Bridge flows
+description: "Component model and sequence diagrams for the testnet mock bridge sandbox."
+---
+
+# Bridge flows
+
+The mock bridge sandbox keeps the integration surface small while making the
+actors explicit: user wallet, builder app, Bridge API, solver, Sepolia, and
+Miden testnet.
+
+The solver role is implemented inside the sandbox service. In production-style
+systems, the solver may be a separate operator, but the app-facing flow remains
+quote, deposit, status, and settlement evidence.
+
+## Component model
+
+```mermaid
+flowchart TB
+    User["User wallet"]
+    App["Builder app"]
+    Bridge["Bridge API<br/>mock 1Click surface"]
+    State["Quote state<br/>Postgres"]
+    Solver["Solver role<br/>inside sandbox"]
+    Sepolia["Sepolia<br/>native ETH"]
+    Miden["Miden testnet<br/>public notes"]
+    Recipient["Recipient wallet"]
+
+    User --> App
+    App -->|"GET /v0/tokens<br/>POST /v0/quote<br/>POST /v0/deposit/submit<br/>GET /v0/status"| Bridge
+    Bridge --> State
+    Bridge --> Solver
+    Solver --> Sepolia
+    Solver --> Miden
+    User --> Sepolia
+    User --> Miden
+    Miden --> Recipient
+```
+
+## Inbound: Sepolia to Miden
+
+Inbound means the user starts with Sepolia native ETH and receives a public
+Miden payout note.
+
+```mermaid
+sequenceDiagram
+    participant User as User wallet
+    participant App as Builder app
+    participant Bridge as Bridge API
+    participant Solver as Solver
+    participant Sepolia
+    participant Miden as Miden testnet
+    participant Recipient as Recipient wallet
+
+    App->>Bridge: POST /v0/quote eth-sepolia:eth -> miden-testnet:eth
+    Bridge-->>App: correlationId and Sepolia depositAddress
+    User->>Sepolia: send native ETH to depositAddress
+    App->>Bridge: POST /v0/deposit/submit with txHash and depositAddress
+    Bridge->>Sepolia: verify receipt, amount, and deposit address
+    Bridge->>Solver: mark quote ready for Miden payout
+    Solver->>Miden: submit public P2ID mint tx to recipient
+    Bridge-->>App: /v0/status returns SUCCESS after payout note is committed
+    Recipient->>Miden: sync and consume public P2ID note
+```
+
+`SUCCESS` means the bridge-side payout note is committed and consumable. The
+recipient still needs to sync and consume the public P2ID note to update local
+wallet balance.
+
+## Outbound: Miden to Sepolia
+
+Outbound means the user starts with a Miden testnet asset and receives Sepolia
+native ETH.
+
+```mermaid
+sequenceDiagram
+    participant User as User wallet
+    participant App as Builder app
+    participant Bridge as Bridge API
+    participant Solver as Solver
+    participant Miden as Miden testnet
+    participant Sepolia
+
+    App->>Bridge: POST /v0/quote miden-testnet:eth -> eth-sepolia:eth
+    Bridge-->>App: correlationId, bridgeAccount, and BridgeOutV1 depositMemo
+    User->>Miden: create public BridgeOutV1 note to bridgeAccount
+    Bridge->>Miden: poll public notes for matching memo and quote hash
+    Bridge->>Solver: validate amount, recipient, refund, deadline, and faucet
+    Solver->>Miden: consume BridgeOutV1 note with bridge account
+    Solver->>Sepolia: release native ETH to destination recipient
+    Bridge-->>App: /v0/status returns SUCCESS with Miden consume tx and Sepolia release tx
+```
+
+The outbound deposit is a public programmable Miden note, not a per-quote Miden
+account. The note carries the `BridgeOutV1` memo and assets, and the bridge
+consumes it only after validating the memo fields against the stored quote.
+
+## Why public notes
+
+Public notes are intentional for the sandbox flow:
+
+- The bridge can observe and validate deposits without requiring per-quote
+  Miden account setup.
+- A user can target a stable bridge account with a programmable note.
+- The note metadata and storage encode the quote hash and settlement
+  instructions.
+- The same public-note pattern matches Miden's account and note model better
+  than EVM-style per-address deposit discovery.
+
+Use private notes only when the bridge or solver has a separate private-note
+transport and discovery design. That is outside the current sandbox scope.
+
+## Lifecycle statuses
+
+The sandbox records quote state so restarts can resume in-flight work.
+
+| Status | Meaning |
+| --- | --- |
+| `PENDING_DEPOSIT` | Quote exists, but the bridge has not verified an origin-chain deposit. |
+| `KNOWN_DEPOSIT_TX` | The app submitted an origin-chain transaction hash for verification. |
+| `PROCESSING` | Deposit is verified and bridge-side settlement is in progress. |
+| `SUCCESS` | Bridge-side settlement is complete. |
+| `REFUNDED` | The quote was refunded instead of settled. |
+| `FAILED` | The bridge could not complete or refund the quote. |

--- a/docs/builder/tools/bridging/index.md
+++ b/docs/builder/tools/bridging/index.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 1
+title: Bridging
+description: "Testnet bridge tooling and interoperability guides for Miden builders."
+pagination_prev: null
+---
+
+# Bridging
+
+Bridging docs cover testnet bridge tooling and interoperability workflows for
+builders integrating Miden with external networks and intent systems.
+
+The first guide in this section is the mock NEAR Intents 1Click-style bridge
+sandbox for Sepolia native ETH and public Miden testnet. Future bridge docs can
+be added beside it, including AggLayer bridging and Epoch bridging, without
+making any single guide the canonical production bridge path.
+
+<Callout variant="warn" title="Testnet only">
+The current bridge sandbox is developer testing infrastructure. It is not a
+production bridge, not a mainnet integration path, and must not be used with
+mainnet funds.
+</Callout>
+
+## Start here
+
+<CardGrid cols={3}>
+  <Card title="Testnet sandbox" href="./testnet-sandbox" eyebrow="Sepolia + Miden testnet">
+    Run the mock 1Click Bridge API locally and reproduce the Sepolia-to-Miden
+    and Miden-to-Sepolia testing flow.
+  </Card>
+  <Card title="Bridge flows" href="./flows" eyebrow="Diagrams">
+    Understand the actors, solver role, public Miden notes, and inbound/outbound
+    lifecycle.
+  </Card>
+  <Card title="API reference" href="./api-reference" eyebrow="/v0">
+    Integration shape for `/v0/tokens`, `/v0/quote`, `/v0/deposit/submit`, and
+    `/v0/status`.
+  </Card>
+</CardGrid>
+
+## Current scope
+
+| Area | Status | Notes |
+| --- | --- | --- |
+| Mock NEAR Intents 1Click bridge sandbox | Available | Testnet-only local service for app integration testing. |
+| AggLayer bridging | Planned | Add as a sibling guide when the developer-facing flow is stable. |
+| Epoch bridging | Planned | Add as a sibling guide when the developer-facing flow is stable. |
+
+## When to use this section
+
+Use these docs when you need to:
+
+- point an app at a local mock Bridge API;
+- test bridge-like quote, deposit, status, and claim flows against public
+  testnets;
+- understand how public Miden notes can represent bridge deposits or payouts;
+- collect evidence with Sepolia transaction hashes and Miden transaction IDs.
+
+For core account, note, and transaction concepts, start with the Smart Contracts
+section instead. For testnet RPC, explorer, faucet, and remote prover endpoints,
+see [Network](../network).

--- a/docs/builder/tools/bridging/testnet-sandbox.md
+++ b/docs/builder/tools/bridging/testnet-sandbox.md
@@ -1,0 +1,128 @@
+---
+sidebar_position: 2
+title: Testnet mock bridge sandbox
+description: "Run the mock NEAR Intents 1Click-style bridge sandbox against Sepolia and public Miden testnet."
+---
+
+# Testnet mock bridge sandbox
+
+The mock bridge sandbox is a local Bridge API for testing app integrations with
+a NEAR Intents 1Click-style flow. It exposes the public `/v0/*` integration
+surface while using Sepolia native ETH and public Miden testnet behind the
+scenes.
+
+The sandbox repository is
+[BrianSeong99/miden-testnet-bridge](https://github.com/BrianSeong99/miden-testnet-bridge).
+
+<Callout variant="warn" title="Do not use mainnet funds">
+This sandbox is testnet-only. Use Sepolia ETH, test-only keys, and fresh Miden
+testnet state. Do not use production keys or mainnet assets.
+</Callout>
+
+## What it provides
+
+- A local Bridge API shaped like a 1Click integration:
+  `/v0/tokens`, `/v0/quote`, `/v0/deposit/submit`, and `/v0/status`.
+- Sepolia native ETH inbound deposits to public Miden testnet payouts.
+- Miden public `BridgeOutV1` notes for outbound testnet releases to Sepolia.
+- Solver behavior inside the sandbox service so builders can test app flows
+  without operating a separate solver.
+- Evidence output with Sepolia transaction hashes, Miden transaction IDs, and
+  lifecycle statuses.
+
+## Prerequisites
+
+- Docker with Compose v2.
+- Rust toolchain for running the live evidence helper.
+- `curl`, `jq`, and OpenSSL.
+- A Sepolia RPC endpoint.
+- Sepolia ETH on two test-only keys:
+  - solver key, used by the bridge service for Sepolia release transactions;
+  - test-user key, used by the live evidence runner to send deposits.
+
+The default public Miden testnet RPC is `https://rpc.testnet.miden.io`. The
+example Sepolia RPC below uses Tenderly's public endpoint.
+
+## Start the Sepolia profile
+
+```bash
+git clone https://github.com/BrianSeong99/miden-testnet-bridge.git
+cd miden-testnet-bridge
+cp .env.sepolia.example .env
+```
+
+Fill `.env` with testnet-only values:
+
+```text
+EVM_RPC_URL=https://gateway.tenderly.co/public/sepolia
+MASTER_MNEMONIC=<builder-controlled-test-mnemonic>
+SOLVER_PRIVATE_KEY=<funded-sepolia-solver-private-key>
+DEMO_EVM_FUNDED_PRIVATE_KEY=<funded-sepolia-test-user-private-key>
+MIDEN_MASTER_SEED_HEX=<fresh-32-byte-hex-seed>
+```
+
+Generate a fresh Miden seed:
+
+```bash
+perl -0pi -e "s/MIDEN_MASTER_SEED_HEX=.*/MIDEN_MASTER_SEED_HEX=$(openssl rand -hex 32)/" .env
+```
+
+Start the sandbox:
+
+```bash
+make sepolia
+```
+
+Check readiness:
+
+```bash
+curl -s http://localhost:8080/healthz
+curl -s http://localhost:8080/readyz | jq .
+```
+
+## Monitor the sandbox
+
+Use `bridgectl` for local status and flow inspection:
+
+```bash
+./bin/bridgectl status
+./bin/bridgectl tokens
+./bin/bridgectl flows
+./bin/bridgectl flow <correlation-id>
+make sepolia-logs
+make sepolia-reset
+```
+
+The `/demo/*` and `/lab` endpoints in the sandbox are local helpers. App
+integrations should use only the `/v0/*` endpoints described in the
+[API reference](./api-reference).
+
+## Run live testnet evidence
+
+After both Sepolia keys are funded, run:
+
+```bash
+RUSTFLAGS='-C debug-assertions=no' cargo run --bin sepolia_e2e 2>&1 | tee sepolia-e2e-live.log
+```
+
+The evidence runner drives both directions:
+
+1. Sepolia native ETH deposit -> `/v0/deposit/submit` -> solver-signed public
+   P2ID mint on Miden -> recipient claim.
+2. Miden public `BridgeOutV1` note -> bridge consume on Miden -> Sepolia native
+   ETH release.
+
+The run prints `SEPOLIA_E2E_EVIDENCE` lines with correlation IDs, Sepolia
+transaction hashes, Miden transaction IDs, and final balance deltas.
+
+## Published evidence
+
+The sandbox repository includes a terminal walkthrough video and a published
+evidence page:
+
+- [Terminal walkthrough](https://github.com/BrianSeong99/miden-testnet-bridge#terminal-walkthrough)
+- [Smoke test report](https://brianseong99.github.io/miden-testnet-bridge/smoke-test-report.html)
+
+Use those artifacts as examples of what to capture when reporting bridge test
+results: command line, lifecycle statuses, Sepolia transaction hashes, Miden
+transaction IDs, and explorer links.

--- a/docs/builder/tools/index.md
+++ b/docs/builder/tools/index.md
@@ -1,12 +1,12 @@
 ---
 title: Tools
-description: "Developer tools for building on and interacting with the Miden network — clients, note transport, playground, and the live network surface."
+description: "Developer tools for building on and interacting with the Miden network — clients, note transport, bridging, playground, and the live network surface."
 pagination_prev: null
 ---
 
 # Tools
 
-Developer tools for building on and interacting with the Miden network. Use the client SDKs inside your app, Note Transport to relay private notes, the Playground to prototype contracts in-browser, and the Network page to find the live testnet endpoints (status, explorer, RPC, faucet, remote prover).
+Developer tools for building on and interacting with the Miden network. Use the client SDKs inside your app, Note Transport to relay private notes, Bridging guides to test interoperability flows, the Playground to prototype contracts in-browser, and the Network page to find the live testnet endpoints (status, explorer, RPC, faucet, remote prover).
 
 ## Clients
 
@@ -36,5 +36,8 @@ Developer tools for building on and interacting with the Miden network. Use the 
   </Card>
   <Card title="Note Transport" href="./note-transport/" eyebrow="Private notes · Relay">
     Off-chain relay service for delivering private note payloads between senders and recipients.
+  </Card>
+  <Card title="Bridging" href="./bridging/" eyebrow="Interop · Testnets">
+    Testnet bridge tooling and interoperability guides, starting with the mock 1Click bridge sandbox.
   </Card>
 </CardGrid>

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -251,6 +251,16 @@ const sidebars: SidebarsConfig = {
             "builder/tools/note-transport/users",
           ],
         },
+        {
+          type: "category",
+          label: "Bridging",
+          link: { type: "doc", id: "builder/tools/bridging/index" },
+          items: [
+            "builder/tools/bridging/testnet-sandbox",
+            "builder/tools/bridging/flows",
+            "builder/tools/bridging/api-reference",
+          ],
+        },
         "builder/tools/midenup",
         "builder/tools/playground",
         "builder/tools/network",


### PR DESCRIPTION
## Summary

- Adds a new Build -> Tools -> Bridging section for testnet bridge tooling.
- Documents the mock NEAR Intents 1Click-style sandbox for Sepolia native ETH and public Miden testnet.
- Adds component and sequence diagrams, flow semantics, and the `/v0/*` API reference.
- Leaves room in the IA for future AggLayer bridging and Epoch bridging guides as sibling pages.

Fixes #299

## Verification

- `npm ci`
- Simulated the Pages deploy aggregation with temporary vendor clones, then ran `NODE_OPTIONS='--max-old-space-size=12288' npm run build` successfully.
- Verified external links: bridge repo, terminal walkthrough anchor, smoke test report.
- Verified Tenderly Sepolia RPC with `eth_chainId` returning `0xaa36a7`.

Notes:
- The build still reports existing broken-link and broken-anchor warnings in versioned/external docs; none reference the new bridging pages.
- `npm run typecheck` remains blocked by existing Docusaurus `@theme/*` alias errors in src/versioned/ingested TSX files.