### PR TITLE
docs: tagline, layer 2 terms, onchain spelling

### DIFF
--- a/docs/builder/faq.md
+++ b/docs/builder/faq.md
@@ -84,7 +84,7 @@ Yes, Miden enables consumption of notes based on time conditions, such as:
 
 ## What does a Miden operator do in Miden?
 
-A Miden operator is an entity that maintains the infrastructure necessary for the functioning of the Miden rollup. Their roles may involve:
+A Miden operator is an entity that maintains the infrastructure necessary for the functioning of the Miden layer 2. Their roles may involve:
 
 1. Running Sequencer Nodes
 2. Operating the Prover Infrastructure

--- a/docs/builder/get-started/notes.md
+++ b/docs/builder/get-started/notes.md
@@ -210,7 +210,7 @@ export async function demo() {
     // Creating Alice's account
     const alice = await client.accounts.create({
         type: AccountType.MutableWallet,
-        storage: "public", // Public: account state is visible on-chain
+        storage: "public", // Public: account state is visible onchain
     });
     console.log("Alice's account ID:", alice.id().toString());
 

--- a/docs/builder/get-started/setup/cli-basics.md
+++ b/docs/builder/get-started/setup/cli-basics.md
@@ -110,7 +110,7 @@ miden client account --default <ACCOUNT_ID>
 
 ### Deploy Your Account
 
-The `miden client new-wallet` command above already deploys your account on-chain automatically. You can verify your account is deployed by syncing and checking its status:
+The `miden client new-wallet` command above already deploys your account onchain automatically. You can verify your account is deployed by syncing and checking its status:
 
 ```bash title=">_ Terminal"
 miden client sync

--- a/docs/builder/get-started/your-first-smart-contract/create.md
+++ b/docs/builder/get-started/your-first-smart-contract/create.md
@@ -24,7 +24,7 @@ counter-project/
 │   └── increment-note/          # Example: Increment note contract
 ├── integration/                 # Integration crate (scripts + tests)
 │   ├── src/
-│   │   ├── bin/                 # Rust binaries for on-chain interactions
+│   │   ├── bin/                 # Rust binaries for onchain interactions
 │   │   ├── lib.rs
 │   │   └── helpers.rs           # Temporary helper file
 │   └── tests/                   # Test files
@@ -35,7 +35,7 @@ counter-project/
 The project follows Miden's design philosophy of clean separation:
 
 - **`contracts/`**: Your primary working directory for writing Miden smart contract code
-- **`integration/`**: All on-chain interactions, deployment scripts, and tests
+- **`integration/`**: All onchain interactions, deployment scripts, and tests
 
 Each contract is organized as its own individual crate, providing independent versioning, dependencies, and clear isolation between different contracts.
 

--- a/docs/builder/get-started/your-first-smart-contract/test.md
+++ b/docs/builder/get-started/your-first-smart-contract/test.md
@@ -20,7 +20,7 @@ This structure keeps your contract logic clean while providing a dedicated space
 
 ## Local Testing with Mockchain
 
-For most testing scenarios, we use Miden's **Mockchain** - a local, mocked blockchain instance specifically designed for testing. While you can also create tests that use the Miden client for end-to-end testing and on-chain interactions, the Mockchain provides the best developer experience for unit and integration testing.
+For most testing scenarios, we use Miden's **Mockchain** - a local, mocked blockchain instance specifically designed for testing. While you can also create tests that use the Miden client for end-to-end testing and onchain interactions, the Mockchain provides the best developer experience for unit and integration testing.
 
 ### What is the Mockchain?
 

--- a/docs/builder/glossary.md
+++ b/docs/builder/glossary.md
@@ -61,7 +61,7 @@ A multi-signature account on Miden that requires a configurable threshold (N-of-
 
 ### Note
 
-A fundamental data structure that represents an off-chain asset or a piece of information that can be transferred between accounts. Miden's UTXO-like model is designed around notes. **Output notes** are new notes created by a transaction; **input notes** are those consumed (spent) by a transaction.
+A fundamental data structure that represents an offchain asset or a piece of information that can be transferred between accounts. Miden's UTXO-like model is designed around notes. **Output notes** are new notes created by a transaction; **input notes** are those consumed (spent) by a transaction.
 
 ### Note script
 

--- a/docs/builder/miden-guardian/core-concepts/architecture.md
+++ b/docs/builder/miden-guardian/core-concepts/architecture.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 
 # Architecture
 
-Guardian sits between Miden clients and the Miden network. It is an off-chain coordination layer for private account state, not the canonical source of account validity. Miden remains authoritative for account commitments; Guardian helps authorized clients keep the private state behind those commitments available, fresh, and synchronized.
+Guardian sits between Miden clients and the Miden network. It is an offchain coordination layer for private account state, not the canonical source of account validity. Miden remains authoritative for account commitments; Guardian helps authorized clients keep the private state behind those commitments available, fresh, and synchronized.
 
 ## System overview
 
@@ -128,8 +128,8 @@ Canonicalization is the process of validating that a candidate delta matches the
 ```mermaid
 stateDiagram-v2
     [*] --> candidate : push_delta
-    candidate --> canonical : On-chain commitment matches
-    candidate --> discarded : On-chain commitment mismatch
+    candidate --> canonical : Onchain commitment matches
+    candidate --> discarded : Onchain commitment mismatch
     canonical --> [*]
     discarded --> [*]
 ```

--- a/docs/builder/miden-guardian/core-concepts/data-structures.md
+++ b/docs/builder/miden-guardian/core-concepts/data-structures.md
@@ -87,17 +87,17 @@ Each delta goes through a state machine:
 ```mermaid
 stateDiagram-v2
     [*] --> candidate : push_delta
-    candidate --> canonical : On-chain commitment matches
-    candidate --> discarded : On-chain commitment mismatch
+    candidate --> canonical : Onchain commitment matches
+    candidate --> discarded : Onchain commitment mismatch
     canonical --> [*]
     discarded --> [*]
 ```
 
 | Status | Meaning |
 |---|---|
-| `candidate` | Accepted by Guardian but not yet verified on-chain. Awaiting canonicalization. |
+| `candidate` | Accepted by Guardian but not yet verified onchain. Awaiting canonicalization. |
 | `canonical` | Verified against the network and permanently recorded. |
-| `discarded` | Failed on-chain verification. Removed from the active delta chain. |
+| `discarded` | Failed onchain verification. Removed from the active delta chain. |
 
 In **optimistic mode**, deltas skip the `candidate` stage and are immediately marked `canonical`.
 

--- a/docs/builder/miden-guardian/index.md
+++ b/docs/builder/miden-guardian/index.md
@@ -5,7 +5,7 @@ sidebar_position: 0
 
 # Miden Guardian
 
-Miden Guardian is an off-chain coordination service built by [OpenZeppelin](https://www.openzeppelin.com/) for Miden accounts. It helps clients back up private account state, synchronize that state across devices, and coordinate multi-signer workflows without giving the Guardian provider unilateral control over the account.
+Miden Guardian is an offchain coordination service built by [OpenZeppelin](https://www.openzeppelin.com/) for Miden accounts. It helps clients back up private account state, synchronize that state across devices, and coordinate multi-signer workflows without giving the Guardian provider unilateral control over the account.
 
 :::warning
 Guardian is a work in progress. Use the docs and the [OpenZeppelin Guardian repository](https://github.com/OpenZeppelin/guardian) as the current operator and integration reference, and expect interfaces and operational defaults to evolve.
@@ -19,11 +19,11 @@ Miden's execution model requires clients to manage their own private state - acc
 - **Shared-account users** risk having stale state due to a faulty or malicious participant withholding updates.
 - **Multi-device users** need all devices to see the same account state, but there is no public ledger to read from.
 
-On a public chain, the ledger is a universally readable source of truth. Every device and every signer can independently observe the latest state. In Miden's private account model, the canonical state is defined by the on-chain commitment, but the full private state is not publicly readable. The coordination surface moves off-chain.
+On a public chain, the ledger is a universally readable source of truth. Every device and every signer can independently observe the latest state. In Miden's private account model, the canonical state is defined by the onchain commitment, but the full private state is not publicly readable. The coordination surface moves offchain.
 
 ## What Guardian provides
 
-Guardian addresses these challenges by acting as an off-chain coordination layer:
+Guardian addresses these challenges by acting as an offchain coordination layer:
 
 - **Backup and recovery** - Account state is stored on Guardian, recoverable even if a device is lost.
 - **Multi-device sync** - Multiple devices push and pull state through Guardian, staying in sync with the latest canonical state.
@@ -50,7 +50,7 @@ Guardian has an explicit trust boundary:
 - **Safety**: The provider cannot forge account state, silently rewrite the commitment chain, or move assets without the required account signatures.
 - **Liveness**: The provider can delay, censor, or refuse requests. Users should keep recovery keys and provider-rotation paths available.
 - **Privacy**: Guardian protects state from unauthorized API callers, but the server stores the account state and delta payloads it receives. Treat the operator as able to observe submitted payloads unless your deployment adds a separate encryption layer or you operate the service yourself.
-- **Freshness**: Clients should verify acknowledgments and compare local state against the latest on-chain commitment when freshness matters.
+- **Freshness**: Clients should verify acknowledgments and compare local state against the latest onchain commitment when freshness matters.
 
 ## Learn more
 

--- a/docs/builder/private-multisig/core-concepts.md
+++ b/docs/builder/private-multisig/core-concepts.md
@@ -34,12 +34,12 @@ sequenceDiagram
 
     P->>Guardian: push_delta (with all signatures)
     Guardian-->>P: Canonical delta with ack_sig
-    P->>P: Execute on-chain with ZK proof
+    P->>P: Execute onchain with ZK proof
 ```
 
 1. **Propose**: The proposer builds a `TransactionSummary` locally, signs it, and pushes it to Guardian as a delta proposal.
 2. **Sign**: Each cosigner fetches pending proposals, verifies the transaction details against their local state, and submits their signature.
-3. **Execute**: Once the threshold is met, any participant pushes the final delta (with all signatures). Guardian returns the acknowledged delta. The executor builds and submits the on-chain transaction.
+3. **Execute**: Once the threshold is met, any participant pushes the final delta (with all signatures). Guardian returns the acknowledged delta. The executor builds and submits the onchain transaction.
 4. **Sync**: All participants fetch the latest state from Guardian to stay synchronized.
 
 ## Key architecture: 2-of-3 setup
@@ -110,12 +110,12 @@ sequenceDiagram
 
     File-->>A: Return signed file
     A->>A: Collect enough signatures
-    A->>A: Execute transaction on-chain
+    A->>A: Execute transaction onchain
 ```
 
 1. Create a proposal locally and export it as JSON.
 2. Share the file with cosigners through any side channel.
 3. Each cosigner signs offline and returns the signed file.
-4. Once the threshold is met, execute the transaction on-chain.
+4. Once the threshold is met, execute the transaction onchain.
 
 This ensures multisig operations remain functional even without Guardian connectivity.

--- a/docs/builder/private-multisig/index.md
+++ b/docs/builder/private-multisig/index.md
@@ -9,12 +9,12 @@ Private multisig on Miden allows multiple parties to collectively control an acc
 
 ## The problem
 
-On public chains, multisig coordination is straightforward: every signer can read the same on-chain state and build their next action on top of it. Safe-style multisigs work because the ledger is transparent.
+On public chains, multisig coordination is straightforward: every signer can read the same onchain state and build their next action on top of it. Safe-style multisigs work because the ledger is transparent.
 
 In Miden's private account model, account state lives client-side. The chain stores only cryptographic commitments. This means:
 
 - Signers can't independently observe the latest state from the chain.
-- Proposals and signatures need an off-chain coordination surface.
+- Proposals and signatures need an offchain coordination surface.
 - Without a shared state view, participants risk divergent state or stale approvals.
 
 The [Miden Guardian](../miden-guardian/) solves this by acting as the coordination server for multisig accounts — keeping signers synchronized, managing proposal workflows, and ensuring all parties work from the same canonical state.
@@ -26,7 +26,7 @@ Miden multisigs can be fully private (code, signers, metadata, etc. are not visi
 1. **Propose**: A signer pushes a delta proposal (containing a `TransactionSummary`) to Guardian. Guardian validates the proposal against the current account state and the Miden network.
 2. **Sign**: Other authorized cosigners fetch the pending proposal from Guardian, verify the transaction details locally, and submit their signatures.
 3. **Ready**: Once enough signatures are collected (meeting the threshold), Guardian emits an acknowledgment.
-4. **Execute**: Any cosigner builds the final transaction using all signatures plus the Guardian acknowledgment, and submits it on-chain.
+4. **Execute**: Any cosigner builds the final transaction using all signatures plus the Guardian acknowledgment, and submits it onchain.
 5. **Sync**: All participants fetch the latest canonical state from Guardian.
 
 ```mermaid

--- a/docs/builder/private-multisig/rust-sdk.md
+++ b/docs/builder/private-multisig/rust-sdk.md
@@ -5,7 +5,7 @@ sidebar_position: 2
 
 # Rust Multisig SDK
 
-The `miden-multisig-client` crate provides a high-level Rust SDK for private multisig workflows on Miden. It wraps the on-chain multisig contracts and Guardian coordination into a single API.
+The `miden-multisig-client` crate provides a high-level Rust SDK for private multisig workflows on Miden. It wraps the onchain multisig contracts and Guardian coordination into a single API.
 
 **Source**: [`crates/miden-multisig-client`](https://github.com/OpenZeppelin/guardian/tree/main/crates/miden-multisig-client)
 

--- a/docs/builder/private-multisig/typescript-sdk.md
+++ b/docs/builder/private-multisig/typescript-sdk.md
@@ -60,7 +60,7 @@ await multisig.registerOnPsm();
 ## Loading an existing account
 
 ```typescript
-// Configuration is auto-detected from on-chain storage
+// Configuration is auto-detected from onchain storage
 const multisig = await client.load(accountId, signer);
 ```
 

--- a/docs/builder/smart-contracts/accounts/authentication.md
+++ b/docs/builder/smart-contracts/accounts/authentication.md
@@ -6,7 +6,7 @@ description: "Authentication component pattern and nonce management for Miden ac
 
 # Authentication
 
-Miden uses digital signatures for transaction authentication. Because transactions execute on the client rather than on-chain validators, the system needs a way to prove that a transaction was authorized by the account owner. Without authentication, anyone could construct a valid proof that transfers assets out of an account. The nonce prevents replay attacks — without it, a valid proof could be resubmitted to execute the same state change twice. For details on the cryptographic primitives, see [Cryptography](./cryptography).
+Miden uses digital signatures for transaction authentication. Because transactions execute on the client rather than onchain validators, the system needs a way to prove that a transaction was authorized by the account owner. Without authentication, anyone could construct a valid proof that transfers assets out of an account. The nonce prevents replay attacks — without it, a valid proof could be resubmitted to execute the same state change twice. For details on the cryptographic primitives, see [Cryptography](./cryptography).
 
 v0.14 unifies the previous per-scheme components (`AuthFalcon512Rpo`, `AuthEcdsaK256Keccak`, …) into a single scheme-agnostic [`AuthSingleSig`](https://docs.rs/miden-standards/latest/miden_standards/account/auth/struct.AuthSingleSig.html) component that takes an `AuthScheme` enum (`Falcon512Poseidon2` or `EcdsaK256Keccak`). The native hash function is Poseidon2, and the Falcon-512 verifier MASM module is `miden::core::crypto::dsa::falcon512_poseidon2`.
 

--- a/docs/builder/smart-contracts/accounts/introduction.md
+++ b/docs/builder/smart-contracts/accounts/introduction.md
@@ -58,16 +58,16 @@ Storage mode controls privacy:
 
 | Mode | Description |
 |------|-------------|
-| **Public** | Full state is stored on-chain and visible to everyone — suitable for shared protocols like DEXs and faucets |
-| **Private** | Only a state commitment is stored on-chain — the actual data stays with the account owner |
+| **Public** | Full state is stored onchain and visible to everyone — suitable for shared protocols like DEXs and faucets |
+| **Private** | Only a state commitment is stored onchain — the actual data stays with the account owner |
 
 ## How accounts differ from EVM contracts
 
 | | EVM | Miden |
 |---|---|---|
 | **Execution** | Every validator re-executes every transaction | Account owner executes locally, submits a ZK proof |
-| **State visibility** | All state variables are public on-chain | State is private by default (only commitments on-chain) |
+| **State visibility** | All state variables are public onchain | State is private by default (only commitments onchain) |
 | **Code structure** | Monolithic contract deployed to an address | Multiple reusable components composed into one account |
 | **Identity** | Wallets are EOAs, contracts are separate | Everything is an account — wallets are smart contracts |
-| **Failure** | `revert` consumes gas, leaves an on-chain trace | Proof cannot be generated — no on-chain trace, no cost |
+| **Failure** | `revert` consumes gas, leaves an onchain trace | Proof cannot be generated — no onchain trace, no cost |
 

--- a/docs/builder/smart-contracts/notes/introduction.md
+++ b/docs/builder/smart-contracts/notes/introduction.md
@@ -41,12 +41,12 @@ Transaction 1 (Sender)                Transaction 2 (Recipient)
 │ 1. Create note           │            │ 1. Discover note         │
 │ 2. Attach assets         │            │ 2. Consume note          │
 │ 3. Note published        │──────────▶│ 3. Script runs           │
-│    (on-chain or private) │            │ 4. Assets move to vault  │
+│    (onchain or private) │            │ 4. Assets move to vault  │
 │                          │            │ 5. Note nullified        │
 └─────────────────────────┘            └─────────────────────────┘
 ```
 
-**Transaction 1**: The sender's account creates an output note, attaches assets to it, and the note is published (either on-chain or kept private).
+**Transaction 1**: The sender's account creates an output note, attaches assets to it, and the note is published (either onchain or kept private).
 
 **Transaction 2**: The recipient discovers the note, consumes it in their own transaction, the note script runs and verifies the consumer is authorized, and assets transfer into the recipient's vault. A **nullifier** is recorded to prevent the same note from being consumed again (see [note design](/core-concepts/protocol/note)).
 
@@ -58,8 +58,8 @@ Notes come in two visibility modes:
 
 | Mode | Description |
 |------|-------------|
-| **Public** | The note's full data (assets, script, storage) is stored by the Miden network and visible on-chain. Anyone can discover and attempt to consume it. |
-| **Private** | Only a commitment (hash) is stored on-chain. The actual note data must be communicated off-chain between sender and recipient. |
+| **Public** | The note's full data (assets, script, storage) is stored by the Miden network and visible onchain. Anyone can discover and attempt to consume it. |
+| **Private** | Only a commitment (hash) is stored onchain. The actual note data must be communicated offchain between sender and recipient. |
 
 Private notes provide stronger privacy guarantees — the network can't even see what assets a note carries — but they require the sender and recipient to have a communication channel outside the protocol.
 
@@ -72,6 +72,6 @@ Miden provides built-in note patterns (P2ID, P2IDE, SWAP) for common transfer sc
 | **Transfer model** | Single `transfer()` call on a token contract | Two transactions: create note, then consume note |
 | **Privacy** | Sender, recipient, and amount are public | Transactions are unlinkable; private notes hide all data |
 | **Programmability** | Token contracts control transfer logic | Each note carries its own script with custom conditions |
-| **Failure** | Revert on-chain, gas consumed | Proof can't be generated — no on-chain trace |
+| **Failure** | Revert onchain, gas consumed | Proof can't be generated — no onchain trace |
 | **Parallelism** | Transfers contend for contract state | Notes are independent — unlimited parallel creation |
 

--- a/docs/builder/smart-contracts/overview.md
+++ b/docs/builder/smart-contracts/overview.md
@@ -6,7 +6,7 @@ description: "Miden's execution model, account structure, note system, and trans
 
 # What is a Miden Smart Contract
 
-Miden is a ZK rollup where transactions execute on the client and only a cryptographic proof is submitted to the network. Every entity — wallets, contracts, faucets — is an account with code, storage, a vault, and a nonce. Assets move between accounts through notes, which act as programmable UTXOs. This page describes the execution model, account structure, note system, and transaction lifecycle. For a hands-on walkthrough, see the [Miden Bank Tutorial](../tutorials/miden-bank/).
+Miden is a zero-knowledge layer 2 where transactions execute on the client and only a cryptographic proof is submitted to the network. Every entity — wallets, contracts, faucets — is an account with code, storage, a vault, and a nonce. Assets move between accounts through notes, which act as programmable UTXOs. This page describes the execution model, account structure, note system, and transaction lifecycle. For a hands-on walkthrough, see the [Miden Bank Tutorial](../tutorials/miden-bank/).
 
 ## What makes Miden different
 

--- a/docs/builder/smart-contracts/overview.md
+++ b/docs/builder/smart-contracts/overview.md
@@ -121,7 +121,7 @@ If the assertion fails, the ZK circuit **cannot produce a valid proof**. This me
 - No state changes occur — it's as if the transaction never happened
 - The client gets an error explaining which assertion failed
 
-This is fundamentally different from Ethereum's `revert` — there's no on-chain transaction that fails. The proof simply doesn't exist if the execution is invalid.
+This is fundamentally different from Ethereum's `revert` — there's no onchain transaction that fails. The proof simply doesn't exist if the execution is invalid.
 
 ## Account types
 

--- a/docs/builder/smart-contracts/patterns.md
+++ b/docs/builder/smart-contracts/patterns.md
@@ -59,7 +59,7 @@ For Felt arithmetic, values wrap modulo the prime field (no overflow panic), but
 
 ### Anti-patterns
 
-- **Don't store secrets in contract code** — contract code is visible on-chain
+- **Don't store secrets in contract code** — contract code is visible onchain
 - **Don't skip nonce management** — prevents replay attacks
 - **Be careful with Felt division** — Felt division computes the multiplicative inverse, not integer division. Convert to `u64` first for integer-style operations
 

--- a/docs/builder/smart-contracts/transactions/advice-provider.md
+++ b/docs/builder/smart-contracts/transactions/advice-provider.md
@@ -10,7 +10,7 @@ The advice provider is a mechanism for supplying non-deterministic auxiliary dat
 
 ## Trust model and data integrity
 
-The advice provider is supplied by the **host** (the Miden client or node) — not by on-chain consensus. This means the VM cannot blindly trust that the host provided correct data. Two patterns address this:
+The advice provider is supplied by the **host** (the Miden client or node) — not by onchain consensus. This means the VM cannot blindly trust that the host provided correct data. Two patterns address this:
 
 ### Unverified stack push (caller must verify)
 

--- a/docs/builder/smart-contracts/transactions/introduction.md
+++ b/docs/builder/smart-contracts/transactions/introduction.md
@@ -68,7 +68,7 @@ The ZK circuit **cannot produce a valid proof**. This means:
 - No gas or fees are consumed
 - The client gets an error explaining which assertion failed
 
-This is fundamentally different from Ethereum's `revert`, where the failed transaction still lands on-chain, consumes gas, and is visible to everyone.
+This is fundamentally different from Ethereum's `revert`, where the failed transaction still lands onchain, consumes gas, and is visible to everyone.
 
 A separate failure mode is the **empty transaction**: a transaction that runs to completion but mutates no account state (storage, vault, or nonce) and consumes no input notes. Both the Rust client (which raises `TransactionRequestError::NoInputNotesNorAccountChange` before submission) and the VM kernel reject it. This typically catches transaction scripts whose conditional logic takes a no-op branch — see [Empty Transaction](../../tutorials/helpers/pitfalls#empty-transaction-no-state-change-no-notes) in the pitfalls guide for the recommended pattern.
 
@@ -79,6 +79,6 @@ A separate failure mode is the **empty transaction**: a transaction that runs to
 | **Execution** | Every validator re-executes the transaction | Client executes locally, submits only the proof |
 | **Scope** | Can call multiple contracts in one tx | One transaction mutates one account; cross-account via notes |
 | **Privacy** | All inputs, state reads, and call traces are public | Network sees only the proof and state commitments |
-| **Failure** | On-chain revert, gas consumed, visible trace | Proof can't be generated — no on-chain trace, no cost |
+| **Failure** | Onchain revert, gas consumed, visible trace | Proof can't be generated — no onchain trace, no cost |
 | **Parallelism** | Transactions touching same state must serialize | Single-account scope enables parallel execution |
 | **Authentication** | `msg.sender` set by protocol | Falcon512 signatures verified inside the transaction |

--- a/docs/builder/tools/clients/index.md
+++ b/docs/builder/tools/clients/index.md
@@ -7,7 +7,7 @@ pagination_prev: null
 
 # Clients
 
-The Miden client manages accounts, builds and executes transactions, produces zero-knowledge proofs, and synchronises local state with the node. The same core ships across three consumer surfaces — pick the runtime that matches your application. All three share the same on-chain semantics.
+The Miden client manages accounts, builds and executes transactions, produces zero-knowledge proofs, and synchronises local state with the node. The same core ships across three consumer surfaces — pick the runtime that matches your application. All three share the same onchain semantics.
 
 ## SDKs
 

--- a/docs/builder/tools/clients/react-sdk/advanced.md
+++ b/docs/builder/tools/clients/react-sdk/advanced.md
@@ -44,7 +44,7 @@ await execute({
 | `skipSync` | Skip pre-send auto-sync (default `false`) |
 | `privateNoteTarget` | Deliver private output notes to this account after commit (any `AccountRef` form) |
 
-The `privateNoteTarget` field is the 4-step pipeline shortcut: execute the tx, commit on-chain, then auto-deliver the private note through the note transport to the target. Useful for "send private note" UIs where the recipient already has the React SDK running.
+The `privateNoteTarget` field is the 4-step pipeline shortcut: execute the tx, commit onchain, then auto-deliver the private note through the note transport to the target. Useful for "send private note" UIs where the recipient already has the React SDK running.
 
 ## `useExecuteProgram`
 

--- a/docs/builder/tools/clients/react-sdk/mutation-hooks.md
+++ b/docs/builder/tools/clients/react-sdk/mutation-hooks.md
@@ -105,7 +105,7 @@ function NewFaucetButton() {
 | `tokenSymbol` | required | Display symbol (e.g. `"USDC"`) |
 | `maxSupply` | required | `bigint \| number` |
 | `decimals` | `8` | Token decimals |
-| `storageMode` | `"private"` | Public faucets are discoverable/readable on-chain |
+| `storageMode` | `"private"` | Public faucets are discoverable/readable onchain |
 | `authScheme` | `AuthScheme.Falcon` | Signing scheme |
 
 ## `useSend`

--- a/docs/builder/tools/clients/web-client/accounts.md
+++ b/docs/builder/tools/clients/web-client/accounts.md
@@ -265,7 +265,7 @@ await client.accounts.import({
 ```
 
 :::warning[Seed imports are public-only]
-Import-by-seed works only for accounts originally created with `storage: "public"`. Private account state is never published on-chain, so it can't be reconstructed from a seed alone. For private accounts, use the file export / import workflow below.
+Import-by-seed works only for accounts originally created with `storage: "public"`. Private account state is never published onchain, so it can't be reconstructed from a seed alone. For private accounts, use the file export / import workflow below.
 :::
 
 If you aren't sure whether the account is already in your local store, prefer [`getOrImport()`](#getorimport) — it skips the network call when the account is already known.

--- a/docs/builder/tools/clients/web-client/compile.md
+++ b/docs/builder/tools/clients/web-client/compile.md
@@ -115,8 +115,8 @@ Each library takes:
 
 | Value | Behaviour | When to use |
 | --- | --- | --- |
-| `Linking.Dynamic` (default) | Links via DYNCALL at prove time. The foreign contract's on-chain code is fetched by the prover. | FPI — foreign contract lives on-chain. |
-| `Linking.Static` | Inlines library code into the script at compile time. | Off-chain libraries that must be self-contained. |
+| `Linking.Dynamic` (default) | Links via DYNCALL at prove time. The foreign contract's onchain code is fetched by the prover. | FPI — foreign contract lives onchain. |
+| `Linking.Static` | Inlines library code into the script at compile time. | Offchain libraries that must be self-contained. |
 
 ## Note scripts
 

--- a/docs/builder/tools/clients/web-client/index.md
+++ b/docs/builder/tools/clients/web-client/index.md
@@ -9,7 +9,7 @@ The Web SDK is the browser-focused toolkit for the Miden network. It wraps the R
 
 ## Capabilities
 
-- Read and write on-chain state: accounts, notes, transactions, tags.
+- Read and write onchain state: accounts, notes, transactions, tags.
 - Build and execute Miden transactions, including custom MASM scripts.
 - Compile Miden Assembly into account components, transaction scripts, and note scripts directly in the browser.
 - Generate zero-knowledge proofs locally via the in-browser prover, or offload proving to a remote or delegated prover.

--- a/docs/builder/tools/clients/web-client/notes.md
+++ b/docs/builder/tools/clients/web-client/notes.md
@@ -34,11 +34,11 @@ for (const note of all) {
 
 Statuses:
 
-- `"committed"` — on-chain, consumable.
+- `"committed"` — onchain, consumable.
 - `"consumed"` — already spent.
 - `"expected"` — the client expects this note to arrive.
 - `"processing"` — mid-consume.
-- `"unverified"` — on-chain, awaiting local verification.
+- `"unverified"` — onchain, awaiting local verification.
 
 ## Retrieve a single note
 
@@ -92,7 +92,7 @@ const details = await client.notes.export("0xnote...", { format: NoteExportForma
 `NoteExportFormat`:
 
 - **`Id`** — just the note ID. Only works for public notes.
-- **`Full`** — complete note data plus inclusion proof. Requires the note to have an on-chain inclusion proof.
+- **`Full`** — complete note data plus inclusion proof. Requires the note to have an onchain inclusion proof.
 - **`Details`** — note ID, metadata, and creation block.
 
 ## Note transport (private notes)

--- a/docs/builder/tools/clients/web-client/sync.md
+++ b/docs/builder/tools/clients/web-client/sync.md
@@ -31,7 +31,7 @@ console.log("Updated accounts:", summary.updatedAccounts().length);
 - `committedNotes(): NoteId[]` — notes committed in this sync window.
 - `consumedNotes(): NoteId[]` — notes consumed in this sync window.
 - `committedTransactions(): TransactionId[]` — transactions that were committed.
-- `updatedAccounts(): AccountId[]` — accounts whose on-chain state advanced.
+- `updatedAccounts(): AccountId[]` — accounts whose onchain state advanced.
 
 ## Sync with timeout
 

--- a/docs/builder/tools/clients/web-client/transactions.md
+++ b/docs/builder/tools/clients/web-client/transactions.md
@@ -5,7 +5,7 @@ sidebar_position: 4
 
 # Transactions
 
-`client.transactions` is the resource namespace for everything that mutates on-chain state: sending, minting, consuming, swapping, running custom scripts, and inspecting history. Every mutation method handles the full lifecycle — execute, prove, submit — in one call.
+`client.transactions` is the resource namespace for everything that mutates onchain state: sending, minting, consuming, swapping, running custom scripts, and inspecting history. Every mutation method handles the full lifecycle — execute, prove, submit — in one call.
 
 ## Simplified operations
 
@@ -229,7 +229,7 @@ const { txId } = await client.transactions.execute({
 
 ## View calls (`executeProgram`)
 
-`executeProgram` runs a transaction script locally, returning the resulting stack without submitting or proving anything. Use it to read on-chain state — similar to `eth_call` in Ethereum.
+`executeProgram` runs a transaction script locally, returning the resulting stack without submitting or proving anything. Use it to read onchain state — similar to `eth_call` in Ethereum.
 
 ```typescript
 const script = await client.compile.txScript({

--- a/docs/builder/tools/index.md
+++ b/docs/builder/tools/index.md
@@ -12,7 +12,7 @@ Developer tools for building on and interacting with the Miden network. Use the 
 
 <CardGrid cols={3}>
   <Card title="Rust client" href="./clients/rust-client/" eyebrow="Rust · SDK">
-    Full-featured Rust library for Miden rollup integration — accounts, transactions, notes, proving.
+    Full-featured Rust library for Miden layer 2 integration — accounts, transactions, notes, proving.
   </Card>
   <Card title="Web SDK" href="./clients/web-client/" eyebrow="TypeScript · SDK">
     Browser-based client for managing accounts and transactions from a web app.

--- a/docs/builder/tools/index.md
+++ b/docs/builder/tools/index.md
@@ -35,7 +35,7 @@ Developer tools for building on and interacting with the Miden network. Use the 
     Live Miden testnet endpoints — status, block explorer (MidenScan), RPC, faucet, remote prover.
   </Card>
   <Card title="Note Transport" href="./note-transport/" eyebrow="Private notes · Relay">
-    Off-chain relay service for delivering private note payloads between senders and recipients.
+    Offchain relay service for delivering private note payloads between senders and recipients.
   </Card>
   <Card title="Bridging" href="./bridging/" eyebrow="Interop · Testnets">
     Testnet bridge tooling and interoperability guides, starting with the mock 1Click bridge sandbox.

--- a/docs/builder/tools/note-transport/design.md
+++ b/docs/builder/tools/note-transport/design.md
@@ -15,7 +15,7 @@ The note transport node is intentionally small: it accepts note bytes, indexes t
 4. A recipient calls `FetchNotes` for one or more tags and receives matching notes with a cursor.
 5. The recipient stores the returned cursor and uses it on the next fetch.
 
-The transport node does not connect to a Miden node and does not know whether a note has been committed on-chain. Clients still need to import fetched notes and sync against the Miden network.
+The transport node does not connect to a Miden node and does not know whether a note has been committed onchain. Clients still need to import fetched notes and sync against the Miden network.
 
 ## Stored data
 

--- a/docs/builder/tools/note-transport/index.md
+++ b/docs/builder/tools/note-transport/index.md
@@ -1,15 +1,15 @@
 ---
 sidebar_position: 1
 title: Note Transport
-description: "Off-chain relay service for private note delivery on Miden."
+description: "Offchain relay service for private note delivery on Miden."
 pagination_prev: null
 ---
 
 # Note Transport
 
-The Miden note transport service is an off-chain relay for private note delivery. It gives senders a place to publish serialized private notes and gives recipients a way to fetch notes that match the tags they monitor.
+The Miden note transport service is an offchain relay for private note delivery. It gives senders a place to publish serialized private notes and gives recipients a way to fetch notes that match the tags they monitor.
 
-Private note contents are not published on-chain. The chain stores note commitments, while the full note data must reach the recipient through another channel. Note transport is the standard network service for that off-chain delivery path.
+Private note contents are not published onchain. The chain stores note commitments, while the full note data must reach the recipient through another channel. Note transport is the standard network service for that offchain delivery path.
 
 ## Start here
 
@@ -43,7 +43,7 @@ Private note contents are not published on-chain. The chain stores note commitme
 
 ## Current boundaries
 
-- **No chain-state validation.** The node does not connect to a Miden node and does not prove that a stored note was committed on-chain.
+- **No chain-state validation.** The node does not connect to a Miden node and does not prove that a stored note was committed onchain.
 - **No block context yet.** The current API does not attach commitment block numbers, note metadata, or inclusion proofs to fetched notes. This is tracked in [0xMiden/note-transport-service#68](https://github.com/0xMiden/note-transport-service/issues/68).
 - **Duplicate notes are rejected.** SQLite stores note IDs with a uniqueness constraint. Sending the same note twice fails instead of creating duplicate rows.
 - **Cursor values are server-owned.** Fetch pagination uses the monotonic SQLite `seq` value returned by the server. Clients should persist returned cursors, not fabricate them.

--- a/docs/builder/tutorials/helpers/pitfalls.md
+++ b/docs/builder/tutorials/helpers/pitfalls.md
@@ -431,8 +431,8 @@ Use the correct values for note types:
 
 | Value | Type | Description |
 |-------|------|-------------|
-| 1 | Public | Note data is visible on-chain |
-| 2 | Private | Note data is hidden (only hash on-chain) |
+| 1 | Public | Note data is visible onchain |
+| 2 | Private | Note data is hidden (only hash onchain) |
 
 ```rust
 // In note inputs or when creating output notes
@@ -476,7 +476,7 @@ let p2id_script_root: Word = P2idNote::script().root();
 ```
 
 :::info Why Not Hardcode
-The native hash function changed from RPO to Poseidon2 in v0.14, so every MAST root — including the P2ID script's — is different from v0.13. Any hardcoded digest from v0.13 will fail a script-root check against v0.14. Reading the root from `P2idNote::script().root()` (or the active note's storage for on-chain code) keeps the contract resilient to future script changes.
+The native hash function changed from RPO to Poseidon2 in v0.14, so every MAST root — including the P2ID script's — is different from v0.13. Any hardcoded digest from v0.13 will fail a script-root check against v0.14. Reading the root from `P2idNote::script().root()` (or the active note's storage for onchain code) keeps the contract resilient to future script changes.
 :::
 
 ---

--- a/docs/core-concepts/index.md
+++ b/docs/core-concepts/index.md
@@ -38,7 +38,7 @@ A technical reference for Miden's architecture: the protocol, the zkVM, the comp
 
 ## Architecture overview
 
-Miden is a zero-knowledge rollup that rethinks blockchain architecture. Instead of a single global state updated sequentially, Miden uses an **actor model** where each account is an independent state machine that executes transactions locally and generates validity proofs.
+Miden is a zero-knowledge layer 2 that rethinks blockchain architecture. Instead of a single global state updated sequentially, Miden uses an **actor model** where each account is an independent state machine that executes transactions locally and generates validity proofs.
 
 ### Core design principles
 

--- a/docs/core-concepts/index.md
+++ b/docs/core-concepts/index.md
@@ -44,9 +44,9 @@ Miden is a zero-knowledge layer 2 that rethinks blockchain architecture. Instead
 
 | Principle | How Miden achieves it |
 |-----------|----------------------|
-| **Privacy** | Accounts and notes store only cryptographic commitments on-chain; full data remains with users |
+| **Privacy** | Accounts and notes store only cryptographic commitments onchain; full data remains with users |
 | **Parallelism** | Single-account transactions enable concurrent execution without contention |
-| **Scalability** | Client-side proving offloads computation; proof aggregation reduces on-chain verification |
+| **Scalability** | Client-side proving offloads computation; proof aggregation reduces onchain verification |
 | **Programmability** | A Turing-complete VM supports arbitrary smart contract logic in accounts and notes |
 
 <Steps>
@@ -88,7 +88,7 @@ Notes are programmable messages that transfer assets between accounts:
 - **Assets** — tokens transferred to the recipient
 - **Metadata** — sender, tag (for discovery), and auxiliary data
 
-Notes can be **public** (all data on-chain) or **private** (only a commitment stored). Private notes require off-chain communication between sender and recipient.
+Notes can be **public** (all data onchain) or **private** (only a commitment stored). Private notes require offchain communication between sender and recipient.
 
 ### State model
 

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -379,7 +379,7 @@ const config: Config = {
             ],
           },
         ],
-        copyright: `<span class="footer__tagline">Private by design · Verifiable by default</span><span class="footer__sep">·</span>© ${new Date().getFullYear()} Miden`,
+        copyright: `<span class="footer__tagline">Private by default · Scalable by design</span><span class="footer__sep">·</span>© ${new Date().getFullYear()} Miden`,
       },
     },
 };

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -60,7 +60,7 @@ export default function Home(): JSX.Element {
                 Build scalable, private applications.
               </h1>
               <p className={styles.heroSub}>
-                A zero-knowledge rollup with client-side proving.
+                A zero-knowledge layer 2 with client-side proving.
                 Accounts and notes are private by default — only
                 commitments go on-chain.
               </p>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -62,7 +62,7 @@ export default function Home(): JSX.Element {
               <p className={styles.heroSub}>
                 A zero-knowledge layer 2 with client-side proving.
                 Accounts and notes are private by default — only
-                commitments go on-chain.
+                commitments go onchain.
               </p>
               <div className={styles.ctaRow}>
                 <Link

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -54,7 +54,7 @@ export default function Home(): JSX.Element {
             <div>
               <div className={styles.eyebrow}>
                 <span className={styles.eyebrowDot} aria-hidden="true" />
-                Private by design · Verifiable by default
+                Private by default · Scalable by design
               </div>
               <h1 className={styles.heroTitle}>
                 Build scalable, private applications.

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -45,7 +45,7 @@ export default function Home(): JSX.Element {
   return (
     <Layout
       title={siteConfig.title}
-      description="Build verifiable, private applications on Miden — a zk-first Layer 1 with client-side proving and native privacy."
+      description="Build verifiable, private applications on Miden — a zk-first layer 2 with client-side proving and native privacy."
     >
       <main className={styles.page}>
         {/* ---- HERO ---- */}

--- a/src/utils/ogImages.ts
+++ b/src/utils/ogImages.ts
@@ -131,7 +131,7 @@ const OG_IMAGE_RULES: OgImageRule[] = [
   {
     pathPrefix: "/builder",
     image: "build.png",
-    description: "Start building private, verifiable applications on the Miden rollup.",
+    description: "Start building private, verifiable applications on the Miden layer 2.",
   },
   {
     pathPrefix: "/core-concepts/protocol/account",


### PR DESCRIPTION
Closes #258.

- **Tagline** → "Private by default · Scalable by design" (2 surfaces: homepage eyebrow + footer).
- **rollup → layer 2** across the 6 substantive Miden descriptions. Skipped Guardian's "not a rollup" line — generic blockchain term there.
- **on-chain/off-chain → onchain/offchain** across 67 prose occurrences in 34 files. Word-boundary bulk replace; no code / slugs / compounds touched.
- **Bonus**: caught the homepage `<meta description>` calling Miden "a zk-first Layer 1" while auditing — fixed in the last commit (same accuracy issue as the rollup change).

Atomic commits so any single concern can be reverted independently.