### PR TITLE
fix(docs): prevent mobile table overflow

### DIFF
--- a/src/custom/_components.css
+++ b/src/custom/_components.css
@@ -726,6 +726,17 @@ article td code {
   padding: 1px 4px;
 }
 
+@media (max-width: 768px) {
+  .theme-doc-markdown table,
+  article table {
+    display: block;
+    max-width: 100%;
+    overflow-x: auto;
+    overflow-y: hidden;
+    -webkit-overflow-scrolling: touch;
+  }
+}
+
 /* ==========================================
    15) VERSION INDICATOR STYLING
    ========================================== */


### PR DESCRIPTION
## Summary

Fixes mobile overflow for markdown tables by making doc tables scroll horizontally inside the article at narrow viewport widths. This keeps long table content from widening the whole page on pages like Standard Notes.

## Verification

- `git diff --check`
- `NODE_OPTIONS=--max-old-space-size=12288 npm run build` passed with existing unrelated broken-link/anchor warnings
- Playwright mobile check at 390px viewport: document/body scroll width stayed 390px, and all three Standard Notes tables stayed inside the viewport with `overflow-x: auto`