### PR TITLE
fix(docs): fix broken external links in rust-client documentation

### DIFF
--- a/versioned_docs/version-0.14/builder/tools/clients/rust-client/cli/cli-config.md
+++ b/versioned_docs/version-0.14/builder/tools/clients/rust-client/cli/cli-config.md
@@ -180,7 +180,7 @@ miden-client init --block-delta 256
 
   Note that this only affects the **global** directory. If a local `./.miden` directory exists, it still takes precedence over the global one (whether default or overridden).
 
-- `MIDEN_DEBUG`: When set to `true`, enables debug mode on the transaction executor and the script compiler. For any script that has been compiled and executed in this mode, debug logs will be output in order to facilitate MASM debugging ([these instructions](https://0xMiden.github.io/miden-vm/user_docs/assembly/debugging.html) can be used to do so). This variable can be overridden by the `--debug` CLI flag.
+- `MIDEN_DEBUG`: When set to `true`, enables debug mode on the transaction executor and the script compiler. For any script that has been compiled and executed in this mode, debug logs will be output in order to facilitate MASM debugging ([these instructions](https://docs.miden.xyz/reference/compiler/guides/debugger) can be used to do so). This variable can be overridden by the `--debug` CLI flag.
 
 ### Note Transport
 

--- a/versioned_docs/version-0.14/builder/tools/clients/rust-client/cli/cli-troubleshooting.md
+++ b/versioned_docs/version-0.14/builder/tools/clients/rust-client/cli/cli-troubleshooting.md
@@ -93,7 +93,7 @@ Below are representative errors you may encounter, their likely causes, and sugg
 
 ### Transaction lifecycle (CLI-oriented overview)
 
-For the full protocol-level lifecycle, see the Miden book: [Transaction lifecycle](https://0xmiden.github.io/miden-docs/imported/miden-base/src/transaction.html#transaction-lifecycle).
+For the full protocol-level lifecycle, see the Miden book: [Transaction lifecycle](https://docs.miden.xyz/reference/protocol/transaction/#transaction-lifecycle).
 
 ```mermaid
 flowchart LR
@@ -144,4 +144,4 @@ Key states the CLI surfaces:
 
 - CLI debug flag and environment variable are documented in `CLI` and `Config` docs.
 - Common error enums originate from the client and RPC layers.
-- Protocol lifecycle: [Miden book — Transaction lifecycle](https://0xmiden.github.io/miden-docs/imported/miden-base/src/transaction.html#transaction-lifecycle)
+- Protocol lifecycle: [Miden book — Transaction lifecycle](https://docs.miden.xyz/reference/protocol/transaction/#transaction-lifecycle)

--- a/versioned_docs/version-0.14/builder/tools/clients/rust-client/design.md
+++ b/versioned_docs/version-0.14/builder/tools/clients/rust-client/design.md
@@ -43,7 +43,7 @@ The available gRPC methods are documented in the [Node gRPC Reference](https://d
 
 ## Transaction executor
 
-The transaction executor uses the [Miden VM](https://0xmiden.github.io/miden-docs/imported/miden-vm/src/intro/main.html) to execute transactions. All transactions run within the [transaction kernel](https://0xmiden.github.io/miden-docs/imported/miden-base/src/transaction.html).
+The transaction executor uses the [Miden VM](https://docs.miden.xyz/reference/miden-vm/) to execute transactions. All transactions run within the [transaction kernel](https://docs.miden.xyz/reference/protocol/transaction).
 
 When executing, the executor needs access to relevant blockchain history. The executor uses a `DataStore` interface for accessing this data. This means that there may be some coupling between the executor and the store.
 

--- a/versioned_docs/version-0.14/builder/tools/clients/rust-client/get-started/create-account-use-faucet.md
+++ b/versioned_docs/version-0.14/builder/tools/clients/rust-client/get-started/create-account-use-faucet.md
@@ -10,7 +10,7 @@ In this section, we show you how to create a new local Miden account and how to 
 The Miden client facilitates interaction with the Miden rollup and provides a way to execute and prove transactions.
 
 :::tip
-Check the [Miden client documentation](https://0xMiden.github.io/miden-docs/miden-client/cli-reference.html) for more information.
+Check the [Miden client documentation](https://docs.miden.xyz/builder/tools/clients/rust-client/) for more information.
 :::
 
 1. If you haven't already done so as part of another tutorial, open your terminal and create a new directory to store the Miden client.
@@ -193,7 +193,7 @@ You have successfully configured and used the Miden client to interact with a Mi
 
 You have performed basic Miden rollup operations like submitting proofs of transactions, generating and consuming notes.
 
-For more information on the Miden client, refer to the [Miden client documentation](https://0xMiden.github.io/miden-docs/miden-client/index.html).
+For more information on the Miden client, refer to the [Miden client documentation](https://docs.miden.xyz/builder/tools/clients/rust-client/).
 
 ## Debugging tips (clear state and folder)
 

--- a/versioned_docs/version-0.14/builder/tools/clients/rust-client/get-started/p2p-private.md
+++ b/versioned_docs/version-0.14/builder/tools/clients/rust-client/get-started/p2p-private.md
@@ -14,7 +14,7 @@ In this section, we show you how to make private transactions and send funds to 
 ## Create a second account
 
 :::tip
-Remember to use the [Miden client documentation](https://0xMiden.github.io/miden-docs/miden-client/cli-reference.html) for clarifications.
+Remember to use the [Miden client documentation](https://docs.miden.xyz/builder/tools/clients/rust-client/) for clarifications.
 :::
 
 1. Create a second account to send funds with. Previously, we created a type `mutable` account (`Account A`). Now, create another `mutable` (`Account B`) using the following command:
@@ -119,7 +119,7 @@ You have successfully configured and used the Miden client to interact with a Mi
 
 You have performed basic Miden rollup operations like submitting proofs of transactions, generating and consuming notes.
 
-For more information on the Miden client, refer to the [Miden client documentation](https://0xMiden.github.io/miden-docs/miden-client/index.html).
+For more information on the Miden client, refer to the [Miden client documentation](https://docs.miden.xyz/builder/tools/clients/rust-client/).
 
 ## Clear data
 

--- a/versioned_docs/version-0.14/builder/tools/clients/rust-client/get-started/p2p-public.md
+++ b/versioned_docs/version-0.14/builder/tools/clients/rust-client/get-started/p2p-public.md
@@ -3,7 +3,7 @@ title: Peer-to-peer transfer
 sidebar_position: 2
 ---
 
-In this section, we show you how to execute transactions and send funds to another account using the Miden client and [public notes](https://0xMiden.github.io/miden-docs/miden-base/architecture/notes.html#note-storage-mode).
+In this section, we show you how to execute transactions and send funds to another account using the Miden client and [public notes](https://docs.miden.xyz/reference/protocol/note/#note-storage-mode).
 
 :::info Important: Prerequisite steps
 - You should have already followed the [prerequisite steps](index.md#prerequisites) and [create account](create-account-use-faucet) documents.
@@ -13,7 +13,7 @@ In this section, we show you how to execute transactions and send funds to anoth
 ## Create a second client
 
 :::tip
-Remember to use the [Miden client documentation](https://0xMiden.github.io/miden-docs/miden-client/cli-reference.html) for clarifications.
+Remember to use the [Miden client documentation](https://docs.miden.xyz/builder/tools/clients/rust-client/) for clarifications.
 :::
 
 This is an alternative to the [private P2P transactions](p2p-private) process.
@@ -28,7 +28,7 @@ To do this, we use two terminals with their own state (using their own `miden-cl
     mkdir miden-client-2
     cd miden-client-2
     ```
-2. On the new client, create a new [basic account](https://0xMiden.github.io/miden-docs/miden-base/architecture/accounts.html):
+2. On the new client, create a new [basic account](https://docs.miden.xyz/reference/protocol/account/):
 
     ```sh
     miden-client new-wallet --mutable -s public


### PR DESCRIPTION
All broken links pointed to the old domain 0xmiden.github.io which no longer exists.
Replaced with correct URLs on docs.miden.xyz.

Changes:
builder/tools/clients/rust-client/design.md:
  `https://0xmiden.github.io/miden-docs/imported/miden-vm/src/intro/main.html`
  → `https://docs.miden.xyz/reference/miden-vm/`

  `https://0xmiden.github.io/miden-docs/imported/miden-base/src/transaction.html`
  → `https://docs.miden.xyz/reference/protocol/transaction`

builder/tools/clients/rust-client/get-started/create-account-use-faucet.md:
  `https://0xMiden.github.io/miden-docs/miden-client/cli-reference.html`
  → `https://docs.miden.xyz/builder/tools/clients/rust-client/`

  `https://0xMiden.github.io/miden-docs/miden-client/index.html`
  → `https://docs.miden.xyz/builder/tools/clients/rust-client/`

builder/tools/clients/rust-client/get-started/p2p-public.md:
  `https://0xMiden.github.io/miden-docs/miden-base/architecture/notes.html#note-storage-mode`
  → `https://docs.miden.xyz/reference/protocol/note/#note-storage-mode`

  `https://0xMiden.github.io/miden-docs/miden-client/cli-reference.html`
  → `https://docs.miden.xyz/builder/tools/clients/rust-client/`

  `https://0xMiden.github.io/miden-docs/miden-base/architecture/accounts.html`
  → `https://docs.miden.xyz/reference/protocol/account/`

builder/tools/clients/rust-client/get-started/p2p-private.md:
  `https://0xMiden.github.io/miden-docs/miden-client/cli-reference.html`
  → `https://docs.miden.xyz/builder/tools/clients/rust-client/`

  `https://0xMiden.github.io/miden-docs/miden-client/index.html`
  → `https://docs.miden.xyz/builder/tools/clients/rust-client/`

builder/tools/clients/rust-client/cli/cli-config.md:
  `https://0xMiden.github.io/miden-vm/user_docs/assembly/debugging.html`
  → `https://docs.miden.xyz/reference/compiler/guides/debugger`

builder/tools/clients/rust-client/cli/cli-troubleshooting.md:
  `https://0xmiden.github.io/miden-docs/imported/miden-base/src/transaction.html#transaction-lifecycle`
  → `https://docs.miden.xyz/reference/protocol/transaction/#transaction-lifecycle`
  (appears twice)

Test plan:
Documentation-only change; no code paths affected.