### PR TITLE
docs(builder): position MASM as mainnet path + add Builder MASM section

### DIFF
--- a/docs/builder/smart-contracts/index.md
+++ b/docs/builder/smart-contracts/index.md
@@ -1,30 +1,37 @@
 ---
 title: "Miden Smart Contracts"
-description: "Build Miden smart contracts with Rust, Miden Assembly, and reusable Miden Standards."
+description: "Build Miden smart contracts in Miden Assembly (MASM) for mainnet production, with the Rust SDK in active development as the long-term direction."
 pagination_prev: null
 ---
 
 # Miden Smart Contracts
 
-This section covers the developer-facing paths for building smart contracts on Miden. Start with the overview for the execution model, use Rust for account, note, and transaction development, and use Miden Standards when you want reusable account components, note scripts, faucet policies, and protocol-compatible building blocks.
+This section covers the developer-facing paths for building smart contracts on Miden: an authoring guide for **Miden Assembly (MASM)** (the supported path for mainnet production today) and **Rust** (in active development as the long-term direction), plus the [Miden Standards](./standards/) library of reusable components callable from either.
 
-If you're new to Miden, follow the hands-on [Miden Bank Tutorial](../tutorials/miden-bank/).
+:::tip Building for mainnet?
+Miden mainnet supports smart contracts authored in **Miden Assembly (MASM)** today. The Rust SDK is in active development and will become the default authoring path once it ships v1. For production deployments now, see [MASM Smart Contracts](./masm/).
+:::
+
+If you're new to Miden, the hands-on [Miden Bank Tutorial](../tutorials/miden-bank/) walks through the full lifecycle using the Rust SDK; the concepts (accounts, notes, transactions, components) translate directly to MASM.
 
 ## Sections
 
-<CardGrid cols={3}>
+<CardGrid cols={2}>
   <Card title="Overview" href="./overview" eyebrow="Model">
-    Learn how accounts, notes, transactions, and components fit together.
+    How accounts, notes, transactions, and components fit together. Concepts apply regardless of authoring language.
   </Card>
-  <Card title="Rust" href="./rust" eyebrow="Authoring path">
-    Build accounts, notes, transactions, and reusable logic with the Rust-first workflow.
+  <Card title="MASM" href="./masm/" eyebrow="Mainnet path">
+    Author production-ready smart contracts directly in Miden Assembly. The path Miden mainnet supports today.
+  </Card>
+  <Card title="Rust" href="./rust" eyebrow="In development">
+    Build accounts, notes, transactions, and reusable logic with the Rust-first workflow. Currently in active development and not yet production-ready for mainnet.
   </Card>
   <Card title="Miden Standards" href="./standards/" eyebrow="Reusable libraries">
-    Use standard components, note scripts, faucet policies, and MASM modules.
+    Standard components, note scripts, faucet policies, and MASM modules. Callable from MASM or Rust.
   </Card>
 </CardGrid>
 
-## Inside Rust
+## Inside the Rust SDK
 
 <CardGrid cols={3}>
   <Card title="Accounts" href="./accounts/" eyebrow="State & code">

--- a/docs/builder/smart-contracts/masm/index.md
+++ b/docs/builder/smart-contracts/masm/index.md
@@ -1,0 +1,51 @@
+---
+title: "MASM Smart Contracts"
+description: "Author Miden smart contracts directly in Miden Assembly (MASM) — the supported path for mainnet production."
+sidebar_position: 0
+---
+
+# MASM Smart Contracts
+
+This section is the practical guide to authoring Miden smart contracts directly in **Miden Assembly (MASM)** — the path Miden mainnet supports for production deployments today. The Rust SDK is in active development and will become the default authoring path once it ships v1; until then, MASM is what you ship with.
+
+:::info Audience
+You're here because you want to deploy a contract to Miden mainnet. MASM is a small, stack-based assembly language — closer to assembly than Rust or Solidity, but it gives you direct, predictable control over the VM and is what the mainnet kernel verifies. The [Reference → Miden VM → Assembly](/reference/miden-vm/user_docs/assembly/) section is the full language reference; this section is the Builder-side cookbook for using it.
+:::
+
+## When to use MASM vs. the Rust SDK
+
+| Concern | MASM | Rust SDK |
+|---|---|---|
+| **Mainnet production** | Supported today | In active development |
+| **Performance / cycle control** | Direct control over emitted instructions | Compiles via Wasm → MASM; less predictable |
+| **Learning curve** | Small instruction set, explicit stack semantics | Familiar Rust ergonomics |
+| **Miden Standards** | [Standards modules](../standards/) callable directly | Same standards via Rust bindings |
+| **Long-term direction** | Long-lived for system-level / performance-critical code | Will become the default authoring path once mature |
+
+For mainnet shipping today, the choice is straightforward: write MASM. Most production patterns — account components, note scripts, transaction scripts, P2ID and P2IDE flows, faucet policies — are already covered by [Miden Standards](../standards/), so most contracts compose existing standards rather than rolling everything from scratch.
+
+## Where the language reference lives
+
+The full Miden Assembly reference — every instruction, the stack semantics, control flow, cryptographic operations, debugging instructions — lives in [Reference → Miden VM → Assembly](/reference/miden-vm/user_docs/assembly/). Treat that as the dictionary. This Builder section is the cookbook: how to structure a project, conventions for accounts, notes, and transactions, deployment, testing, and debugging in the context of building a Miden app.
+
+## Tutorials
+
+Practical, end-to-end tutorials are in progress in the [Miden tutorials repository](https://github.com/0xMiden/tutorials) and will land in this section as they ship:
+
+| Tutorial | Status |
+|---|---|
+| Project setup and first MASM contract | In progress |
+| MASM account components | In progress |
+| MASM note scripts | In progress |
+| MASM transaction scripts | In progress |
+| Testing with MockChain | In progress |
+| Debugging MASM contracts | In progress |
+
+In the meantime, the existing [Rust-based Miden Bank tutorial](../../tutorials/miden-bank/) is useful for understanding the overall transaction lifecycle and the patterns that translate to MASM. The [Reference assembly section](/reference/miden-vm/user_docs/assembly/) covers the language itself.
+
+## See also
+
+- [Miden Standards](../standards/) — reusable account components, standard notes, faucet policies, callable from MASM.
+- [Reference → Miden VM → Assembly](/reference/miden-vm/user_docs/assembly/) — full language reference (instructions, stack semantics, control flow).
+- [Smart Contracts → Overview](../overview) — execution model and lifecycle (the concepts apply regardless of authoring language).
+- [Tools → Playground](../../tools/playground) — interactive browser-based MASM environment for quick experiments.

--- a/docs/builder/smart-contracts/overview.md
+++ b/docs/builder/smart-contracts/overview.md
@@ -25,17 +25,25 @@ This means:
 
 ## The compilation pipeline
 
-Your Rust code goes through several transformations before it runs:
+Miden runs **MASM** (Miden Assembly) — the VM's native instruction set. There are two authoring paths that produce it:
+
+**MASM directly** (the supported mainnet path):
 
 ```
-Rust → Wasm → Miden Assembly (MASM) → ZK Circuit → Proof
+MASM → ZK Circuit → Proof
 ```
 
-1. **Rust → Wasm**: The Miden compiler (`cargo-miden`) compiles your `#![no_std]` Rust to WebAssembly
-2. **Wasm → MASM**: The compiler translates Wasm to Miden Assembly, the VM's native instruction set
-3. **MASM → Proof**: When a transaction executes, the Miden VM runs the MASM code and produces a zero-knowledge proof
+You write MASM directly and build it into a `.masp` package (Miden Assembly Package). This is what mainnet supports for production today. See [MASM Smart Contracts](./masm/).
 
-The output of `miden build` is a `.masp` file (Miden Assembly Package) containing the compiled MASM and metadata.
+**Rust** (in active development):
+
+```
+Rust → Wasm → MASM → ZK Circuit → Proof
+```
+
+The Miden compiler (`cargo-miden`) compiles your `#![no_std]` Rust to WebAssembly, then translates it to MASM. The output is the same `.masp` package, so both paths share the same execution model and the same [Miden Standards](./standards/) library.
+
+When a transaction executes, the Miden VM runs the MASM and produces a zero-knowledge proof of correct execution. The output of `cargo miden build` (Rust) or the MASM build tooling is a `.masp` file containing the compiled MASM and metadata.
 
 ## The account model
 
@@ -127,29 +135,42 @@ If the assertion fails, the ZK circuit **cannot produce a valid proof**. This me
 
 This is fundamentally different from Ethereum's `revert` — there's no onchain transaction that fails. The proof simply doesn't exist if the execution is invalid.
 
+A separate failure mode is the [empty transaction](../tutorials/helpers/pitfalls#empty-transaction-no-state-change-no-notes) — a transaction that completes without mutating account state or consuming a note is also rejected, since Miden refuses to admit transactions with no observable effect.
+
 ## Account types
 
-Miden supports several account types, configured in `Cargo.toml`:
+Miden supports four account types, set at deployment time. The same types are used regardless of authoring language:
 
 | Type | Description |
 |------|-------------|
 | `RegularAccountUpdatableCode` | Standard account — code can be updated after deployment |
-| `RegularAccountImmutableCode` | Account with fixed code — cannot be changed |
+| `RegularAccountImmutableCode` | Account with fixed code — cannot be changed after deployment |
 | `FungibleFaucet` | Token minting account (fungible assets) |
 | `NonFungibleFaucet` | NFT minting account (non-fungible assets) |
 
-## Building blocks
+## Where to go next
 
-| Building Block | Description | Details |
-|----------------|-------------|---------|
-| [Components](./accounts/components) | Reusable code modules with storage and WIT interfaces | `#[component]` macro |
-| [Storage](./accounts/storage) | Up to 255 slots of Value or StorageMap | Persistent state |
-| [Custom Types](./accounts/custom-types) | Exported structs/enums for public APIs | `#[export_type]` |
-| [Account Operations](./accounts/account-operations) | Read/write account state and vault | `active_account`, `native_account` |
-| [Notes](./notes/) | Programmable UTXOs for asset transfers | Note scripts |
-| [The tx Module](./transactions/transaction-context) | Block queries and expiration management | `tx` module, `#[tx_script]` |
-| [Authentication](./accounts/authentication) | Falcon512 signatures and replay protection | Nonce management |
-| [Cross-Component Calls](./cross-component-calls) | Inter-component communication | WIT bindings, `generate!()` |
-| [Types](./types) | Felt, Word, Asset — the VM's native types | Field arithmetic |
+**Authoring paths and libraries:**
 
-Ready to start building? Follow the [Miden Bank Tutorial](../tutorials/miden-bank/) for a hands-on walkthrough.
+| Section | When to use |
+|---|---|
+| [MASM Smart Contracts](./masm/) | Production contracts for mainnet today |
+| [Rust SDK](./rust/) | Prototyping today; long-term default once it ships v1 |
+| [Miden Standards](./standards/) | Reusable building blocks callable from either path |
+
+**Topic guides** (concepts apply regardless of authoring language):
+
+| Topic | Description |
+|---|---|
+| [Components](./accounts/components) | Reusable code modules with storage and exported interfaces |
+| [Storage](./accounts/storage) | Up to 255 slots of `Value` or `StorageMap` |
+| [Custom Types](./accounts/custom-types) | Exported structs/enums for public APIs |
+| [Account Operations](./accounts/account-operations) | Read/write account state and vault |
+| [Notes](./notes/) | Programmable UTXOs for asset transfers |
+| [Transactions](./transactions/) | Transaction context, scripts, and the advice provider |
+| [Authentication](./accounts/authentication) | RPO-Falcon512 signatures and replay protection |
+| [Cross-Component Calls](./cross-component-calls) | Inter-component communication |
+| [Types](./types) | Felt, Word, Asset — the VM's native types |
+| [Patterns](./patterns) | Access control, rate limiting, spending limits, anti-patterns |
+
+Ready to start building? The [Miden Bank Tutorial](../tutorials/miden-bank/) is a hands-on walkthrough (currently written against the Rust SDK; the concepts translate to MASM).

--- a/docs/builder/smart-contracts/overview.md
+++ b/docs/builder/smart-contracts/overview.md
@@ -1,10 +1,14 @@
 ---
 title: "What is a Miden Smart Contract"
 sidebar_position: 1
-description: "Miden's execution model, account structure, note system, and transaction lifecycle — how Rust code becomes zero-knowledge proofs."
+description: "Miden's execution model, account structure, note system, and transaction lifecycle."
 ---
 
 # What is a Miden Smart Contract
+
+:::info Concepts apply to both authoring paths
+This page describes Miden's execution model — accounts, notes, transactions, and lifecycle. The concepts apply regardless of whether you author contracts in MASM (the mainnet path) or the Rust SDK (in active development). Code examples on this page use Rust; for the MASM path, see [MASM Smart Contracts](./masm/).
+:::
 
 Miden is a zero-knowledge layer 2 where transactions execute on the client and only a cryptographic proof is submitted to the network. Every entity — wallets, contracts, faucets — is an account with code, storage, a vault, and a nonce. Assets move between accounts through notes, which act as programmable UTXOs. This page describes the execution model, account structure, note system, and transaction lifecycle. For a hands-on walkthrough, see the [Miden Bank Tutorial](../tutorials/miden-bank/).
 

--- a/docs/builder/smart-contracts/rust/index.md
+++ b/docs/builder/smart-contracts/rust/index.md
@@ -1,0 +1,55 @@
+---
+title: "Rust Smart Contracts"
+description: "Author Miden smart contracts in Rust — the long-term direction for Miden development, currently in active development."
+---
+
+# Rust Smart Contracts
+
+The Rust SDK is the long-term direction for Miden smart-contract development: define account components, note scripts, and transaction scripts in idiomatic `#![no_std]` Rust with typed storage, attribute macros, and client-side proving. The SDK compiles to Miden Assembly (MASM) under the hood, so the same execution model and standards library apply.
+
+:::caution Currently in active development
+The Rust SDK is being actively developed and is **not yet production-ready for mainnet**. For production deployments today, write contracts in [Miden Assembly (MASM)](../masm/) — the supported path Miden mainnet verifies. Use the Rust SDK for prototyping, experimentation, and exploration of the long-term direction.
+:::
+
+The pages below describe the Rust SDK's current shape: how accounts and components compose, how notes are scripted, how transactions execute, and the patterns you can already build with.
+
+## Inside the Rust SDK
+
+<CardGrid cols={3}>
+  <Card title="Accounts" href="../accounts/" eyebrow="State & code">
+    Components, storage, custom types, operations, cryptography, and authentication.
+  </Card>
+  <Card title="Notes" href="../notes/" eyebrow="Programmable messages">
+    Programmable UTXOs for asset transfers and cross-account interaction.
+  </Card>
+  <Card title="Transactions" href="../transactions/" eyebrow="Execution">
+    Transaction context, scripts, and the advice provider.
+  </Card>
+  <Card title="Cross-component calls" href="../cross-component-calls" eyebrow="Composition">
+    Calling methods across account components and from note scripts.
+  </Card>
+  <Card title="Types" href="../types" eyebrow="Primitives">
+    Core types: Felt, Word, AccountId, NoteId, and more.
+  </Card>
+  <Card title="Patterns" href="../patterns" eyebrow="Recipes">
+    Access control, rate limiting, spending limits, and anti-patterns.
+  </Card>
+</CardGrid>
+
+## When to choose Rust vs MASM today
+
+| Concern | Rust SDK | MASM |
+|---|---|---|
+| **Mainnet production** | In active development | [Supported today](../masm/) |
+| **Ergonomics** | Familiar Rust idioms, type-checked storage, attribute macros | Stack-based assembly, explicit control |
+| **Compilation target** | Compiles via Wasm → MASM | Directly authored |
+| **Use case** | Long-term default once mature; prototyping and exploration today | Production contracts for mainnet |
+
+Both authoring paths share the same [Miden Standards](../standards/) library — standard components, notes, and faucet policies are callable from either.
+
+## Related pages
+
+- [MASM Smart Contracts](../masm/) — the path mainnet supports today.
+- [Miden Standards](../standards/) — reusable building blocks callable from Rust or MASM.
+- [Smart Contracts → Overview](../overview) — execution model and lifecycle (concepts apply to both authoring paths).
+- [API reference on docs.rs](https://docs.rs/miden/latest/miden/) — full Rust SDK API documentation.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -52,12 +52,7 @@ const sidebars: SidebarsConfig = {
         {
           type: "category",
           label: "Rust",
-          link: {
-            type: "generated-index",
-            slug: "/builder/smart-contracts/rust",
-            title: "Rust Smart Contracts",
-            description: "Rust-first account, note, transaction, type, and composition docs.",
-          },
+          link: { type: "doc", id: "builder/smart-contracts/rust/index" },
           items: [
             {
               type: "category",

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -45,6 +45,12 @@ const sidebars: SidebarsConfig = {
         "builder/smart-contracts/overview",
         {
           type: "category",
+          label: "MASM",
+          link: { type: "doc", id: "builder/smart-contracts/masm/index" },
+          items: [],
+        },
+        {
+          type: "category",
           label: "Rust",
           link: {
             type: "generated-index",


### PR DESCRIPTION
Establishes MASM as the supported authoring path for mainnet production smart contracts, with the Rust SDK framed as in active development. First step of the post-Standards MASM developer education pass. Lives in the unversioned `docs/` (next version) since this is positioned as the v0.15 mainnet deliverable.

**Changes:**
- New `docs/builder/smart-contracts/masm/` landing — audience framing, MASM-vs-Rust decision table, pointer to Reference → Miden VM → Assembly for the language reference, placeholder for upcoming tutorials.
- Smart-contracts landing now leads with MASM (mainnet path) and Rust (in development) side by side, 2×2 card grid, prominent `:::tip` admonition.
- New Rust SDK landing replacing the bare generated-index, mirroring the Standards/MASM shape so the three are visually consistent.
- Smart-contracts overview restructured for both authoring paths: dual-path compilation pipeline diagram, language-agnostic account types, two-table "where to go next" splitting authoring paths from topic guides. Small fixes: `miden build` → `cargo miden build`, `Falcon512` → `RPO-Falcon512`, link to empty-tx pitfall from #307.
- Sidebar wires the new MASM category between Overview and Rust under Smart Contracts.

**Out of scope** (deliberate follow-ups): MASM-authored tutorials (project setup, account components, note scripts, transaction scripts, testing, debugging) live in `0xMiden/tutorials` and will land via the ingest workflow once Philipp ships them upstream. Homepage hero messaging shift held until v1 lands and we see feedback.