### PR TITLE
docs: explain "no state change, no notes" transaction failure

### DIFF
--- a/docs/builder/smart-contracts/accounts/account-operations.md
+++ b/docs/builder/smart-contracts/accounts/account-operations.md
@@ -84,12 +84,15 @@ Several operations cause proof generation to fail if preconditions aren't met:
 | `get_balance(faucet_id)` | Referenced asset is non-fungible |
 | `get_procedure_root(index)` | Index out of bounds |
 | Any `assert!()` | Condition is false |
+| Transaction body (overall) | No state change occurred **and** no notes were consumed |
 
 When proof generation fails:
 1. The ZK circuit cannot produce a valid proof
 2. The transaction is rejected **before reaching the network**
 3. No state changes occur
 4. The client receives an error describing the failure
+
+The last row is enforced at end-of-execution by the VM kernel rather than mid-execution: a transaction that mutates no account state (storage, vault, or nonce) **and** consumes no notes is rejected. The Rust client also catches this case before submission as `TransactionRequestError::NoInputNotesNorAccountChange`. See [Empty Transaction](../../tutorials/helpers/pitfalls#empty-transaction-no-state-change-no-notes) for the recommended pattern.
 
 ## Example: ManagedWallet
 

--- a/docs/builder/smart-contracts/transactions/introduction.md
+++ b/docs/builder/smart-contracts/transactions/introduction.md
@@ -70,6 +70,8 @@ The ZK circuit **cannot produce a valid proof**. This means:
 
 This is fundamentally different from Ethereum's `revert`, where the failed transaction still lands on-chain, consumes gas, and is visible to everyone.
 
+A separate failure mode is the **empty transaction**: a transaction that runs to completion but mutates no account state (storage, vault, or nonce) and consumes no input notes. Both the Rust client (which raises `TransactionRequestError::NoInputNotesNorAccountChange` before submission) and the VM kernel reject it. This typically catches transaction scripts whose conditional logic takes a no-op branch — see [Empty Transaction](../../tutorials/helpers/pitfalls#empty-transaction-no-state-change-no-notes) in the pitfalls guide for the recommended pattern.
+
 ## How transactions differ from EVM transactions
 
 | | EVM | Miden |

--- a/docs/builder/tutorials/helpers/pitfalls.md
+++ b/docs/builder/tutorials/helpers/pitfalls.md
@@ -481,6 +481,80 @@ The native hash function changed from RPO to Poseidon2 in v0.14, so every MAST r
 
 ---
 
+## Empty Transaction (No State Change, No Notes)
+
+### Problem
+
+Every Miden transaction must either change tracked account state (storage, vault, or nonce) **or** consume at least one input note. A transaction that does neither is rejected.
+
+The Rust client surfaces this as `TransactionRequestError::NoInputNotesNorAccountChange` before submission:
+
+```
+empty transaction: the request has no input notes and no account state changes
+```
+
+The VM kernel enforces the same invariant during execution, surfacing the message:
+
+```
+executed transaction neither changed the account state, nor consumed any notes
+```
+
+This commonly catches transaction scripts that take a no-op branch — the script ran fine, but nothing in its body mutated state:
+
+```rust
+#[tx_script]
+fn run(arg: Word, account: &mut Account) {
+    let should_settle = arg[0];
+    if should_settle == felt!(1) {
+        account.settle();  // mutates state
+    }
+    // WRONG: when should_settle != felt!(1), the script returns
+    //        without mutating state and the transaction is rejected.
+}
+```
+
+The script executed correctly — Miden just refuses to admit transactions with no observable effect.
+
+### Solution
+
+Give every branch something to mutate, or record the no-op explicitly so the transaction has a state delta:
+
+```rust
+#[tx_script]
+fn run(arg: Word, account: &mut Account) {
+    let should_settle = arg[0];
+    if should_settle == felt!(1) {
+        account.settle();
+    } else {
+        // Record the attempt so the transaction still has a state delta.
+        account.record_attempt();
+    }
+}
+```
+
+Alternatively, if the flow naturally consumes a note (most do — note scripts mutate state when they run), make sure the transaction request includes at least one input note:
+
+```rust
+let request = TransactionRequestBuilder::new()
+    .authenticated_input_notes([(note_id, args)])
+    .build()?;
+```
+
+:::tip Standard auth handles this for you
+Most account templates run an authentication procedure that calls `incr_nonce()` on every transaction. If your account uses `BasicWallet`, `IncrNonceAuthComponent`, or any auth component that increments the nonce, you only hit this pitfall in transaction-script-only flows that skip the auth path. See [Authentication](../../smart-contracts/accounts/authentication) for details.
+:::
+
+### Why this exists
+
+A Miden transaction commits to a state delta plus a set of consumed notes. A transaction with neither is indistinguishable from "no transaction at all" — admitting it would waste a block slot and a proof verification. The invariant lets the network reject empty proofs cheaply.
+
+:::info See also
+- Client-side error catalog: [`TransactionRequestError::NoInputNotesNorAccountChange`](../../tools/clients/common-errors)
+- Failure modes table: [Account Operations](../../smart-contracts/accounts/account-operations#when-proof-generation-fails)
+:::
+
+---
+
 ## Quick Reference Table
 
 | Pitfall | Symptom | Solution |
@@ -493,6 +567,7 @@ The native hash function changed from RPO to Poseidon2 in v0.14, so every MAST r
 | Missing wallet | Asset operation fails | Add `BasicWallet` component |
 | Key mismatch | Zero balances | Use helper function for keys |
 | Note type | Wrong note visibility | Use 1 (Public) or 2 (Private) |
+| Empty transaction | "Neither changed account state nor consumed notes" | Mutate state in every path, or consume a note |
 
 :::tip View Complete Source
 See these patterns in context in the [miden-bank repository](https://github.com/keinberger/miden-bank).

--- a/docs/builder/tutorials/helpers/pitfalls.md
+++ b/docs/builder/tutorials/helpers/pitfalls.md
@@ -532,11 +532,11 @@ fn run(arg: Word, account: &mut Account) {
 }
 ```
 
-Alternatively, if the flow naturally consumes a note (most do — note scripts mutate state when they run), make sure the transaction request includes at least one input note:
+Alternatively, if the flow naturally consumes a note (most do — note scripts mutate state when they run), make sure the transaction request includes at least one input note. Pass the `Note` (the client deduces authentication from the note record) along with optional `NoteArgs`:
 
 ```rust
 let request = TransactionRequestBuilder::new()
-    .authenticated_input_notes([(note_id, args)])
+    .input_notes(vec![(input_note, None)])
     .build()?;
 ```
 


### PR DESCRIPTION
Adds the "no state change, no notes consumed" failure mode to the pitfalls guide, transaction intro, and account-operations failure table. Distinguishes the Rust-client preflight (`TransactionRequestError::NoInputNotesNorAccountChange`) from the kernel-side message the original reporter hit.

Audited against v0.15 sources (`compiler@i1125-migrate-protocol-v015`, `miden-client@igamigo-protocol-0.15`). Audit caught one drift: the API is `.input_notes(vec![(note, Option<NoteArgs>)])`, not `.authenticated_input_notes(...)` (collapsed in miden-client #1624). Fixed in the final commit. Not compile-tested locally — `cargo-miden 0.7.1` is pinned to SDK v0.10.

Closes #302.