### PR TITLE
docs: re-snapshot v0.14 rust tutorials from tutorials@main

### DIFF
--- a/versioned_docs/version-0.14/builder/tutorials/recipes/rust/counter_contract_tutorial.md
+++ b/versioned_docs/version-0.14/builder/tutorials/recipes/rust/counter_contract_tutorial.md
@@ -41,10 +41,7 @@ miden-client = { version = "0.14", features = ["testing", "tonic"] }
 miden-client-sqlite-store = { version = "0.14", package = "miden-client-sqlite-store" }
 miden-protocol = { version = "0.14" }
 rand = { version = "0.9" }
-serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1.0", features = ["raw_value"] }
 tokio = { version = "1.46", features = ["rt-multi-thread", "net", "macros", "fs"] }
-rand_chacha = "0.9.0"
 ```
 
 ### Set up your `src/main.rs` file
@@ -54,50 +51,23 @@ In the previous section, we explained how to instantiate the Miden client. We ca
 Copy and paste the following code into your `src/main.rs` file:
 
 ```rust no_run
-use miden_client::auth::NoAuth;
-use miden_client::transaction::TransactionKernel;
 use rand::RngCore;
-use std::{fs, path::Path, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
-use miden_client::{
-    address::NetworkId,
-    assembly::{
-        Assembler,
-        CodeBuilder,
-        DefaultSourceManager,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
-    },
-    builder::ClientBuilder,
-    keystore::FilesystemKeyStore,
-    rpc::{Endpoint, GrpcClient},
-    transaction::TransactionRequestBuilder,
-    ClientError,
-};
-use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_client::{
     account::{
         component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountStorageMode,
         AccountType, StorageSlot, StorageSlotName,
     },
-    Word,
+    address::NetworkId,
+    auth::NoAuth,
+    builder::ClientBuilder,
+    keystore::FilesystemKeyStore,
+    rpc::{Endpoint, GrpcClient},
+    transaction::TransactionRequestBuilder,
+    ClientError, Word,
 };
-
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<std::sync::Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
-}
+use miden_client_sqlite_store::ClientBuilderSqliteExt;
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -107,10 +77,10 @@ async fn main() -> Result<(), ClientError> {
     let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
 
     // Initialize keystore
-    let keystore_path = std::path::PathBuf::from("./keystore");
+    let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
-    let store_path = std::path::PathBuf::from("./store.sqlite3");
+    let store_path = PathBuf::from("./store.sqlite3");
 
     let mut client = ClientBuilder::new()
         .rpc(rpc_client)
@@ -256,15 +226,17 @@ To build the counter contract copy and paste the following code at the end of yo
 // -------------------------------------------------------------------------
 println!("\n[STEP 1] Creating counter contract.");
 
-// Load the MASM file for the counter contract
-let counter_path = Path::new("../masm/accounts/counter.masm");
-let counter_code = fs::read_to_string(counter_path).unwrap();
+// Load the MASM file for the counter contract. `include_str!` resolves at
+// compile time relative to this source file, so the binary is independent of
+// the working directory it is run from.
+let counter_code = include_str!("../masm/accounts/counter.masm");
 
-// Compile the account code into `AccountComponent` with one storage slot
+// Compile the account code into `AccountComponent` with one storage slot.
 let counter_slot_name =
     StorageSlotName::new("miden::tutorials::counter").expect("valid slot name");
-let component_code = CodeBuilder::new()
-    .compile_component_code("external_contract::counter_contract", &counter_code)
+let component_code = client
+    .code_builder()
+    .compile_component_code("external_contract::counter_contract", counter_code)
     .unwrap();
 let counter_component = AccountComponent::new(
     component_code,
@@ -324,21 +296,15 @@ Paste the following code at the end of your `src/main.rs` file:
 println!("\n[STEP 2] Call Counter Contract With Script");
 
 // Load the MASM script referencing the increment procedure
-let script_path = Path::new("../masm/scripts/counter_script.masm");
-let script_code = fs::read_to_string(script_path).unwrap();
+let script_code = include_str!("../masm/scripts/counter_script.masm");
 
-// Create a library from the counter contract code
-let account_component_lib = create_library(
-    "external_contract::counter_contract",
-    &counter_code,
-)
-.unwrap();
-
+// Compile the script with the counter contract code linked as a module
+// on the same `CodeBuilder` chain.
 let tx_script = client
     .code_builder()
-    .with_dynamically_linked_library(&account_component_lib)
+    .with_linked_module("external_contract::counter_contract", counter_code)
     .unwrap()
-    .compile_tx_script(&script_code)
+    .compile_tx_script(script_code)
     .unwrap();
 
 // Build a transaction request with the custom script
@@ -384,50 +350,23 @@ println!(
 The final `src/main.rs` file should look like this:
 
 ```rust no_run
-use miden_client::auth::NoAuth;
-use miden_client::transaction::TransactionKernel;
 use rand::RngCore;
-use std::{fs, path::Path, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
-use miden_client::{
-    address::NetworkId,
-    assembly::{
-        Assembler,
-        CodeBuilder,
-        DefaultSourceManager,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
-    },
-    builder::ClientBuilder,
-    keystore::FilesystemKeyStore,
-    rpc::{Endpoint, GrpcClient},
-    transaction::TransactionRequestBuilder,
-    ClientError,
-};
-use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_client::{
     account::{
         component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountStorageMode,
         AccountType, StorageSlot, StorageSlotName,
     },
-    Word,
+    address::NetworkId,
+    auth::NoAuth,
+    builder::ClientBuilder,
+    keystore::FilesystemKeyStore,
+    rpc::{Endpoint, GrpcClient},
+    transaction::TransactionRequestBuilder,
+    ClientError, Word,
 };
-
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<std::sync::Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
-}
+use miden_client_sqlite_store::ClientBuilderSqliteExt;
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -437,10 +376,10 @@ async fn main() -> Result<(), ClientError> {
     let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
 
     // Initialize keystore
-    let keystore_path = std::path::PathBuf::from("./keystore");
+    let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
-    let store_path = std::path::PathBuf::from("./store.sqlite3");
+    let store_path = PathBuf::from("./store.sqlite3");
 
     let mut client = ClientBuilder::new()
         .rpc(rpc_client)
@@ -458,15 +397,17 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Creating counter contract.");
 
-    // Load the MASM file for the counter contract
-    let counter_path = Path::new("../masm/accounts/counter.masm");
-    let counter_code = fs::read_to_string(counter_path).unwrap();
+    // Load the MASM file for the counter contract. `include_str!` resolves at
+    // compile time relative to this source file, so the binary is independent
+    // of the working directory it is run from.
+    let counter_code = include_str!("../masm/accounts/counter.masm");
 
-    // Compile the account code into `AccountComponent` with one storage slot
+    // Compile the account code into `AccountComponent` with one storage slot.
     let counter_slot_name =
         StorageSlotName::new("miden::tutorials::counter").expect("valid slot name");
-    let component_code = CodeBuilder::new()
-        .compile_component_code("external_contract::counter_contract", &counter_code)
+    let component_code = client
+        .code_builder()
+        .compile_component_code("external_contract::counter_contract", counter_code)
         .unwrap();
     let counter_component = AccountComponent::new(
         component_code,
@@ -503,21 +444,15 @@ async fn main() -> Result<(), ClientError> {
     println!("\n[STEP 2] Call Counter Contract With Script");
 
     // Load the MASM script referencing the increment procedure
-    let script_path = Path::new("../masm/scripts/counter_script.masm");
-    let script_code = fs::read_to_string(script_path).unwrap();
+    let script_code = include_str!("../masm/scripts/counter_script.masm");
 
-    // Create a library from the counter contract code
-    let account_component_lib = create_library(
-        "external_contract::counter_contract",
-        &counter_code,
-    )
-    .unwrap();
-
+    // Compile the script with the counter contract code linked as a module
+    // on the same `CodeBuilder` chain.
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_linked_module("external_contract::counter_contract", counter_code)
         .unwrap()
-        .compile_tx_script(&script_code)
+        .compile_tx_script(script_code)
         .unwrap();
 
     // Build a transaction request with the custom script

--- a/versioned_docs/version-0.14/builder/tutorials/recipes/rust/create_deploy_tutorial.md
+++ b/versioned_docs/version-0.14/builder/tutorials/recipes/rust/create_deploy_tutorial.md
@@ -52,10 +52,7 @@ miden-client = { version = "0.14", features = ["testing", "tonic"] }
 miden-client-sqlite-store = { version = "0.14", package = "miden-client-sqlite-store" }
 miden-protocol = { version = "0.14" }
 rand = { version = "0.9" }
-serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1.0", features = ["raw_value"] }
 tokio = { version = "1.46", features = ["rt-multi-thread", "net", "macros", "fs"] }
-rand_chacha = "0.9.0"
 ```
 
 ## Step 2: Initialize the client
@@ -72,7 +69,7 @@ Copy and paste the following code into your `src/main.rs` file.
 ```rust no_run
 use miden_client::auth::{AuthSchemeId, AuthSingleSig};
 use rand::RngCore;
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 use tokio::time::Duration;
 
 use miden_client::{
@@ -105,10 +102,10 @@ async fn main() -> Result<(), ClientError> {
     let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
 
     // Initialize keystore
-    let keystore_path = std::path::PathBuf::from("./keystore");
+    let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
-    let store_path = std::path::PathBuf::from("./store.sqlite3");
+    let store_path = PathBuf::from("./store.sqlite3");
 
     let mut client = ClientBuilder::new()
         .rpc(rpc_client)
@@ -242,7 +239,7 @@ Your updated `main()` function in `src/main.rs` should look like this:
 ```rust no_run
 use miden_client::auth::{AuthSchemeId, AuthSingleSig};
 use rand::RngCore;
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 use tokio::time::Duration;
 
 use miden_client::{
@@ -275,10 +272,10 @@ async fn main() -> Result<(), ClientError> {
     let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
 
     // Initialize keystore
-    let keystore_path = std::path::PathBuf::from("./keystore");
+    let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
-    let store_path = std::path::PathBuf::from("./store.sqlite3");
+    let store_path = PathBuf::from("./store.sqlite3");
 
     let mut client = ClientBuilder::new()
         .rpc(rpc_client)

--- a/versioned_docs/version-0.14/builder/tutorials/recipes/rust/creating_notes_in_masm_tutorial.md
+++ b/versioned_docs/version-0.14/builder/tutorials/recipes/rust/creating_notes_in_masm_tutorial.md
@@ -55,10 +55,7 @@ miden-client = { version = "0.14", features = ["testing", "tonic"] }
 miden-client-sqlite-store = { version = "0.14", package = "miden-client-sqlite-store" }
 miden-protocol = { version = "0.14" }
 rand = { version = "0.9" }
-serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1.0", features = ["raw_value"] }
 tokio = { version = "1.46", features = ["rt-multi-thread", "net", "macros", "fs"] }
-rand_chacha = "0.9.0"
 ```
 
 ## Step 2: Write the Note Script
@@ -80,7 +77,7 @@ masm/
 └── notes/
 ```
 
-Inside the `masm/notes/` directory, create the file `iterative_output_note.masm`:
+Inside the `masm/notes/` directory, create the file `iterative_output_note.masm`. Note scripts in v0.14.5+ are compiled as libraries; the `@note_script` attribute marks the entrypoint procedure.
 
 ```masm
 use miden::protocol::active_note
@@ -97,8 +94,10 @@ const ASSET_HALF_VALUE_PTR=8    # half-amount ASSET_VALUE stored here
 const ACCOUNT_ID_PREFIX=12      # storage: [prefix, suffix, tag, 0]
 const TAG=14                    # = ACCOUNT_ID_PREFIX + 2
 
-# => []
-begin
+#! Inputs:  []
+#! Outputs: []
+@note_script
+pub proc main
     # Drop word if user accidentally pushes note_args
     dropw
     # => []
@@ -204,7 +203,7 @@ Copy and paste the following code into your `src/main.rs` file.
 ```rust no_run
 use miden_client::auth::{AuthSchemeId, AuthSingleSig};
 use rand::RngCore;
-use std::{fs, path::Path, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 use tokio::time::{sleep, Duration};
 
 use miden_client::{
@@ -312,10 +311,10 @@ async fn main() -> Result<(), ClientError> {
     let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
 
     // Initialize keystore
-    let keystore_path = std::path::PathBuf::from("./keystore");
+    let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
-    let store_path = std::path::PathBuf::from("./store.sqlite3");
+    let store_path = PathBuf::from("./store.sqlite3");
 
     let mut client = ClientBuilder::new()
         .rpc(rpc_client)
@@ -395,13 +394,15 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 3] Create iterative output note");
 
-    let code = fs::read_to_string(Path::new("../masm/notes/iterative_output_note.masm")).unwrap();
+    // `include_str!` resolves at compile time relative to this source file,
+    // so the binary is independent of the working directory it is run from.
+    let code = include_str!("../masm/notes/iterative_output_note.masm");
     let serial_num = client.rng().draw_word();
 
     // Create note metadata and tag
     let tag = NoteTag::new(0);
     let metadata = NoteMetadata::new(alice_account.id(), NoteType::Public).with_tag(tag);
-    let note_script = client.code_builder().compile_note_script(&code).unwrap();
+    let note_script = client.code_builder().compile_note_script(code).unwrap();
     let note_storage = NoteStorage::new(vec![
         alice_account.id().prefix().as_felt(),
         alice_account.id().suffix(),

--- a/versioned_docs/version-0.14/builder/tutorials/recipes/rust/custom_note_how_to.md
+++ b/versioned_docs/version-0.14/builder/tutorials/recipes/rust/custom_note_how_to.md
@@ -49,7 +49,7 @@ Now, combine the minted asset and the secret hash to build the custom note. The 
 2. **Miden Assembly Code:**
    - The Miden assembly note script ensures that the note can only be consumed if the provided secret, when hashed, matches the hash stored in the note input.
 
-Below is the Miden Assembly code for the note:
+Below is the Miden Assembly code for the note. Note scripts in v0.14.5+ are compiled as libraries; the `@note_script` attribute marks the entrypoint procedure.
 
 ```masm
 use miden::protocol::active_note
@@ -70,7 +70,8 @@ const ERROR_DIGEST_MISMATCH="Expected digest does not match computed digest"
 #!
 #! Note storage is assumed to be as follows:
 #!  => EXPECTED_DIGEST
-begin
+@note_script
+pub proc main
     # => HASH_PREIMAGE_SECRET
     # Hashing the secret number
     hash
@@ -124,7 +125,7 @@ The following Rust code demonstrates how to implement the steps outlined above u
 ```rust no_run
 use miden_client::auth::{AuthSchemeId, AuthSingleSig};
 use rand::RngCore;
-use std::{fs, path::Path, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 use tokio::time::{sleep, Duration};
 
 use miden_client::{
@@ -243,10 +244,10 @@ async fn main() -> Result<(), ClientError> {
     let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
 
     // Initialize keystore
-    let keystore_path = std::path::PathBuf::from("./keystore");
+    let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
-    let store_path = std::path::PathBuf::from("./store.sqlite3");
+    let store_path = PathBuf::from("./store.sqlite3");
 
     let mut client = ClientBuilder::new()
         .rpc(rpc_client)
@@ -334,7 +335,9 @@ async fn main() -> Result<(), ClientError> {
     let digest = Hasher::hash_elements(&secret_vals);
     println!("digest: {:?}", digest);
 
-    let code = fs::read_to_string(Path::new("../masm/notes/hash_preimage_note.masm")).unwrap();
+    // `include_str!` resolves at compile time relative to this source file,
+    // so the binary is independent of the working directory it is run from.
+    let code = include_str!("../masm/notes/hash_preimage_note.masm");
     let serial_num = client.rng().draw_word();
 
     let note_script = client.code_builder().compile_note_script(code).unwrap();

--- a/versioned_docs/version-0.14/builder/tutorials/recipes/rust/delegated_proving_tutorial.md
+++ b/versioned_docs/version-0.14/builder/tutorials/recipes/rust/delegated_proving_tutorial.md
@@ -52,10 +52,7 @@ miden-client = { version = "0.14", features = ["testing", "tonic"] }
 miden-client-sqlite-store = { version = "0.14", package = "miden-client-sqlite-store" }
 miden-protocol = { version = "0.14" }
 rand = { version = "0.9" }
-serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1.0", features = ["raw_value"] }
 tokio = { version = "1.46", features = ["rt-multi-thread", "net", "macros", "fs"] }
-rand_chacha = "0.9.0"
 ```
 
 ## Step 2: Initialize the client and prover and construct transactions
@@ -67,7 +64,7 @@ We construct a `LocalTransactionProver` for this walkthrough.
 use miden_client::auth::AuthSecretKey;
 use miden_client::auth::{AuthSchemeId, AuthSingleSig};
 use rand::RngCore;
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 
 use miden_client::{
     account::component::BasicWallet,
@@ -93,10 +90,10 @@ async fn main() -> Result<(), ClientError> {
     let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
 
     // Initialize keystore
-    let keystore_path = std::path::PathBuf::from("./keystore");
+    let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
-    let store_path = std::path::PathBuf::from("./store.sqlite3");
+    let store_path = PathBuf::from("./store.sqlite3");
 
     let mut client = ClientBuilder::new()
         .rpc(rpc_client)

--- a/versioned_docs/version-0.14/builder/tutorials/recipes/rust/foreign_procedure_invocation_tutorial.md
+++ b/versioned_docs/version-0.14/builder/tutorials/recipes/rust/foreign_procedure_invocation_tutorial.md
@@ -125,46 +125,22 @@ end
 
 ```rust no_run
 use rand::RngCore;
-use std::{fs, path::Path, sync::Arc, time::Duration};
+use std::{path::PathBuf, sync::Arc, time::Duration};
 use tokio::time::sleep;
 
 use miden_client::{
     account::{
-        component::AccountComponentMetadata, AccountBuilder, AccountComponent,
+        component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountId,
         AccountStorageMode, AccountType, StorageSlot, StorageSlotName,
-    },
-    account::AccountId,
-    assembly::{
-        CodeBuilder,
-        DefaultSourceManager,
-        Library,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
     },
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{domain::account::AccountStorageRequirements, Endpoint, GrpcClient},
-    transaction::{ForeignAccount, TransactionKernel, TransactionRequestBuilder},
+    transaction::{ForeignAccount, TransactionRequestBuilder},
     ClientError, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<Arc<Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
-}
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -173,10 +149,10 @@ async fn main() -> Result<(), ClientError> {
     let timeout_ms = 10_000;
     let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
 
-    let keystore_path = std::path::PathBuf::from("./keystore");
+    let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
-    let store_path = std::path::PathBuf::from("./store.sqlite3");
+    let store_path = PathBuf::from("./store.sqlite3");
 
     let mut client = ClientBuilder::new()
         .rpc(rpc_client)
@@ -194,13 +170,15 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Creating count reader contract.");
 
-    let count_reader_path = Path::new("../masm/accounts/count_reader.masm");
-    let count_reader_code = fs::read_to_string(count_reader_path).unwrap();
+    // `include_str!` resolves at compile time relative to this source file,
+    // so the binary is independent of the working directory it is run from.
+    let count_reader_code = include_str!("../masm/accounts/count_reader.masm");
 
     let count_reader_slot_name =
         StorageSlotName::new("miden::tutorials::count_reader").expect("valid slot name");
-    let count_reader_component_code = CodeBuilder::new()
-        .compile_component_code("external_contract::count_reader_contract", &count_reader_code)
+    let count_reader_component_code = client
+        .code_builder()
+        .compile_component_code("external_contract::count_reader_contract", count_reader_code)
         .unwrap();
     let count_reader_component = AccountComponent::new(
         count_reader_component_code,
@@ -297,13 +275,13 @@ Add this snippet to the end of your file in the `main()` function:
 println!("\n[STEP 3] Call counter contract with FPI from count reader contract");
 
 // Derive the get_count procedure hash from the locally compiled counter library.
-let counter_contract_path = Path::new("../masm/accounts/counter.masm");
-let counter_contract_code = fs::read_to_string(counter_contract_path).unwrap();
+let counter_contract_code = include_str!("../masm/accounts/counter.masm");
 
 // Compile the counter as a component (same path as the deploy binary) to get
 // the correct procedure root that matches the on-chain MAST.
-let counter_component_code = CodeBuilder::new()
-    .compile_component_code("external_contract::counter_contract", &counter_contract_code)
+let counter_component_code = client
+    .code_builder()
+    .compile_component_code("external_contract::counter_contract", counter_contract_code)
     .unwrap();
 let counter_component = AccountComponent::new(
     counter_component_code,
@@ -323,9 +301,7 @@ println!("get_count hash: {:?}", get_count_hash);
 println!("counter id prefix: {:?}", counter_contract_id.prefix());
 println!("counter id suffix: {:?}", counter_contract_id.suffix());
 
-let script_path = Path::new("../masm/scripts/reader_script.masm");
-let script_code_original = fs::read_to_string(script_path).unwrap();
-let script_code = script_code_original
+let script_code = include_str!("../masm/scripts/reader_script.masm")
     .replace("{get_count_proc_hash}", &get_count_hash)
     .replace(
         "{account_id_suffix}",
@@ -336,17 +312,13 @@ let script_code = script_code_original
         &u64::from(counter_contract_id.prefix()).to_string(),
     );
 
-let account_component_lib = create_library(
-    "external_contract::count_reader_contract",
-    &count_reader_code,
-)
-.unwrap();
-
+// Link the count reader contract code into the same `CodeBuilder` chain
+// that compiles the script.
 let tx_script = client
     .code_builder()
-    .with_dynamically_linked_library(&account_component_lib)
+    .with_linked_module("external_contract::count_reader_contract", count_reader_code)
     .unwrap()
-    .compile_tx_script(&script_code)
+    .compile_tx_script(script_code.as_str())
     .unwrap();
 
 let foreign_account =
@@ -406,7 +378,7 @@ The final `src/main.rs` file should look like this:
 
 ```rust no_run
 use rand::RngCore;
-use std::{fs, path::Path, sync::Arc, time::Duration};
+use std::{path::PathBuf, sync::Arc, time::Duration};
 use tokio::time::sleep;
 
 use miden_client::{
@@ -414,33 +386,14 @@ use miden_client::{
         component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountId,
         AccountStorageMode, AccountType, StorageSlot, StorageSlotName,
     },
-    assembly::{
-        CodeBuilder, DefaultSourceManager, Library, Module, ModuleKind,
-        Path as AssemblyPath,
-    },
     auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{domain::account::AccountStorageRequirements, Endpoint, GrpcClient},
-    transaction::{ForeignAccount, TransactionKernel, TransactionRequestBuilder},
+    transaction::{ForeignAccount, TransactionRequestBuilder},
     ClientError, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-
-fn create_library(
-    library_path: &str,
-    source_code: &str,
-) -> Result<Arc<Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager,
-    )?;
-    let library = assembler.assemble_library([module])?;
-    Ok(library)
-}
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -449,10 +402,10 @@ async fn main() -> Result<(), ClientError> {
     let timeout_ms = 10_000;
     let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
 
-    let keystore_path = std::path::PathBuf::from("./keystore");
+    let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
-    let store_path = std::path::PathBuf::from("./store.sqlite3");
+    let store_path = PathBuf::from("./store.sqlite3");
 
     let mut client = ClientBuilder::new()
         .rpc(rpc_client)
@@ -470,15 +423,17 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Creating count reader contract.");
 
-    let count_reader_path = Path::new("../masm/accounts/count_reader.masm");
-    let count_reader_code = fs::read_to_string(count_reader_path).unwrap();
+    // `include_str!` resolves at compile time relative to this source file,
+    // so the binary is independent of the working directory it is run from.
+    let count_reader_code = include_str!("../masm/accounts/count_reader.masm");
 
     let count_reader_slot_name =
         StorageSlotName::new("miden::tutorials::count_reader").expect("valid slot name");
-    let count_reader_component_code = CodeBuilder::new()
+    let count_reader_component_code = client
+        .code_builder()
         .compile_component_code(
             "external_contract::count_reader_contract",
-            &count_reader_code,
+            count_reader_code,
         )
         .unwrap();
     let count_reader_component = AccountComponent::new(
@@ -547,13 +502,13 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 3] Call counter contract with FPI from count reader contract");
 
-    let counter_contract_path = Path::new("../masm/accounts/counter.masm");
-    let counter_contract_code = fs::read_to_string(counter_contract_path).unwrap();
+    let counter_contract_code = include_str!("../masm/accounts/counter.masm");
 
     // Compile the counter as a component (same path as the deploy binary) to get
     // the correct procedure root that matches the on-chain MAST.
-    let counter_component_code = CodeBuilder::new()
-        .compile_component_code("external_contract::counter_contract", &counter_contract_code)
+    let counter_component_code = client
+        .code_builder()
+        .compile_component_code("external_contract::counter_contract", counter_contract_code)
         .unwrap();
     let counter_component = AccountComponent::new(
         counter_component_code,
@@ -573,9 +528,7 @@ async fn main() -> Result<(), ClientError> {
     println!("counter id prefix: {:?}", counter_contract_id.prefix());
     println!("counter id suffix: {:?}", counter_contract_id.suffix());
 
-    let script_path = Path::new("../masm/scripts/reader_script.masm");
-    let script_code_original = fs::read_to_string(script_path).unwrap();
-    let script_code = script_code_original
+    let script_code = include_str!("../masm/scripts/reader_script.masm")
         .replace("{get_count_proc_hash}", &get_count_hash)
         .replace(
             "{account_id_suffix}",
@@ -586,17 +539,13 @@ async fn main() -> Result<(), ClientError> {
             &u64::from(counter_contract_id.prefix()).to_string(),
         );
 
-    let account_component_lib = create_library(
-        "external_contract::count_reader_contract",
-        &count_reader_code,
-    )
-    .unwrap();
-
+    // Link the count reader contract code into the same `CodeBuilder` chain
+    // that compiles the script.
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_linked_module("external_contract::count_reader_contract", count_reader_code)
         .unwrap()
-        .compile_tx_script(&script_code)
+        .compile_tx_script(script_code.as_str())
         .unwrap();
 
     let foreign_account =

--- a/versioned_docs/version-0.14/builder/tutorials/recipes/rust/mappings_in_masm_how_to.md
+++ b/versioned_docs/version-0.14/builder/tutorials/recipes/rust/mappings_in_masm_how_to.md
@@ -145,49 +145,22 @@ The script calls the `write_to_map` procedure in the account which writes the ke
 Below is the Rust code that deploys the smart contract, creates the transaction script, and submits a transaction to update the mapping in the account:
 
 ```rust no_run
-use miden_client::auth::NoAuth;
-use miden_client::transaction::TransactionKernel;
 use rand::RngCore;
-use std::{fs, path::Path, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
-use miden_client::{
-    assembly::{
-        Assembler,
-        CodeBuilder,
-        DefaultSourceManager,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
-    },
-    builder::ClientBuilder,
-    keystore::FilesystemKeyStore,
-    rpc::{Endpoint, GrpcClient},
-    transaction::TransactionRequestBuilder,
-    ClientError,
-};
-use miden_client_sqlite_store::ClientBuilderSqliteExt;
 use miden_client::{
     account::{
         component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountStorageMode,
         AccountType, StorageMap, StorageSlot, StorageSlotName,
     },
-    Felt, Word,
+    auth::NoAuth,
+    builder::ClientBuilder,
+    keystore::FilesystemKeyStore,
+    rpc::{Endpoint, GrpcClient},
+    transaction::TransactionRequestBuilder,
+    ClientError, Felt, Word,
 };
-
-fn create_library(
-    assembler: Assembler,
-    library_path: &str,
-    source_code: &str,
-) -> Result<std::sync::Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager.clone(),
-    )?;
-    let library = assembler.clone().assemble_library([module])?;
-    Ok(library)
-}
+use miden_client_sqlite_store::ClientBuilderSqliteExt;
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -197,10 +170,10 @@ async fn main() -> Result<(), ClientError> {
     let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
 
     // Initialize keystore
-    let keystore_path = std::path::PathBuf::from("./keystore");
+    let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
-    let store_path = std::path::PathBuf::from("./store.sqlite3");
+    let store_path = PathBuf::from("./store.sqlite3");
 
     let mut client = ClientBuilder::new()
         .rpc(rpc_client)
@@ -218,12 +191,9 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 1] Deploy a smart contract with a mapping");
 
-    // Load the MASM file for the counter contract
-    let file_path = Path::new("../masm/accounts/mapping_example_contract.masm");
-    let account_code = fs::read_to_string(file_path).unwrap();
-
-    // Prepare assembler (debug mode = true)
-    let assembler: Assembler = TransactionKernel::assembler();
+    // Load the MASM file for the counter contract. `include_str!` resolves at
+    // compile time relative to this source file.
+    let account_code = include_str!("../masm/accounts/mapping_example_contract.masm");
 
     // Using an empty storage value in slot 0 since this is usually reserved
     // for the account pub_key and metadata
@@ -238,8 +208,9 @@ async fn main() -> Result<(), ClientError> {
     let storage_slot_map = StorageSlot::with_map(map_slot_name.clone(), storage_map.clone());
 
     // Compile the account code into `AccountComponent` with one storage slot
-    let component_code = CodeBuilder::new()
-        .compile_component_code("miden_by_example::mapping_example_contract", &account_code)
+    let component_code = client
+        .code_builder()
+        .compile_component_code("miden_by_example::mapping_example_contract", account_code)
         .unwrap();
     let mapping_contract_component = AccountComponent::new(
         component_code,
@@ -271,23 +242,15 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 2] Call Mapping Contract With Script");
 
-    let script_code =
-        fs::read_to_string(Path::new("../masm/scripts/mapping_example_script.masm")).unwrap();
+    let script_code = include_str!("../masm/scripts/mapping_example_script.masm");
 
-    // Create the library from the account source code using the helper function.
-    let account_component_lib = create_library(
-        assembler.clone(),
-        "miden_by_example::mapping_example_contract",
-        &account_code,
-    )
-    .unwrap();
-
-    // Compile the transaction script with the library.
+    // Compile the transaction script with the account code linked as a
+    // module on the same `CodeBuilder` chain.
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_linked_module("miden_by_example::mapping_example_contract", account_code)
         .unwrap()
-        .compile_tx_script(&script_code)
+        .compile_tx_script(script_code)
         .unwrap();
 
     // Build a transaction request with the custom script

--- a/versioned_docs/version-0.14/builder/tutorials/recipes/rust/mint_consume_create_tutorial.md
+++ b/versioned_docs/version-0.14/builder/tutorials/recipes/rust/mint_consume_create_tutorial.md
@@ -251,7 +251,7 @@ Your `src/main.rs` function should now look like this:
 ```rust no_run
 use miden_client::auth::{AuthSchemeId, AuthSingleSig};
 use rand::RngCore;
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 use tokio::time::Duration;
 
 use miden_client::{
@@ -284,10 +284,10 @@ async fn main() -> Result<(), ClientError> {
     let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
 
     // Initialize keystore
-    let keystore_path = std::path::PathBuf::from("./keystore");
+    let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
-    let store_path = std::path::PathBuf::from("./store.sqlite3");
+    let store_path = PathBuf::from("./store.sqlite3");
 
     let mut client = ClientBuilder::new()
         .rpc(rpc_client)

--- a/versioned_docs/version-0.14/builder/tutorials/recipes/rust/network_transactions_tutorial.md
+++ b/versioned_docs/version-0.14/builder/tutorials/recipes/rust/network_transactions_tutorial.md
@@ -53,10 +53,7 @@ miden-client = { version = "0.14", features = ["testing", "tonic"] }
 miden-client-sqlite-store = { version = "0.14", package = "miden-client-sqlite-store" }
 miden-protocol = { version = "0.14" }
 rand = { version = "0.9" }
-serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1.0", features = ["raw_value"] }
 tokio = { version = "1.46", features = ["rt-multi-thread", "net", "macros", "fs"] }
-rand_chacha = "0.9.0"
 ```
 
 ## Step 2: Set up MASM files
@@ -124,12 +121,15 @@ This script executes a function call (increment) that creates a necessary state 
 
 ### Network Note for User Interaction
 
-Create `masm/notes/network_increment_note.masm`:
+Create `masm/notes/network_increment_note.masm`. Note scripts in v0.14.5+ are compiled as libraries; the `@note_script` attribute marks the entrypoint procedure.
 
 ```masm
 use external_contract::counter_contract
 
-begin
+#! Inputs:  []
+#! Outputs: []
+@note_script
+pub proc main
     call.counter_contract::increment_count
 end
 ```
@@ -143,14 +143,17 @@ Before deploying the network account and creating network notes, we need to set 
 Copy and paste the following code into your `src/main.rs` file:
 
 ```rust no_run
-use std::{fs, path::Path, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
-use miden_client::account::component::BasicWallet;
 use miden_client::{
+    account::{
+        component::{AccountComponentMetadata, BasicWallet}, AccountBuilder, AccountComponent,
+        AccountStorageMode, AccountType, StorageSlot, StorageSlotName,
+    },
     address::NetworkId,
-    auth::AuthSecretKey,
-    crypto::FeltRng,
+    auth::{self, AuthSchemeId, AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
+    crypto::FeltRng,
     keystore::{FilesystemKeyStore, Keystore},
     note::{
         NetworkAccountTarget, Note, NoteAssets, NoteError, NoteExecutionHint, NoteMetadata,
@@ -162,23 +165,6 @@ use miden_client::{
     Client, ClientError, Felt, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-use miden_client::auth::{self, AuthSchemeId, AuthSingleSig};
-use miden_client::transaction::TransactionKernel;
-use miden_client::{
-    account::{
-        component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountStorageMode,
-        AccountType, StorageSlot, StorageSlotName,
-    },
-    assembly::{
-        Assembler,
-        CodeBuilder,
-        DefaultSourceManager,
-        Library,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
-    },
-};
 use rand::RngCore;
 use tokio::time::{sleep, Duration};
 
@@ -214,22 +200,6 @@ async fn wait_for_tx(
     Ok(())
 }
 
-/// Creates a Miden library from the provided account code and library path.
-fn create_library(
-    account_code: String,
-    library_path: &str,
-) -> Result<std::sync::Arc<Library>, Box<dyn std::error::Error>> {
-    let assembler: Assembler = TransactionKernel::assembler();
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        account_code,
-        source_manager.clone(),
-    )?;
-    let library = assembler.clone().assemble_library([module])?;
-    Ok(library)
-}
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize client
@@ -238,10 +208,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
 
     // Initialize keystore
-    let keystore_path = std::path::PathBuf::from("./keystore");
+    let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
-    let store_path = std::path::PathBuf::from("./store.sqlite3");
+    let store_path = PathBuf::from("./store.sqlite3");
 
     let mut client = ClientBuilder::new()
         .rpc(rpc_client)
@@ -303,14 +273,17 @@ Add this code to your `main()` function:
 // -------------------------------------------------------------------------
 println!("\n[STEP 2] Creating a network counter smart contract");
 
-let counter_code = fs::read_to_string(Path::new("../masm/accounts/counter.masm")).unwrap();
+// `include_str!` resolves at compile time relative to this source file,
+// so the binary is independent of the working directory it is run from.
+let counter_code = include_str!("../masm/accounts/counter.masm");
 
 // Create the network counter smart contract account
 // First, compile the MASM code into an account component
 let counter_slot_name =
     StorageSlotName::new("miden::tutorials::counter").expect("valid slot name");
-let component_code = CodeBuilder::new()
-    .compile_component_code("external_contract::counter_contract", &counter_code)
+let component_code = client
+    .code_builder()
+    .compile_component_code("external_contract::counter_contract", counter_code)
     .unwrap();
 let counter_component = AccountComponent::new(
     component_code,
@@ -354,17 +327,14 @@ Add this code to your `main()` function:
 // -------------------------------------------------------------------------
 println!("\n[STEP 3] Deploy network counter smart contract");
 
-let script_code = fs::read_to_string(Path::new("../masm/scripts/counter_script.masm")).unwrap();
+let script_code = include_str!("../masm/scripts/counter_script.masm");
 
-let account_code = fs::read_to_string(Path::new("../masm/accounts/counter.masm")).unwrap();
-let library_path = "external_contract::counter_contract";
-
-let library = create_library(account_code, library_path).unwrap();
-
+// Link the counter contract code into the same `CodeBuilder` chain that
+// compiles the script.
 let tx_script = client
     .code_builder()
-    .with_dynamically_linked_library(&library)?
-    .compile_tx_script(&script_code)?;
+    .with_linked_module("external_contract::counter_contract", counter_code)?
+    .compile_tx_script(script_code)?;
 
 let tx_increment_request = TransactionRequestBuilder::new()
     .custom_script(tx_script)
@@ -399,22 +369,18 @@ Add this code to your `main()` function:
 // -------------------------------------------------------------------------
 println!("\n[STEP 4] Creating a network note for network counter contract");
 
-let network_note_code =
-    fs::read_to_string(Path::new("../masm/notes/network_increment_note.masm")).unwrap();
-let account_code = fs::read_to_string(Path::new("../masm/accounts/counter.masm")).unwrap();
-
-let library_path = "external_contract::counter_contract";
-let library = create_library(account_code, library_path).unwrap();
+let network_note_code = include_str!("../masm/notes/network_increment_note.masm");
 
 // Create and submit the network note that will increment the counter
 // Generate a random serial number for the note
 let serial_num = client.rng().draw_word();
 
-// Compile the note script with the counter contract library
+// Compile the note script with the counter contract code linked as a
+// module on the same `CodeBuilder` chain.
 let note_script = client
     .code_builder()
-    .with_dynamically_linked_library(&library)?
-    .compile_note_script(&network_note_code)?;
+    .with_linked_module("external_contract::counter_contract", counter_code)?
+    .compile_note_script(network_note_code)?;
 
 // Create note recipient with empty storage
 let note_storage = NoteStorage::new([].to_vec())?;
@@ -496,14 +462,17 @@ This step creates a public note that the network operator can consume to execute
 Your complete `main()` function should look like this:
 
 ```rust no_run
-use std::{fs, path::Path, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
-use miden_client::account::component::BasicWallet;
 use miden_client::{
+    account::{
+        component::{AccountComponentMetadata, BasicWallet}, AccountBuilder, AccountComponent,
+        AccountStorageMode, AccountType, StorageSlot, StorageSlotName,
+    },
     address::NetworkId,
-    auth::AuthSecretKey,
-    crypto::FeltRng,
+    auth::{self, AuthSchemeId, AuthSecretKey, AuthSingleSig},
     builder::ClientBuilder,
+    crypto::FeltRng,
     keystore::{FilesystemKeyStore, Keystore},
     note::{
         NetworkAccountTarget, Note, NoteAssets, NoteError, NoteExecutionHint, NoteMetadata,
@@ -515,23 +484,6 @@ use miden_client::{
     Client, ClientError, Felt, Word,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-use miden_client::auth::{self, AuthSchemeId, AuthSingleSig};
-use miden_client::transaction::TransactionKernel;
-use miden_client::{
-    account::{
-        component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountStorageMode,
-        AccountType, StorageSlot, StorageSlotName,
-    },
-    assembly::{
-        Assembler,
-        CodeBuilder,
-        DefaultSourceManager,
-        Library,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
-    },
-};
 use rand::RngCore;
 use tokio::time::{sleep, Duration};
 
@@ -567,22 +519,6 @@ async fn wait_for_tx(
     Ok(())
 }
 
-/// Creates a Miden library from the provided account code and library path.
-fn create_library(
-    account_code: String,
-    library_path: &str,
-) -> Result<std::sync::Arc<Library>, Box<dyn std::error::Error>> {
-    let assembler: Assembler = TransactionKernel::assembler();
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        account_code,
-        source_manager.clone(),
-    )?;
-    let library = assembler.clone().assemble_library([module])?;
-    Ok(library)
-}
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize client
@@ -591,10 +527,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
 
     // Initialize keystore
-    let keystore_path = std::path::PathBuf::from("./keystore");
+    let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
-    let store_path = std::path::PathBuf::from("./store.sqlite3");
+    let store_path = PathBuf::from("./store.sqlite3");
 
     let mut client = ClientBuilder::new()
         .rpc(rpc_client)
@@ -643,14 +579,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 2] Creating a network counter smart contract");
 
-    let counter_code = fs::read_to_string(Path::new("../masm/accounts/counter.masm")).unwrap();
+    // `include_str!` resolves at compile time relative to this source file,
+    // so the binary is independent of the working directory it is run from.
+    let counter_code = include_str!("../masm/accounts/counter.masm");
 
     // Create the network counter smart contract account
     // First, compile the MASM code into an account component
     let counter_slot_name =
         StorageSlotName::new("miden::tutorials::counter").expect("valid slot name");
-    let component_code = CodeBuilder::new()
-        .compile_component_code("external_contract::counter_contract", &counter_code)
+    let component_code = client
+        .code_builder()
+        .compile_component_code("external_contract::counter_contract", counter_code)
         .unwrap();
     let counter_component = AccountComponent::new(
         component_code,
@@ -684,17 +623,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 3] Deploy network counter smart contract");
 
-    let script_code = fs::read_to_string(Path::new("../masm/scripts/counter_script.masm")).unwrap();
+    let script_code = include_str!("../masm/scripts/counter_script.masm");
 
-    let account_code = fs::read_to_string(Path::new("../masm/accounts/counter.masm")).unwrap();
-    let library_path = "external_contract::counter_contract";
-
-    let library = create_library(account_code, library_path).unwrap();
-
+    // Link the counter contract code into the same `CodeBuilder` chain that
+    // compiles the script.
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&library)?
-        .compile_tx_script(&script_code)?;
+        .with_linked_module("external_contract::counter_contract", counter_code)?
+        .compile_tx_script(script_code)?;
 
     let tx_increment_request = TransactionRequestBuilder::new()
         .custom_script(tx_script)
@@ -719,22 +655,18 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 4] Creating a network note for network counter contract");
 
-    let network_note_code =
-        fs::read_to_string(Path::new("../masm/notes/network_increment_note.masm")).unwrap();
-    let account_code = fs::read_to_string(Path::new("../masm/accounts/counter.masm")).unwrap();
-
-    let library_path = "external_contract::counter_contract";
-    let library = create_library(account_code, library_path).unwrap();
+    let network_note_code = include_str!("../masm/notes/network_increment_note.masm");
 
     // Create and submit the network note that will increment the counter
     // Generate a random serial number for the note
     let serial_num = client.rng().draw_word();
 
-    // Compile the note script with the counter contract library
+    // Compile the note script with the counter contract code linked as a
+    // module on the same `CodeBuilder` chain.
     let note_script = client
         .code_builder()
-        .with_dynamically_linked_library(&library)?
-        .compile_note_script(&network_note_code)?;
+        .with_linked_module("external_contract::counter_contract", counter_code)?
+        .compile_note_script(network_note_code)?;
 
     // Create note recipient with empty inputs
     let note_storage = NoteStorage::new([].to_vec())?;

--- a/versioned_docs/version-0.14/builder/tutorials/recipes/rust/oracle_tutorial.md
+++ b/versioned_docs/version-0.14/builder/tutorials/recipes/rust/oracle_tutorial.md
@@ -53,32 +53,24 @@ Copy and paste the following code into your `src/main.rs` file:
 
 ```rust no_run
 use miden_client::{
-    assembly::{
-        Assembler,
-        CodeBuilder,
-        DefaultSourceManager,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
+    account::{
+        component::AccountComponentMetadata, AccountBuilder, AccountComponent, AccountId,
+        AccountStorageMode, AccountType, StorageMapKey, StorageSlot, StorageSlotName,
     },
+    assembly::{
+        CodeBuilder, DefaultSourceManager, Module, ModuleKind, Path as AssemblyPath,
+    },
+    auth::NoAuth,
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{
-        domain::account::{AccountStorageRequirements, StorageMapKey},
+        domain::account::AccountStorageRequirements,
         Endpoint, GrpcClient,
     },
-    transaction::{ForeignAccount, TransactionRequestBuilder},
-    Client, ClientError,
+    transaction::{ForeignAccount, TransactionKernel, TransactionRequestBuilder},
+    Client, ClientError, Felt, Word, ZERO,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-use miden_client::{auth::NoAuth, transaction::TransactionKernel};
-use miden_client::{
-    account::{
-        component::AccountComponentMetadata, AccountComponent, AccountId, AccountStorageMode,
-        AccountType, StorageSlot, StorageSlotName, StorageSlotType,
-    },
-    Felt, Word, ZERO,
-};
 use rand::RngCore;
 use std::{fs, path::Path, sync::Arc};
 
@@ -88,99 +80,86 @@ use std::{fs, path::Path, sync::Arc};
 pub async fn get_oracle_foreign_accounts(
     client: &mut Client<FilesystemKeyStore>,
     oracle_account_id: AccountId,
-    trading_pair: u64,
+    faucet_pair: Word,
 ) -> Result<Vec<ForeignAccount>, ClientError> {
     client.import_account_by_id(oracle_account_id).await?;
+    client.sync_state().await?;
 
-    let oracle_account = client
+    let oracle_record = client
         .get_account(oracle_account_id)
         .await
         .expect("RPC failed")
         .expect("oracle account not found");
 
-    let storage = oracle_account.storage();
-    let publisher_count_slot = storage
-        .slots()
-        .iter()
-        .find(|slot| {
-            let name = slot.name().as_str();
-            name.contains("publisher") && name.contains("count")
-        })
-        .map(|slot| slot.name().clone())
-        .or_else(|| storage.slots().first().map(|slot| slot.name().clone()))
-        .expect("oracle storage is expected to have at least one slot");
+    let storage = oracle_record.storage();
 
-    let publisher_count = storage
-        .get_item(&publisher_count_slot)
-        .map(|word| word[0].as_canonical_u64())
-        .unwrap_or(0);
+    // The oracle tracks the next free publisher index in a value slot.
+    // Publisher slots start at index 2, so the publisher count is `next_index - 2`.
+    let next_index_slot =
+        StorageSlotName::new("pragma::oracle::next_publisher_index").expect("valid slot name");
+    let next_publisher_index = storage
+        .get_item(&next_index_slot)
+        .expect("oracle is missing the next_publisher_index slot")[0]
+        .as_canonical_u64();
 
-    let publisher_id_slots: Vec<StorageSlotName> = storage
-        .slots()
-        .iter()
-        .filter(|slot| slot.slot_type() == StorageSlotType::Value)
-        .filter(|slot| slot.name() != &publisher_count_slot)
-        .map(|slot| slot.name().clone())
-        .collect();
-
-    let publisher_ids: Vec<AccountId> = publisher_id_slots
-        .iter()
-        .take(publisher_count.saturating_sub(1) as usize)
-        .filter_map(|slot_name| storage.get_item(slot_name).ok())
-        .map(|digest| {
-            let words: Word = digest.into();
-            AccountId::new_unchecked([words[3], words[2]])
+    // Publisher account IDs are stored in the `publishers` map, keyed by index.
+    let publishers_slot =
+        StorageSlotName::new("pragma::oracle::publishers").expect("valid slot name");
+    let publisher_ids: Vec<AccountId> = (2..next_publisher_index)
+        .map(|index| {
+            let key: Word = [Felt::new(index), ZERO, ZERO, ZERO].into();
+            let publisher_word = storage
+                .get_map_item(&publishers_slot, key)
+                .expect("publisher entry missing from oracle storage");
+            AccountId::new_unchecked([publisher_word[0], publisher_word[1]])
         })
         .collect();
 
+    // Each publisher exposes its price entries in the `entries` map, keyed by
+    // the faucet ID word of the trading pair.
+    let entries_slot =
+        StorageSlotName::new("pragma::publisher::entries").expect("valid slot name");
     let mut foreign_accounts = Vec::with_capacity(publisher_ids.len() + 1);
-    let empty_keys: [StorageMapKey; 0] = [];
 
-    for pid in publisher_ids {
-        client.import_account_by_id(pid).await?;
+    for publisher_id in publisher_ids {
+        client.import_account_by_id(publisher_id).await?;
 
-        let publisher_account = client
-            .get_account(pid)
-            .await
-            .expect("RPC failed")
-            .expect("publisher account not found");
-        let map_slot_names: Vec<StorageSlotName> = publisher_account
-            .storage()
-            .slots()
-            .iter()
-            .filter(|slot| slot.slot_type() == StorageSlotType::Map)
-            .map(|slot| slot.name().clone())
-            .collect();
+        let storage_requirements = AccountStorageRequirements::new([(
+            entries_slot.clone(),
+            &[StorageMapKey::new(faucet_pair)],
+        )]);
 
-        let storage_requirements = AccountStorageRequirements::new(
-            map_slot_names
-                .iter()
-                .map(|slot_name| (slot_name.clone(), empty_keys.iter())),
-        );
-
-        foreign_accounts.push(ForeignAccount::public(pid, storage_requirements)?);
+        foreign_accounts.push(ForeignAccount::public(publisher_id, storage_requirements)?);
     }
 
+    // The oracle account itself is also a foreign account. `get_median` reads
+    // the publisher registry from the oracle's `publishers` map, so the proofs
+    // for those map keys must be requested as well.
+    let publisher_index_keys: Vec<StorageMapKey> = (2..next_publisher_index)
+        .map(|index| StorageMapKey::new([Felt::new(index), ZERO, ZERO, ZERO].into()))
+        .collect();
     foreign_accounts.push(ForeignAccount::public(
         oracle_account_id,
-        AccountStorageRequirements::default(),
+        AccountStorageRequirements::new([(publishers_slot.clone(), publisher_index_keys.iter())]),
     )?);
+
+    client.sync_state().await?;
 
     Ok(foreign_accounts)
 }
 
 fn create_library(
-    assembler: Assembler,
     library_path: &str,
     source_code: &str,
-) -> Result<std::sync::Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
+) -> Result<Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
     let source_manager = Arc::new(DefaultSourceManager::default());
+    let assembler = TransactionKernel::assembler_with_source_manager(source_manager.clone());
     let module = Module::parser(ModuleKind::Library).parse_str(
         AssemblyPath::new(library_path),
         source_code,
-        source_manager.clone(),
+        source_manager,
     )?;
-    let library = assembler.clone().assemble_library([module])?;
+    let library = assembler.assemble_library([module])?;
     Ok(library)
 }
 
@@ -211,14 +190,19 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     // Get all foreign accounts for oracle data
     // -------------------------------------------------------------------------
-    // The oracle account ID must be supplied as a CLI argument.
     let oracle_bech32 = std::env::args()
         .nth(1)
         .expect("Usage: oracle_data_query <ORACLE_BECH32_ID>");
     let (_, oracle_account_id) = AccountId::from_bech32(&oracle_bech32).unwrap();
-    let btc_usd_pair_id = 120195681;
+
+    // BTC/USD is identified by the faucet ID pair `1:0` (prefix 1, suffix 0).
+    // The faucet ID word is laid out as [0, 0, suffix, prefix].
+    let pair_prefix: u64 = 1;
+    let pair_suffix: u64 = 0;
+    let btc_usd_pair: Word =
+        [ZERO, ZERO, Felt::new(pair_suffix), Felt::new(pair_prefix)].into();
     let foreign_accounts: Vec<ForeignAccount> =
-        get_oracle_foreign_accounts(&mut client, oracle_account_id, btc_usd_pair_id).await?;
+        get_oracle_foreign_accounts(&mut client, oracle_account_id, btc_usd_pair).await?;
 
     println!(
         "Oracle accountId prefix: {:?} suffix: {:?}",
@@ -239,7 +223,10 @@ async fn main() -> Result<(), ClientError> {
         .unwrap();
     let contract_component = AccountComponent::new(
         contract_component_code,
-        vec![StorageSlot::with_value(contract_slot_name.clone(), Word::default())],
+        vec![StorageSlot::with_value(
+            contract_slot_name.clone(),
+            Word::default(),
+        )],
         AccountComponentMetadata::new("external_contract::oracle_reader", AccountType::all()),
     )
     .unwrap();
@@ -247,7 +234,7 @@ async fn main() -> Result<(), ClientError> {
     let mut seed = [0_u8; 32];
     client.rng().fill_bytes(&mut seed);
 
-    let oracle_reader_contract = miden_client::account::AccountBuilder::new(seed)
+    let oracle_reader_contract = AccountBuilder::new(seed)
         .account_type(AccountType::RegularAccountImmutableCode)
         .storage_mode(AccountStorageMode::Public)
         .with_component(contract_component.clone())
@@ -266,10 +253,9 @@ async fn main() -> Result<(), ClientError> {
     let script_path = Path::new("../masm/scripts/oracle_reader_script.masm");
     let script_code = fs::read_to_string(script_path).unwrap();
 
-    let assembler = TransactionKernel::assembler();
     let library_path = "external_contract::oracle_reader";
     let account_component_lib =
-        create_library(assembler.clone(), library_path, &contract_code).unwrap();
+        create_library(library_path, &contract_code).unwrap();
 
     let tx_script = client
         .code_builder()
@@ -302,10 +288,10 @@ async fn main() -> Result<(), ClientError> {
 
 _Don't run this code just yet, we still need to create our smart contract that queries the oracle_
 
-In the code above, we specified the Pragma oracle account id `0x4f67e78643022e00000220d8997e33` and the BTC/USD pair `120195681`. The `get_oracle_foreign_accounts` function returns all of the `ForeignAccounts` that you will need to execute the transaction to get the price data from the oracle. Since Pragma's oracle depends on multiple publishers, this function queries all of the publisher account ids required to make a successful FPI call.
+In the code above, the Pragma oracle account ID is provided as a command-line argument in bech32 form, and the BTC/USD price feed is identified by the faucet ID pair `1:0` (prefix `1`, suffix `0`). The `get_oracle_foreign_accounts` function returns all of the `ForeignAccount`s that you will need to execute the transaction to get the price data from the oracle. Since Pragma's oracle aggregates data from multiple publishers, this function reads the oracle's on-chain publisher registry and collects every publisher account id required to make a successful FPI call.
 
 :::note
-The oracle account ID, procedure hash, and trading pair ID used in this tutorial reference Pragma's testnet deployment. These values are maintained by Pragma and may change if they redeploy their oracle. For the latest values, check the [Pragma Miden repository](https://github.com/astraly-labs/pragma-miden).
+The oracle account ID, procedure hash, and faucet pair used in this tutorial reference Pragma's testnet deployment. These values are maintained by Pragma and may change if they redeploy their oracle. For the latest values, check the [Pragma Miden repository](https://github.com/astraly-labs/pragma-miden).
 :::
 
 ## Step 2: Build the price reader smart contract and script
@@ -322,7 +308,7 @@ mkdir -p masm/accounts masm/scripts
 
 This will create:
 
-```
+```text
 masm/
 ├── accounts/
 └── scripts/
@@ -336,37 +322,48 @@ The import `miden::tx` contains the `tx::execute_foreign_procedure` which we wil
 
 #### Here's a breakdown of what the `get_price` procedure does:
 
-1. Pushes `0.0.0.120195681` onto the stack, representing the BTC/USD pair in the Pragma oracle.
-2. Pushes `0xb86237a8c9cd35acfef457e47282cc4da43df676df410c988eab93095d8fb3b9` onto the stack which is the procedure root of the `get_median` procedure in the oracle.
-3. Pushes `939716883672832.2172042075194638080` onto the stack which is the oracle id prefix and suffix.
-4. Calls `tx::execute_foreign_procedure` which calls the `get_median` procedure via foreign procedure invocation.
+1. Pushes the 16 foreign procedure inputs that `tx::execute_foreign_procedure` requires. The first four are the arguments to `get_median` — the BTC/USD faucet ID prefix `1`, suffix `0`, an `amount` of `0`, and a trailing `0` — and the remaining twelve are zero padding.
+2. Pushes `0xd1aa2a8b38ccf58f37bb7aa490a8154c1cf89c537144ab23bd1111f13e5a28e8` onto the stack, which is the procedure root of the `get_median` procedure in the oracle.
+3. Pushes the Pragma oracle account ID prefix and suffix.
+4. Calls `tx::execute_foreign_procedure`, which invokes the `get_median` procedure via foreign procedure invocation. `get_median` returns `[is_tracked, median_price, amount]` on the stack.
 
 Inside of the `masm/accounts/` directory, create the `oracle_reader.masm` file:
 
 ```masm
+# The oracle account ID, procedure hash, and pair ID below reference
+# Pragma's testnet deployment (https://github.com/astraly-labs/pragma-miden).
+# If Pragma redeploys their oracle, these values must be updated.
+
 use miden::protocol::tx
 
 # Fetches the current price from the `get_median`
 # procedure from the Pragma oracle
 # => []
 pub proc get_price
-    push.0.0.0.120195681
-    # => [PAIR]
+    # `execute_foreign_procedure` requires exactly 16 foreign procedure inputs.
+    # `get_median` only reads the first four, so the rest are zero padding.
+    padw padw padw
+    # => [PAD(12)]
+
+    # BTC/USD pair: faucet id prefix `1`, suffix `0`, amount `0`
+    push.0.0.0.1
+    # => [pair_prefix, pair_suffix, amount, 0, PAD(12)]
 
     # This is the procedure root of the `get_median` procedure
-    push.0xb86237a8c9cd35acfef457e47282cc4da43df676df410c988eab93095d8fb3b9
-    # => [GET_MEDIAN_HASH, PAIR]
+    push.0xd1aa2a8b38ccf58f37bb7aa490a8154c1cf89c537144ab23bd1111f13e5a28e8
+    # => [GET_MEDIAN_HASH, FOREIGN_INPUTS(16)]
 
-    push.939716883672832.2172042075194638080
-    # => [oracle_id_prefix, oracle_id_suffix, GET_MEDIAN_HASH, PAIR]
+    # The Pragma oracle account id: prefix then suffix, leaving suffix on top
+    push.17041133956008732928.1562038061251555584
+    # => [oracle_id_suffix, oracle_id_prefix, GET_MEDIAN_HASH, FOREIGN_INPUTS(16)]
 
     exec.tx::execute_foreign_procedure
-    # => [price]
+    # => [is_tracked, median_price, amount, PAD(13)]
 
     debug.stack
-    # => [price]
+    # => [is_tracked, median_price, amount, PAD(13)]
 
-    dropw dropw
+    dropw dropw dropw dropw
 end
 ```
 
@@ -390,19 +387,18 @@ end
 
 Run the following command to execute src/main.rs:
 
-```
+```bash
 cargo run --release
 ```
 
 The output of our program will look something like this:
 
-```
-cleared sqlite store: ./store.sqlite3
-Latest block: 648397
-Oracle accountId prefix: V0(AccountIdPrefixV0 { prefix: 5721796415433354752 }) suffix: 599064613630720
-Stack state before step 8766:
-├──  0: 82655190335
-├──  1: 0
+```text
+Latest block: 806773
+Oracle accountId prefix: V0(AccountIdPrefixV0 { prefix: 17041133956008732928 }) suffix: 1562038061251555584
+Stack state before step 11449:
+├──  0: 1
+├──  1: 76307450000
 ├──  2: 0
 ├──  3: 0
 ├──  4: 0
@@ -420,12 +416,24 @@ Stack state before step 8766:
 ├── 16: 0
 ├── 17: 0
 ├── 18: 0
-└── 19: 0
+├── 19: 0
+├── 20: 0
+├── 21: 0
+├── 22: 0
+├── 23: 0
+├── 24: 0
+├── 25: 0
+├── 26: 0
+├── 27: 0
+├── 28: 0
+├── 29: 0
+├── 30: 0
+└── 31: 0
 
-View transaction on MidenScan: https://testnet.midenscan.com/tx/0xc8951190564d5c3ac59fe99d8911f8c17f5b59ba542e2eb860413898902f3722
+View transaction on MidenScan: https://testnet.midenscan.com/tx/0x28dbb2ea1270884701e8f4875032db675ab9dfff13c3caaa5e53adfcf56e383b
 ```
 
-As you can see, at the top of the stack is the price returned from the Pragma oracle. The price is returned with 6 decimal places. Currently Pragma only publishes the `BTC/USD` price feed on testnet.
+The `get_median` procedure leaves three values on the stack. Index `0` holds `is_tracked` — `1` when Pragma tracks the requested pair. Index `1` holds the median price; in the output above it is `76307450000`, which is `$76307.45` once the 6 decimal places are applied. Index `2` holds the `amount` value that was passed into the call. Pragma publishes several price feeds on testnet; this tutorial reads the `BTC/USD` feed.
 
 ### Running the tutorial
 

--- a/versioned_docs/version-0.14/builder/tutorials/recipes/rust/public_account_interaction_tutorial.md
+++ b/versioned_docs/version-0.14/builder/tutorials/recipes/rust/public_account_interaction_tutorial.md
@@ -41,10 +41,7 @@ miden-client = { version = "0.14", features = ["testing", "tonic"] }
 miden-client-sqlite-store = { version = "0.14", package = "miden-client-sqlite-store" }
 miden-protocol = { version = "0.14" }
 rand = { version = "0.9" }
-serde = { version = "1", features = ["derive"] }
-serde_json = { version = "1.0", features = ["raw_value"] }
 tokio = { version = "1.46", features = ["rt-multi-thread", "net", "macros", "fs"] }
-rand_chacha = "0.9.0"
 ```
 
 ## Step 2: Build the counter contract
@@ -121,18 +118,10 @@ end
 Copy and paste the following code into your `src/main.rs` file:
 
 ```rust no_run
-use miden_client::transaction::TransactionKernel;
-use std::{fs, path::Path, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 use miden_client::{
-    account::AccountId,
-    assembly::{
-        Assembler,
-        DefaultSourceManager,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
-    },
+    account::{AccountId, StorageSlotName},
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{Endpoint, GrpcClient},
@@ -140,21 +129,6 @@ use miden_client::{
     ClientError,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-
-fn create_library(
-    assembler: Assembler,
-    library_path: &str,
-    source_code: &str,
-) -> Result<std::sync::Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager.clone(),
-    )?;
-    let library = assembler.clone().assemble_library([module])?;
-    Ok(library)
-}
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -164,10 +138,10 @@ async fn main() -> Result<(), ClientError> {
     let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
 
     // Initialize keystore
-    let keystore_path = std::path::PathBuf::from("./keystore");
+    let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
-    let store_path = std::path::PathBuf::from("./store.sqlite3");
+    let store_path = PathBuf::from("./store.sqlite3");
 
     let mut client = ClientBuilder::new()
         .rpc(rpc_client)
@@ -241,26 +215,18 @@ Add the following code snippet to the end of your `src/main.rs` function:
 // -------------------------------------------------------------------------
 println!("\n[STEP 2] Call the increment_count procedure in the counter contract");
 
-// Load the MASM script referencing the increment procedure
-let script_path = Path::new("../masm/scripts/counter_script.masm");
-let script_code = fs::read_to_string(script_path).unwrap();
+// Load the MASM sources at compile time so the binary is independent of
+// the working directory it is run from.
+let script_code = include_str!("../masm/scripts/counter_script.masm");
+let counter_code = include_str!("../masm/accounts/counter.masm");
 
-let counter_path = Path::new("../masm/accounts/counter.masm");
-let counter_code = fs::read_to_string(counter_path).unwrap();
-
-let assembler = TransactionKernel::assembler();
-let account_component_lib = create_library(
-    assembler.clone(),
-    "external_contract::counter_contract",
-    &counter_code,
-)
-.unwrap();
-
+// Compile the script with the counter contract code linked as a module
+// on the same `CodeBuilder` chain.
 let tx_script = client
     .code_builder()
-    .with_dynamically_linked_library(&account_component_lib)
+    .with_linked_module("external_contract::counter_contract", counter_code)
     .unwrap()
-    .compile_tx_script(&script_code)
+    .compile_tx_script(script_code)
     .unwrap();
 
 // Build a transaction request with the custom script
@@ -302,18 +268,10 @@ println!(
 The final `src/main.rs` file should look like this:
 
 ```rust no_run
-use miden_client::transaction::TransactionKernel;
-use std::{fs, path::Path, sync::Arc};
+use std::{path::PathBuf, sync::Arc};
 
 use miden_client::{
-    account::AccountId,
-    assembly::{
-        Assembler,
-        DefaultSourceManager,
-        Module,
-        ModuleKind,
-        Path as AssemblyPath,
-    },
+    account::{AccountId, StorageSlotName},
     builder::ClientBuilder,
     keystore::FilesystemKeyStore,
     rpc::{Endpoint, GrpcClient},
@@ -321,21 +279,6 @@ use miden_client::{
     ClientError,
 };
 use miden_client_sqlite_store::ClientBuilderSqliteExt;
-
-fn create_library(
-    assembler: Assembler,
-    library_path: &str,
-    source_code: &str,
-) -> Result<std::sync::Arc<miden_client::assembly::Library>, Box<dyn std::error::Error>> {
-    let source_manager = Arc::new(DefaultSourceManager::default());
-    let module = Module::parser(ModuleKind::Library).parse_str(
-        AssemblyPath::new(library_path),
-        source_code,
-        source_manager.clone(),
-    )?;
-    let library = assembler.clone().assemble_library([module])?;
-    Ok(library)
-}
 
 #[tokio::main]
 async fn main() -> Result<(), ClientError> {
@@ -345,10 +288,10 @@ async fn main() -> Result<(), ClientError> {
     let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
 
     // Initialize keystore
-    let keystore_path = std::path::PathBuf::from("./keystore");
+    let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
-    let store_path = std::path::PathBuf::from("./store.sqlite3");
+    let store_path = PathBuf::from("./store.sqlite3");
 
     let mut client = ClientBuilder::new()
         .rpc(rpc_client)
@@ -390,26 +333,18 @@ async fn main() -> Result<(), ClientError> {
     // -------------------------------------------------------------------------
     println!("\n[STEP 2] Call the increment_count procedure in the counter contract");
 
-    // Load the MASM script referencing the increment procedure
-    let script_path = Path::new("../masm/scripts/counter_script.masm");
-    let script_code = fs::read_to_string(script_path).unwrap();
+    // Load the MASM sources at compile time so the binary is independent of
+    // the working directory it is run from.
+    let script_code = include_str!("../masm/scripts/counter_script.masm");
+    let counter_code = include_str!("../masm/accounts/counter.masm");
 
-    let counter_path = Path::new("../masm/accounts/counter.masm");
-    let counter_code = fs::read_to_string(counter_path).unwrap();
-
-    let assembler = TransactionKernel::assembler();
-    let account_component_lib = create_library(
-        assembler.clone(),
-        "external_contract::counter_contract",
-        &counter_code,
-    )
-    .unwrap();
-
+    // Compile the script with the counter contract code linked as a module
+    // on the same `CodeBuilder` chain.
     let tx_script = client
         .code_builder()
-        .with_dynamically_linked_library(&account_component_lib)
+        .with_linked_module("external_contract::counter_contract", counter_code)
         .unwrap()
-        .compile_tx_script(&script_code)
+        .compile_tx_script(script_code)
         .unwrap();
 
     // Build a transaction request with the custom script

--- a/versioned_docs/version-0.14/builder/tutorials/recipes/rust/unauthenticated_note_how_to.md
+++ b/versioned_docs/version-0.14/builder/tutorials/recipes/rust/unauthenticated_note_how_to.md
@@ -55,7 +55,7 @@ Alice ➡ Bob ➡ Charlie ➡ Dave ➡ Eve ➡ Frank ➡ ...
 ```rust no_run
 use miden_client::auth::{AuthSchemeId, AuthSingleSig};
 use rand::RngCore;
-use std::sync::Arc;
+use std::{path::PathBuf, sync::Arc};
 use tokio::time::{sleep, Duration, Instant};
 
 use miden_client::{
@@ -115,10 +115,10 @@ async fn main() -> Result<(), ClientError> {
     let rpc_client = Arc::new(GrpcClient::new(&endpoint, timeout_ms));
 
     // Initialize keystore
-    let keystore_path = std::path::PathBuf::from("./keystore");
+    let keystore_path = PathBuf::from("./keystore");
     let keystore = Arc::new(FilesystemKeyStore::new(keystore_path).unwrap());
 
-    let store_path = std::path::PathBuf::from("./store.sqlite3");
+    let store_path = PathBuf::from("./store.sqlite3");
 
     let mut client = ClientBuilder::new()
         .rpc(rpc_client)


### PR DESCRIPTION
## Summary

Refreshes the v0.14 rust tutorial snapshot (`versioned_docs/version-0.14/builder/tutorials/recipes/rust/`) to match the current `0xMiden/tutorials` `main` branch. The versioned snapshot was never redone after release, so the rendered v0.14 tutorials — most visibly the Pragma oracle tutorial flagged on Slack — were stale relative to the code that actually runs on testnet. Only `main` maps to the docs "next"/unreleased version, so upstream fixes never reach the v0.14 version until the snapshot is redone.

## Why this is safe for v0.14

`tutorials@main` pins `miden-client = "0.14"` and `miden-protocol = "0.14"` — main has not begun the v15 migration, so every tutorial on it is v0.14-compatible. Each page is copied verbatim from main (the same content CI ingests into the unreleased docs version).

## Changes

All 12 rust recipe pages refreshed verbatim from `tutorials@main` (914dd0f):

- `oracle_tutorial` (the reported one)
- `network_transactions_tutorial`
- `counter_contract_tutorial`
- `foreign_procedure_invocation_tutorial`
- `public_account_interaction_tutorial`
- `mappings_in_masm_how_to`
- `creating_notes_in_masm_tutorial`
- `create_deploy_tutorial`
- `custom_note_how_to`
- `delegated_proving_tutorial`
- `mint_consume_create_tutorial`
- `unauthenticated_note_how_to`

## Verification

- Each page byte-identical to its `tutorials@main` source.
- Link check across all 12 pages: zero net-new broken links. The single filesystem-unresolved link (`../miden_node_setup.md`) is byte-identical to the prior snapshot and resolved via `plugin-client-redirects`.
- Only the versioned snapshot is touched; web recipes were already current.
- This exact content already builds and renders on the unreleased docs version via CI, so it builds identically in v0.14.

## Test plan

- [ ] Build the docs site and confirm `[SUCCESS]` with no new broken links/anchors on the v0.14 rust tutorial pages.
- [ ] Spot-check the rendered v0.14 oracle tutorial matches the testnet-validated flow.

## Out of scope

- `bridging_with_epoch_tutorial.md` — a new web tutorial on main with no v0.14 equivalent; adding it is an IA change, not a staleness fix.
- The miden-bank example is also stale and v0.14-pinned; deferred to its own PR.
