### PR TITLE
docs(migration): add v0.15 migration guide

### DIFF
--- a/docs/builder/migration/01-imports-dependencies.md
+++ b/docs/builder/migration/01-imports-dependencies.md
@@ -1,107 +1,133 @@
 ---
 sidebar_position: 1
 title: "Imports & Dependencies"
-description: "Crate version bumps, import relocations, and MSRV changes in v0.14"
+description: "Crate version bumps, MSRV changes, and the non-round-tripping 0.14 artifacts in v0.15"
 ---
 
 # Imports & Dependencies
 
 :::warning Breaking Change
-Miden VM dependencies move from 0.20 to 0.22 and `miden-crypto` from 0.19 to 0.23. Several types have been relocated across crates, and `Felt::as_int()` has been renamed.
+Miden VM dependencies move from 0.22 to 0.23 and `miden-crypto` from 0.23 to 0.25. The protocol crates move from 0.14 to **0.15.3** and `miden-client` from 0.14 to 0.15, and the client's MSRV is now Rust **1.93**. Because the native hash and the MAST/serialization formats changed, **0.14 artifacts (accounts, notes, proofs, serialized stores, `.masl`/`.masp` packages) do not round-trip.**
 :::
 
 ## Quick Fix
 
 ```toml title="Cargo.toml"
 # Replace these
-miden-protocol  = "0.13"
-miden-standards = "0.13"
-miden-assembly  = "0.20"
-miden-core      = "0.20"
-miden-processor = "0.20"
-miden-prover    = "0.20"
-miden-crypto    = "0.19"
+miden-client              = "0.14"
+miden-client-sqlite-store = "0.14"
+miden-protocol            = "0.14"
+miden-standards           = "0.14"
+miden-tx                  = "0.14"
+miden-assembly            = "0.22"
+miden-core                = "0.22"
+miden-core-lib            = "0.22"
+miden-processor           = "0.22"
+miden-prover              = "0.22"
+miden-crypto              = "0.23"
 
 # With these
-miden-protocol  = "0.14"
-miden-standards = "0.14"
-miden-assembly  = "0.22"
-miden-core      = "0.22"
-miden-processor = "0.22"
-miden-prover    = "0.22"
-miden-crypto    = "0.23"
+miden-client              = "0.15"
+miden-client-sqlite-store = "0.15"
+miden-protocol            = "0.15.3"
+miden-standards           = "0.15.3"
+miden-tx                  = "0.15.3"
+miden-assembly            = "0.23"
+miden-core                = "0.23"
+miden-core-lib            = "0.23"
+miden-processor           = "0.23"
+miden-prover              = "0.23"
+miden-crypto              = "0.25"
 ```
+
+---
+
+## Summary
+
+Every Miden crate moves up a minor: the protocol crates (`miden-protocol`, `miden-standards`, `miden-tx`, `miden-testing`) go `0.14` → `0.15.3`, the VM crates (`miden-assembly`, `miden-core`, `miden-core-lib`, `miden-processor`, `miden-prover`) go `0.22` → `0.23`, and `miden-crypto` goes `0.23` → `0.25`. `miden-client` and `miden-client-sqlite-store` go `0.14` → `0.15`; the Web SDK packages go `0.14` → `0.15`. The client's MSRV is Rust **1.93** (the base crates build on 1.90+).
+
+> The prover crate is **`miden-prover`** in this line — it is *not* `miden-prove`. Keep depending on `miden-prover`.
+
+Because the native hash and the MAST/serialization formats changed upstream, **0.14 artifacts (accounts, notes, proofs, serialized stores, `.masl`/`.masp` packages) do not round-trip.** Re-assemble from source and re-sync into a fresh store.
 
 ---
 
 ## Version Bumps
 
-| Crate | v0.13 | v0.14 |
+| Crate | v0.14 | v0.15 |
 |-------|-------|-------|
-| `miden-protocol` | 0.13 | 0.14 |
-| `miden-standards` | 0.13 | 0.14 |
-| `miden-assembly` | 0.20 | 0.22 |
-| `miden-core` | 0.20 | 0.22 |
-| `miden-core-lib` | 0.20 | 0.22 |
-| `miden-processor` | 0.20 | 0.22 |
-| `miden-prover` | 0.20 | 0.22 |
-| `miden-crypto` | 0.19 | 0.23 |
+| `miden-client` | 0.14 | 0.15 |
+| `miden-client-sqlite-store` | 0.14 | 0.15 |
+| `miden-protocol` | 0.14 | 0.15.3 |
+| `miden-standards` | 0.14 | 0.15.3 |
+| `miden-tx` | 0.14 | 0.15.3 |
+| `miden-assembly` | 0.22 | 0.23 |
+| `miden-core` | 0.22 | 0.23 |
+| `miden-core-lib` | 0.22 | 0.23 |
+| `miden-processor` | 0.22 | 0.23 |
+| `miden-prover` | 0.22 | 0.23 |
+| `miden-crypto` | 0.23 | 0.25 |
 
 ---
 
-## `ExecutionOptions`, `ProvingOptions`, `ExecutionProof` Relocated
+## Affected Code
 
-These types moved out of `miden-air` into their respective crates:
-
-```rust
-// Before (0.13)
-use miden_air::{ExecutionOptions, ProvingOptions, ExecutionProof};
-
-// After (0.14)
-use miden_processor::ExecutionOptions;
-use miden_prover::ProvingOptions;
-use miden_core::ExecutionProof;
+**Cargo.toml:**
+```diff
+- miden-client              = "0.14"
+- miden-client-sqlite-store = "0.14"
+- miden-protocol            = "0.14"
+- miden-standards           = "0.14"
+- miden-tx                  = "0.14"
+- miden-assembly            = "0.22"
+- miden-core                = "0.22"
+- miden-core-lib            = "0.22"
+- miden-processor           = "0.22"
+- miden-prover              = "0.22"
+- miden-crypto              = "0.23"
++ miden-client              = "0.15"
++ miden-client-sqlite-store = "0.15"
++ miden-protocol            = "0.15.3"
++ miden-standards           = "0.15.3"
++ miden-tx                  = "0.15.3"
++ miden-assembly            = "0.23"
++ miden-core                = "0.23"
++ miden-core-lib            = "0.23"
++ miden-processor           = "0.23"
++ miden-prover              = "0.23"
++ miden-crypto              = "0.25"
 ```
 
----
-
-## `Felt::as_int()` → `Felt::as_canonical_u64()`
-
-The `Felt::as_int()` method has been renamed to `Felt::as_canonical_u64()` for clarity:
-
-```rust
-// Before (0.13)
-let value: u64 = felt.as_int();
-
-// After (0.14)
-let value: u64 = felt.as_canonical_u64();
+**package.json (Web SDK):**
+```diff
+- "@miden-sdk/miden-sdk": "^0.14.0",
+- "@miden-sdk/react": "^0.14.0",
+- "miden-idxdb-store": "^0.14.0"
++ "@miden-sdk/miden-sdk": "^0.15.0",
++ "@miden-sdk/react": "^0.15.0",
++ "miden-idxdb-store": "^0.15.0"
 ```
-
-:::tip
-Use find-and-replace across your codebase: `as_int()` → `as_canonical_u64()`.
-:::
 
 ---
 
 ## MSRV (Minimum Supported Rust Version)
 
-If you depend on `miden-client`, update your `rust-toolchain.toml` to Rust **1.91**:
+If you depend on `miden-client`, update your `rust-toolchain.toml` to Rust **1.93** (the base crates build on 1.90+):
 
 ```toml title="rust-toolchain.toml"
 [toolchain]
-channel = "1.91"
+channel = "1.93"
 ```
 
 ---
 
 ## Migration Steps
 
-1. Bump every Miden crate version in `Cargo.toml` per the table above.
-2. Move imports of `ExecutionOptions`, `ProvingOptions`, `ExecutionProof` to their new homes.
-3. Replace all `Felt::as_int()` calls with `Felt::as_canonical_u64()`.
-4. If you depend on `miden-client`, update your `rust-toolchain.toml` to Rust 1.91.
-5. Run `cargo update` to pull the new versions.
-6. Run `cargo build` and fix any remaining import errors.
+1. Bump every Miden crate per the table above and run `cargo update` to pull the matching `miden-crypto 0.25` and VM `0.23` minors.
+2. Do **not** rename `miden-prover` to `miden-prove`.
+3. Set the client toolchain to at least Rust `1.93`.
+4. Bump `@miden-sdk/miden-sdk`, `@miden-sdk/react`, and `miden-idxdb-store` to `^0.15.0` together — a mix of 0.14/0.15 packages will not link against the shared WASM ABI.
+5. Point the client at a `0.15` node (the protocol version is negotiated at connect; a mismatch is rejected), and re-sync into a fresh store.
 
 ---
 
@@ -109,6 +135,6 @@ channel = "1.91"
 
 | Error Message | Cause | Solution |
 | --- | --- | --- |
-| `unresolved import miden_air::ExecutionOptions` | Type moved | Import from `miden_processor::ExecutionOptions`. |
-| `no method named as_int found for Felt` | Method renamed | Use `Felt::as_canonical_u64()`. |
-| `package requires rustc 1.91` | MSRV bumped | Update toolchain. |
+| `failed to select a version for miden-prove` | Crate not renamed in 0.15 | Keep depending on `miden-prover`. |
+| `MastForest deserialization failed: unexpected version` | MAST wire format bumped to `0.0.3` | Re-assemble every `.masl`/`.masp` from source under `0.23`. |
+| node version negotiation failure | `0.15` client against a `0.14` node | Upgrade the node to `0.15`. |

--- a/docs/builder/migration/02-hashing-stack.md
+++ b/docs/builder/migration/02-hashing-stack.md
@@ -1,117 +1,110 @@
 ---
 sidebar_position: 2
-title: "Hashing & Stack Changes"
-description: "Poseidon2 hash function, little-endian stack, and Falcon module rename in v0.14"
+title: "Hashing, SMT & Crypto Changes"
+description: "SMT leaf domain separation, miden-crypto 0.25, and downstream crypto renames in v0.15"
 ---
 
-# Hashing & Stack Changes
+# Hashing, SMT & Crypto Changes
 
 :::warning Breaking Change
-The native hash function changed from RPO to Poseidon2, and the operand stack is now little-endian. These are the most fundamental changes in v0.14 — every digest and every multi-limb operation is affected.
+SMT leaf hashing now mixes a Poseidon2 leaf-domain separator into the capacity word, and `miden-crypto` bumped to `0.25`. These are digest-changing: persisted SMT roots, leaf digests, and `PartialSmt` values from earlier versions do not round-trip.
 :::
 
 ---
 
-## Native Hash Function: RPO → Poseidon2
+## SMT leaf hashing switched to Poseidon2 domain separation
 
 ### Summary
 
-The VM's native sponge hash flipped from RPO to Poseidon2. Rust type names (`Word`, `Hasher`, digests) are unchanged but **every digest the VM produces is different**: MAST roots, advice-map keys derived from hashing, account/note commitments, transaction IDs — none of them roundtrip with 0.13 artifacts.
-
-### Migration Steps
-
-1. Re-assemble every `.masl` and `.masp` from source under 0.22 (the MAST format version was bumped — old serialized forests will not deserialize anyway).
-2. Re-derive any persisted commitments (account commitments, note commitments, advice-map keys, MAST roots).
-3. Discard any cached transaction IDs, proven transactions, and proofs from 0.13.
-4. If you hard-coded MAST root literals in tests, regenerate them.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `MastForest deserialization failed: unexpected version` | MAST format version bumped along with the hash change | Re-assemble from source under 0.22. |
-| `transaction id mismatch` / `account commitment mismatch` | Old digest computed under RPO | Recompute from current state under 0.14. |
-
----
-
-## Operand Stack Is Little-Endian
-
-### Summary
-
-Every multi-limb operation in the VM was unified around **"low limb closest to the top of the stack"**. Before 0.14 conventions were mixed: `u64` lived on the stack as `[hi, lo]`, `hperm` consumed `[R1, R0, C]` and produced its digest at indices 4..8, `mem_stream` returned words with the address-highest word on top. After 0.14 the low-significance limb is always on top: `u64` is `[lo, hi]`, `hperm` takes `[R0, R1, C]` with the digest at indices 0..4, and `mem_stream` returns the words in address-ascending order.
-
-This affects MASM that uses `u32split`, `u32widening_mul`, `u32madd`, `hperm`, `hmerge`, `mem_stream`, `adv_pipe`, `adv.insert_hdword`, `adv.insert_hdword_d`, `adv.insert_hqword`, `adv.insert_hperm`, all of `std::math::u64`, all of `std::math::u256`, and `ext2` extension-field values.
+The core library's Sparse Merkle Tree leaf hashing (`miden::core` `collections::smt`) now mixes a leaf‑domain separator into the Poseidon2 capacity word, so MASM‑side leaf digests match `SmtLeaf::hash()` in `miden-crypto`. Leaf preimages are hashed with `poseidon2::merge_in_domain` using `LEAF_DOMAIN = 0x13af`. This is a **digest‑changing** change: any SMT leaf digest, SMT root, or advice‑map key derived from MASM‑side leaf hashing under `0.22` will not reproduce under `0.23`. It pairs with the `miden-crypto 0.25` bump.
 
 ### Affected Code
 
-**MASM (u64 add):**
-```masm
-# Before (0.13): [b_hi, b_lo, a_hi, a_lo, ...] -> [c_hi, c_lo, ...]
-push.0.0xFFFFFFFF push.0.1
-exec.::std::math::u64::wrapping_add
-
-# After (0.14): [b_lo, b_hi, a_lo, a_hi, ...] -> [c_lo, c_hi, ...]
-push.0xFFFFFFFF.0 push.1.0
-exec.::std::math::u64::wrapping_add
+**MASM (core‑lib `collections::smt`, simplified):**
+```diff
+- exec.poseidon2::merge assert_eqw
++ push.LEAF_DOMAIN exec.poseidon2::merge_in_domain assert_eqw
 ```
-
-**MASM (`hperm` and digest extraction):** the input is now `[R0, R1, C, ...]` (was `[R1, R0, C, ...]`) and the digest comes out at indices `0..4` (was `4..8`).
-
-**MASM (`hmerge`):** input is now `[A, B, ...] -> [hash(A || B), ...]` (was `[B, A, ...]`).
-
-**Rust (`StackInputs` / `StackOutputs`):**
-
-For `StackInputs::try_from_ints([1, 2, 3, 4])` the first element (`1`) is the top of the stack — no reversal. When seeding a `u64`, push `[lo, hi]`, not `[hi, lo]`. Same when reading `StackOutputs`: `stack[0]` is the top.
+The per‑leaf cycle cost also changed (the `pair_count` coefficient went from `3` to `6`), so any hard‑coded cycle‑count expectations around `smt::get` / `smt::set` need updating.
 
 ### Migration Steps
 
-1. Audit every MASM call into `std::math::u64` / `u256` and flip the limb order in adjacent `push`/`movdn`/`movup` instructions.
-2. Audit every `hperm`/`hmerge` site and update the index where you extract the digest (it moved from `[4..8]` to `[0..4]`).
-3. Audit `mem_stream` / `adv_pipe` users — the word at the address now lands on top, not buried.
-4. In Rust, drop any `[Felt; 16]` reversal helpers you used to construct stacks "in pretty order".
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `assertion failed: ...` (off-by-one in u64 arithmetic) | Limb order flipped | Push `[lo, hi]` instead of `[hi, lo]`. |
-| `expected hash 0x... at clock cycle ...` | Digest at wrong stack offset | The digest is now at indices 0..4, not 4..8. |
+1. Re‑derive every persisted SMT root, leaf digest, and advice‑map key computed from a MASM‑side SMT leaf hash under `0.22`.
+2. If you compute SMT leaf digests in Rust via `miden-crypto`, upgrade to `0.25` so both sides agree.
+3. Discard cached proofs / transaction artifacts whose witnesses depend on the old leaf hashing.
 
 ---
 
-## Falcon Module Rename
+## `miden-crypto` 0.25 downstream renames
 
 ### Summary
 
-Because the native hash flipped to Poseidon2, the Falcon-512 verifier was rewritten and renamed. The MASM module path moved to `miden::core::crypto::dsa::falcon512_poseidon2` and the Rust auth scheme variant is `Falcon512Poseidon2`.
+Bumping to `miden-crypto 0.25` (and `miden-vm 0.23`) surfaces several renames in code that builds against the protocol crates directly:
+
+- `Felt::new(n)` call sites that want the previous (non‑reducing) behaviour are now **`Felt::new_unchecked(n)`** (`Felt::new` now reduces modulo the field).
+- The ECDSA secret key type `ecdsa_k256_keccak::SecretKey` is renamed **`SigningKey`**; the EdDSA/X25519 key `eddsa_25519_sha512::SecretKey` is **`KeyExchangeKey`**. Falcon's `falcon512_poseidon2::SecretKey` is unchanged.
+- The kernel's `EMPTY_SMT_ROOT` constant was recomputed for the Plonky3‑aligned Poseidon2 and the domain‑separated `SmtLeaf::hash` — any hard‑coded SMT‑root literal changes.
+- In kernel/standards MASM, the immediate form of `adv_push` was dropped and cross‑module‑referenced MASM constants/procedures must be marked `pub`.
 
 ### Affected Code
 
-**MASM:**
-```masm
-# Before (0.13)
-use.miden::core::crypto::dsa::falcon512rpo
-exec.falcon512rpo::verify
-
-# After (0.14)
-use.miden::core::crypto::dsa::falcon512_poseidon2
-exec.falcon512_poseidon2::verify
+```diff
+- let f = Felt::new(value);
+- use miden_protocol::crypto::dsa::ecdsa_k256_keccak::SecretKey;
+- use miden_protocol::crypto::dsa::eddsa_25519_sha512::SecretKey as EdSecretKey;
++ let f = Felt::new_unchecked(value);
++ use miden_protocol::crypto::dsa::ecdsa_k256_keccak::SigningKey;
++ use miden_protocol::crypto::dsa::eddsa_25519_sha512::KeyExchangeKey;
 ```
 
-**Rust:**
-```rust
-// Before (0.13)
-use miden_protocol::account::auth::AuthScheme;
-let scheme = AuthScheme::Falcon512Rpo;
+### Migration Steps
 
-// After (0.14)
-use miden_protocol::account::auth::AuthScheme;
-let scheme = AuthScheme::Falcon512Poseidon2;
-```
+1. Replace `Felt::new(...)` with `Felt::new_unchecked(...)` where you relied on the non‑reducing constructor.
+2. Rename `ecdsa_k256_keccak::SecretKey` → `SigningKey` and `eddsa_25519_sha512::SecretKey` → `KeyExchangeKey`.
+3. Mark any cross‑module‑referenced MASM constants/procedures `pub`, and regenerate hard‑coded `EMPTY_SMT_ROOT` / SMT‑root literals.
 
-### Common Errors
+---
 
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `unknown module miden::core::crypto::dsa::falcon512rpo` | Module renamed | Use `falcon512_poseidon2`. |
-| `no variant or associated item named Falcon512Rpo for AuthScheme` | Variant renamed | Use `AuthScheme::Falcon512Poseidon2`. |
+## `PartialSmt` serialization changed
+
+### Summary
+
+In `miden-crypto 0.25` the serialized byte layout of `PartialSmt` changed. Old serialized `PartialSmt` values are **not compatible** with `0.25` and will not deserialize correctly.
+
+### Migration Steps
+
+1. Discard any `PartialSmt` values serialized under an earlier `miden-crypto`.
+2. Rebuild them from current state, or re‑fetch them under `0.25`.
+
+---
+
+## Custom `LargeSmt` storage backends: reads move to `SmtStorageReader`
+
+### Summary
+
+Custom `LargeSmt` storage backends need a small trait update: reads moved to a dedicated **`SmtStorageReader`**. Writable storage still implements `SmtStorage`, but now also sets an associated `type Reader` and returns a point‑in‑time reader via `reader()`. Read operations go through `SmtStorageReader` rather than the writable `SmtStorage` directly.
+
+### Migration Steps
+
+1. Keep your writable backend implementing `SmtStorage`, and add the associated `type Reader` plus a `reader()` method that returns a point‑in‑time `SmtStorageReader`.
+2. Move read operations onto the `SmtStorageReader` returned by `reader()`.
+
+---
+
+## Direct `miden-crypto` 0.24 API breaks
+
+### Summary
+
+For the rare consumers that depend on `miden-crypto` directly, the `0.24` step carries a few additional API breaks:
+
+- The `WORD_SIZE`, `WORD_SIZE_FELTS`, and `WORD_SIZE_BYTES` constants moved to **`Word::NUM_ELEMENTS`** / **`Word::SERIALIZED_SIZE`**.
+- `LexicographicWord` is now just **`Word`**.
+- `Felt` no longer derefs.
+- Custom multi‑AIR prover/verifier code must handle `StarkProof` log trace heights and `air_order`.
+
+### Migration Steps
+
+1. Replace `WORD_SIZE` / `WORD_SIZE_FELTS` with `Word::NUM_ELEMENTS` and `WORD_SIZE_BYTES` with `Word::SERIALIZED_SIZE`.
+2. Replace `LexicographicWord` with `Word`.
+3. Remove any reliance on `Felt`'s `Deref`; access the inner value explicitly.
+4. If you maintain custom multi‑AIR prover/verifier code, update it to handle `StarkProof` log trace heights and `air_order`.

--- a/docs/builder/migration/03-account-changes.md
+++ b/docs/builder/migration/03-account-changes.md
@@ -1,342 +1,100 @@
 ---
 sidebar_position: 3
 title: "Account Changes"
+description: "AccountType/AccountStorageMode rework, network-account allowlist, typed roots, and auth/policy renames in v0.15"
 ---
 
 # Account Changes
 
 :::warning Breaking Change
-The v0.14 release introduces significant breaking changes to account construction, authentication components, and related APIs. All of the changes below require code updates when migrating from v0.13.
+The v0.15 release simplifies the account ID so that its prefix no longer encodes whether the account is a faucet or regular account, whether its code is mutable, or whether it is a network account. The old `AccountType` enum is removed, `AccountStorageMode` is renamed to `AccountType` (`{ Private, Public }`), and the account ID version is renamed `0` → `1`. All of the changes below require code updates when migrating from v0.14.
 :::
 
-## `AccountComponent::new` requires `AccountComponentMetadata`
+## `AccountType` removed; `AccountStorageMode` renamed to `AccountType`
 
 ### Summary
 
-`AccountComponent::new` previously accepted two arguments (library, storage slots). It now requires a third argument: an `AccountComponentMetadata` value that describes the component's name and supported account types. The builder methods `with_metadata`, `with_supported_type`, and `with_supports_all_types` have been removed. Additionally, `AccountComponentTemplateError` has been renamed to `ComponentMetadataError`.
+The account ID was simplified so its prefix no longer encodes whether the account is a faucet/regular account or whether its code is mutable. As a result:
+
+- The old `AccountType` enum (`FungibleFaucet`, `NonFungibleFaucet`, `RegularAccountImmutableCode`, `RegularAccountUpdatableCode`) is **removed**.
+- `AccountStorageMode` is **renamed to `AccountType`** and trimmed to `{ Private, Public }` (the `Network` variant is gone — see the next section).
+- The `AccountId` accessors `is_faucet()`, `is_regular_account()`, `storage_mode()`, `is_network()`, and the old `account_type()` semantics no longer exist. `AccountId::account_type()` now returns the visibility‑style `AccountType` (`Private`/`Public`).
+- The account ID **version is renamed 0 → 1**; encoded version `0` is now invalid.
+
+Faucet‑vs‑regular is now a property of the account's *code/components*, not its ID.
 
 ### Affected Code
 
-Before:
-
 ```rust
-let component = AccountComponent::new(library, storage_slots)?
-    .with_supports_all_types();
+// 0.15 — new API:
+use miden_protocol::account::AccountType;                      // formerly AccountStorageMode
+let kind: AccountType = account_id.account_type();             // Private / Public
+let is_pub = account_id.is_public();
+// "is this a faucet?" now comes from the account's code/interface, not the id.
 ```
-
-After:
-
-```rust
-let metadata = AccountComponentMetadata::new(
-    "my-component",
-    AccountType::all(),
-)?;
-
-let component = AccountComponent::new(library, storage_slots, metadata)?;
-```
+`AccountId::new(seed, version, ..)` keeps the same parameters, but `version` must be `AccountIdVersion::Version1` (`Version0` no longer exists).
 
 ### Migration Steps
 
-1. Create an `AccountComponentMetadata` instance with a name and the set of supported `AccountType` values.
-2. Pass the metadata as the third argument to `AccountComponent::new`.
-3. Remove any chained calls to `with_supports_all_types()`, `with_supported_type()`, or `with_metadata()`.
-4. Replace references to `AccountComponentTemplateError` with `ComponentMetadataError`.
+1. Replace imports of `AccountStorageMode` with `AccountType`; the variants are `Private` / `Public`.
+2. Delete the old `AccountType` import (`Regular*`/`*Faucet`); that enum is gone.
+3. Replace `id.storage_mode()` with `id.account_type()` (or `id.is_public()` / `id.is_private()`).
+4. Replace `id.is_faucet()` / `id.is_regular_account()` with checks on the account's code/components.
+5. Replace `AccountIdVersion::Version0` with `Version1`; regenerate any persisted account IDs.
 
-### Common Errors
+---
 
-| Error Message | Cause | Solution |
-|---|---|---|
-| `expected 3 arguments, found 2` | Missing metadata argument | Add `AccountComponentMetadata` as the third argument |
-| `no method named with_supports_all_types` | Removed builder method | Use `AccountType::all()` in metadata constructor |
-| `AccountComponentTemplateError not found` | Type renamed | Replace with `ComponentMetadataError` |
-
-## Auth components consolidated into `AuthSingleSig`
+## `AccountStorageMode::Network` removed; network accounts via an allowlist
 
 ### Summary
 
-The six per-scheme authentication types (`AuthFalcon512Rpo`, `AuthFalcon512Poseidon2`, `AuthEcdsaK256Keccak`, `AuthEcdsaK256Rpx`, `AuthEcdsaB256Rpx`, `AuthEcdsaB256Poseidon2`) have been replaced by a single `AuthSingleSig` component that accepts an `AuthScheme` enum. The corresponding ACL type `AuthSingleSigAcl` and multisig type `AuthMultisig` follow the same pattern.
-
-### Affected Code
-
-Before:
-
-```rust
-// Falcon-based auth
-let auth_component: AccountComponent = AuthFalcon512Rpo::new(pk_commitment).into();
-
-// ECDSA-based auth
-let auth_component: AccountComponent = AuthEcdsaK256Keccak::new(pk_commitment).into();
-```
-
-After:
-
-```rust
-// Falcon-based auth
-let auth_component: AccountComponent =
-    AuthSingleSig::new(pk_commitment, AuthScheme::Falcon512Poseidon2).into();
-
-// ECDSA-based auth
-let auth_component: AccountComponent =
-    AuthSingleSig::new(pk_commitment, AuthScheme::EcdsaK256Keccak).into();
-```
+The `Network` storage mode was removed (`AccountStorageMode` itself is now `AccountType`). An account is now recognised as a network account by the presence of a standardized **`NetworkAccountNoteAllowlist`** storage slot, with helpers `NetworkAccount` (a wrapper for identification) and the `AuthNetworkAccount` auth component. `AccountId::is_network()` is gone.
 
 ### Migration Steps
 
-1. Replace all per-scheme auth constructors with `AuthSingleSig::new(pk_commitment, AuthScheme::...)`.
-2. Choose the correct `AuthScheme` variant that matches the old type name.
-3. Update ACL components to use `AuthSingleSigAcl` and multisig components to use `AuthMultisig`.
+1. Remove any use of `AccountStorageMode::Network`; pick `Public` and add the network‑account components (`AuthNetworkAccount::with_allowed_notes(...)`).
+2. Replace `id.is_network()` with `NetworkAccount::new(account)` / the `NetworkAccountNoteAllowlist` slot check.
 
-## `@auth_script` MASM attribute replaces `auth_` prefix
+---
+
+## `AuthNetworkAccount` gains a tx‑script allowlist
 
 ### Summary
 
-Authentication procedures in MASM are no longer identified by a naming convention (`auth_` prefix). Instead, exactly one procedure per auth component must be annotated with the `@auth_script` attribute.
-
-### Affected Code
-
-Before:
-
-```masm
-use.miden::standards::auth::falcon512_rpo
-
-export.auth_tx_falcon512_rpo
-    exec.falcon512_rpo::authenticate
-end
-```
-
-After:
-
-```masm
-use.miden::standards::auth::signature
-
-@auth_script
-export.auth_tx
-    exec.signature::authenticate
-end
-```
+*(v0.15.2)* The `AuthNetworkAccount` auth component previously banned transaction scripts outright. It now gates them with a **root allowlist**, so approved tx scripts (e.g. setting the expiration delta) can run. The note‑allowlist constructor `with_allowlist` was renamed to **`with_allowed_notes`** to pair with the new **`with_allowed_tx_scripts`** setter.
 
 ### Migration Steps
 
-1. Replace the scheme-specific `use` import with `use.miden::standards::auth::signature`.
-2. Add the `@auth_script` attribute on the line before the procedure declaration.
-3. Rename the procedure to remove scheme-specific suffixes (e.g., `auth_tx_falcon512_rpo` becomes `auth_tx`).
-4. Replace the scheme-specific `exec` call with `exec.signature::authenticate`.
+1. Rename `AuthNetworkAccount::with_allowlist(...)` to `with_allowed_notes(...)`.
+2. To permit specific transaction scripts, chain `.with_allowed_tx_scripts(roots)` (an empty set — the default — permits none).
 
-## `AccountComponent::get_procedures()` replaced by `procedures()`
+---
+
+## `procedure_digest!` → `procedure_root!`; new `NoteScriptRoot` / `AccountComponentName`
 
 ### Summary
 
-The method `get_procedures()` has been renamed to `procedures()` and now returns an iterator instead of a `Vec<(Word, bool)>`. The `is_auth` flag is now derived from the `@auth_script` attribute rather than a naming convention.
+Several root/identifier values gained dedicated newtypes:
 
-### Affected Code
-
-Before:
-
-```rust
-let procs: Vec<(Word, bool)> = component.get_procedures();
-```
-
-After:
-
-```rust
-for (proc_root, is_auth) in component.procedures() {
-    let digest: Word = proc_root.into();
-    // is_auth is true when @auth_script is present
-}
-```
+- The `procedure_digest!` macro is renamed **`procedure_root!`**. It now returns an `AccountProcedureRoot` (instead of `Word`) and takes an `AccountComponentCode` (`Component::code()`) instead of a library‑producing closure.
+- `NoteScript::root()` returns a new **`NoteScriptRoot`** newtype instead of `Word` (convert with `.into()`).
+- A new **`AccountComponentName`** string wrapper validates component names.
 
 ### Migration Steps
 
-1. Replace `get_procedures()` with `procedures()`.
-2. Update code to consume an iterator instead of a `Vec`.
-3. Note that `is_auth` is now determined by the `@auth_script` attribute, not the procedure name.
+1. Rename `procedure_digest!` → `procedure_root!` and pass `Component::code()` as the last argument; the static is now a `LazyLock<AccountProcedureRoot>`.
+2. Update bindings of `note_script.root()` to `NoteScriptRoot` (convert with `.into()` / `Word::from(..)` where a `Word` is needed).
+3. Use `AccountComponentName::new(...)` where a validated component name is required.
 
-## `commitment()` renamed to `to_commitment()` everywhere; `hash_account` removed
+---
+
+## `is_compatible_with` removed; auth/policy renames
 
 ### Summary
 
-All `commitment()` methods across the codebase have been renamed to `to_commitment()` for consistency. The standalone `hash_account` function has been removed in favor of calling `to_commitment()` on the account directly.
+A handful of standards‑library APIs changed:
 
-### Affected Code
-
-Before:
-
-```rust
-let account_hash = account.commitment();
-let note_hash = note_header.commitment();
-let account_hash = hash_account(&id, &nonce, &code_commitment, &storage_commitment);
-```
-
-After:
-
-```rust
-let account_hash = account.to_commitment();
-let note_hash = note_header.to_commitment();
-let account_hash = account.to_commitment();
-```
-
-### Migration Steps
-
-1. Find and replace all calls to `.commitment()` with `.to_commitment()`.
-2. Replace any calls to `hash_account(...)` with `.to_commitment()` on the account instance.
-
-## `TransactionAuthenticator::get_public_key` returns `Arc<PublicKey>`
-
-### Summary
-
-`TransactionAuthenticator::get_public_key` now returns `Option<Arc<PublicKey>>` instead of `Option<&PublicKey>`. This change enables sharing the public key across threads without lifetime constraints.
-
-### Affected Code
-
-Before:
-
-```rust
-fn get_public_key(&self) -> Option<&PublicKey> {
-    Some(&self.public_key)
-}
-```
-
-After:
-
-```rust
-fn get_public_key(&self) -> Option<Arc<PublicKey>> {
-    Some(Arc::new(self.public_key.clone()))
-}
-```
-
-### Migration Steps
-
-1. Update the return type of any `get_public_key` implementations to `Option<Arc<PublicKey>>`.
-2. Wrap returned values in `Arc::new(...)`.
-3. Add `use std::sync::Arc;` if not already imported.
-
-## `Ownable2Step` and `MintPolicyConfig` for faucets
-
-### Summary
-
-`NetworkFungibleFaucet::new` no longer accepts an owner account ID. Ownership is now managed through a separate `Ownable2Step` component, and mint policy is configured through an `AuthControlled` component with `AuthControlledInitConfig`. This enables two-step ownership transfer and more flexible access control.
-
-### Affected Code
-
-Before:
-
-```rust
-let faucet = NetworkFungibleFaucet::new(
-    owner_account_id,
-    symbol,
-    8,
-    max_supply,
-)?;
-```
-
-After:
-
-```rust
-let faucet = NetworkFungibleFaucet::new(symbol, 8, max_supply)?;
-let ownable = Ownable2Step::new(owner_account_id);
-let auth_controlled = AuthControlled::new(AuthControlledInitConfig::AllowAll);
-
-// Add all three components to the account builder
-```
-
-### Migration Steps
-
-1. Remove the `owner_account_id` argument from `NetworkFungibleFaucet::new`.
-2. Create an `Ownable2Step` component with the owner account ID.
-3. Create an `AuthControlled` component with the desired policy (e.g., `AuthControlledInitConfig::AllowAll`).
-4. Add all three components to the account builder.
-
-## `AccountSchemaCommitment` and `build_with_schema_commitment`
-
-### Summary
-
-A new `AccountBuilderSchemaCommitmentExt` extension trait provides a `build_with_schema_commitment()` method on the account builder. This enables building accounts that include a schema commitment for type-safe component validation.
-
-### Affected Code
-
-After:
-
-```rust
-use miden_account::AccountBuilderSchemaCommitmentExt;
-
-let (account, seed) = AccountBuilder::new(init_seed)
-    .with_component(component)
-    .build_with_schema_commitment()?;
-```
-
-### Migration Steps
-
-1. Add `use miden_account::AccountBuilderSchemaCommitmentExt;` to bring the extension trait into scope.
-2. Replace `.build()` with `.build_with_schema_commitment()` where schema commitment is desired.
-
-## `EthAddress` / `EthEmbeddedAccountId` split
-
-### Summary
-
-The single `EthAddressFormat` type has been split into two distinct types: `EthAddress` for raw Ethereum addresses and `EthEmbeddedAccountId` for account IDs that embed an Ethereum address. This provides clearer semantics for different use cases.
-
-### Affected Code
-
-Before:
-
-```rust
-let eth_addr = EthAddressFormat::new(*params.origin_token_address);
-```
-
-After:
-
-```rust
-let eth_addr = EthAddress::new(params.origin_token_address);
-let embedded_id = EthEmbeddedAccountId::from_account_id(account_id);
-```
-
-### Migration Steps
-
-1. Replace `EthAddressFormat::new(...)` with `EthAddress::new(...)` when working with raw Ethereum addresses.
-2. Use `EthEmbeddedAccountId::from_account_id(...)` when extracting an Ethereum address from a Miden account ID.
-3. Update imports to use the new type names.
-
-## `SchemaTypeId` renamed to `SchemaType`
-
-### Summary
-
-`SchemaTypeId` has been renamed to `SchemaType`. This is a pure rename with no behavioral changes.
-
-### Affected Code
-
-Before:
-
-```rust
-use SchemaTypeId;
-
-let t: SchemaTypeId = SchemaType::native_felt();
-```
-
-After:
-
-```rust
-use SchemaType;
-
-let t: SchemaType = SchemaType::native_felt();
-```
-
-### Migration Steps
-
-1. Find and replace all occurrences of `SchemaTypeId` with `SchemaType`.
-
-## Common Errors Reference
-
-| Error Message | Cause | Solution |
-|---|---|---|
-| `expected 3 arguments, found 2` on `AccountComponent::new` | Missing `AccountComponentMetadata` argument | Create metadata and pass as third argument |
-| `no method named with_supports_all_types` | Removed builder method | Use `AccountType::all()` in `AccountComponentMetadata` |
-| `AccountComponentTemplateError not found` | Type renamed | Replace with `ComponentMetadataError` |
-| `AuthFalcon512Rpo not found` | Per-scheme auth types removed | Use `AuthSingleSig` with `AuthScheme::Falcon512Poseidon2` |
-| `AuthEcdsaK256Keccak not found` | Per-scheme auth types removed | Use `AuthSingleSig` with `AuthScheme::EcdsaK256Keccak` |
-| `no method named get_procedures` | Method renamed | Use `procedures()` (returns iterator) |
-| `no method named commitment` | Method renamed | Use `to_commitment()` |
-| `hash_account not found` | Function removed | Call `.to_commitment()` on the account instance |
-| `expected Option<&PublicKey>, found Option<Arc<PublicKey>>` | Return type changed | Update signature to return `Option<Arc<PublicKey>>` |
-| `expected 4 arguments, found 3` on `NetworkFungibleFaucet::new` | Owner removed from constructor | Remove owner arg; use `Ownable2Step` component instead |
-| `EthAddressFormat not found` | Type split into two | Use `EthAddress` or `EthEmbeddedAccountId` |
-| `SchemaTypeId not found` | Type renamed | Replace with `SchemaType` |
+- `StandardNote::is_compatible_with` and `AccountInterfaceExt::is_compatible_with` were **removed** — perform compatibility checks via the account interface directly.
+- The guarded‑multisig API was renamed `AuthMultisigGuardian` → `AuthGuardedMultisig` (the `guardian` auth namespace is retained).
+- `OwnerControlledBlocklist` was renamed `BlocklistOwnerControlled`.
+- New standard components were added: `Pausable`, `Authority`, allowlist/blocklist transfer policies, and `FungibleTokenMetadata`.

--- a/docs/builder/migration/04-note-changes.md
+++ b/docs/builder/migration/04-note-changes.md
@@ -1,441 +1,177 @@
 ---
 sidebar_position: 4
 title: "Note Changes"
-description: "Note API renames, script format, asset building, type simplification, and constructor changes in v0.14"
+description: "Note identity split, multiple attachments, metadata reshape, nullifier, and capacity changes in v0.15"
 ---
 
 # Note Changes
 
 :::warning Breaking Change
-`NoteInputs` has been renamed to `NoteStorage` across the entire API (Rust and MASM), and note scripts are now MASM libraries annotated with `@note_script` instead of programs with `begin` blocks. These two changes affect virtually every note-related code path.
+Note identity is split in two: the old `NoteId` (recipient + assets) becomes `NoteDetailsCommitment`, and a brand‑new `NoteId` also commits to metadata. Notes now carry multiple attachments off the metadata (`NoteMetadata` → `PartialNoteMetadata`), and nullifiers fold in the metadata word and attachments commitment. None of these values roundtrip with 0.14 — recompute and re‑persist note ids and nullifiers.
 :::
 
 ---
 
-## NoteInputs → NoteStorage
+## `NoteId` → `NoteDetailsCommitment`; new `NoteId` commits to metadata
 
 ### Summary
 
-The `NoteInputs` type has been renamed end-to-end to `NoteStorage`. This affects the Rust struct name, its methods, associated constants, `NoteRecipient` construction, the MASM procedure path, and the relevant error variant.
+The 0.14 `NoteId` (a commitment over recipient + assets only) is renamed to **`NoteDetailsCommitment`**. A brand‑new **`NoteId`** is introduced that hashes the details commitment together with the note metadata commitment, so the public note ID now changes when the note's metadata (sender, type, tag, attachments) changes.
 
-### Affected Code
-
-**Rust:**
-```rust
-// Before (0.13)
-use miden_protocol::note::NoteInputs;
-
-let inputs = NoteInputs::new(values)?;
-let v = inputs.values();
-let n = inputs.num_values();
-assert!(n <= NoteInputs::MAX_INPUTS_PER_NOTE);
-
-let recipient = NoteRecipient::new(serial_num, script, inputs);
-
-// After (0.14)
-use miden_protocol::note::NoteStorage;
-
-let storage = NoteStorage::new(values)?;
-let v = storage.storage();
-let n = storage.num_items();
-assert!(n <= NoteStorage::MAX_NOTE_STORAGE_ITEMS);
-
-let recipient = NoteRecipient::new(serial_num, script, storage);
+```text
+NoteDetailsCommitment = hash(NOTE_RECIPIENT_DIGEST || NOTE_ASSETS_COMMITMENT)    // == old NoteId
+NoteId                = hash(NOTE_DETAILS_COMMITMENT || NOTE_METADATA_COMMITMENT) // new
 ```
-
-**MASM:**
-```masm
-# Before (0.13)
-exec.active_note::get_inputs
-
-# After (0.14)
-exec.active_note::get_storage
-```
-
-**Error variants:**
-```rust
-// Before (0.13)
-NoteError::TooManyInputs
-
-// After (0.14)
-NoteError::TooManyStorageItems
-```
-
-### Migration Steps
-
-1. Find-and-replace `NoteInputs` with `NoteStorage` across all Rust files.
-2. Rename method calls: `values()` → `storage()`, `num_values()` → `num_items()`.
-3. Replace `MAX_INPUTS_PER_NOTE` with `MAX_NOTE_STORAGE_ITEMS`.
-4. Update the third argument of `NoteRecipient::new(...)` from inputs to storage.
-5. In MASM, replace `active_note::get_inputs` with `active_note::get_storage`.
-6. Update any error matching on `NoteError::TooManyInputs` to `NoteError::TooManyStorageItems`.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `cannot find type NoteInputs in module note` | Type renamed | Use `NoteStorage`. |
-| `no method named values found for NoteStorage` | Method renamed | Use `.storage()`. |
-| `unknown procedure active_note::get_inputs` | MASM procedure renamed | Use `active_note::get_storage`. |
-
----
-
-## NoteMetadata::new No Longer Takes a Tag
-
-### Summary
-
-`NoteMetadata::new` previously accepted three arguments including the tag. It now takes only `sender` and `type`. The tag is set separately via the builder method `.with_tag(tag)`.
 
 ### Affected Code
 
 ```rust
-// Before (0.13)
-let metadata = NoteMetadata::new(sender, note_type, tag);
-
-// After (0.14)
-let metadata = NoteMetadata::new(sender, note_type).with_tag(tag);
+// 0.15 — new API:
+use miden_protocol::note::{NoteDetailsCommitment, NoteId};
+let details_commitment = NoteDetailsCommitment::new(&recipient, &assets);
+let id = NoteId::new(details_commitment, &metadata);   // the real NoteId mixes in metadata
+// On a built note: note.id() / note.details_commitment().
 ```
+`NoteDetails::commitment()` now returns a `NoteDetailsCommitment` (not the public note id, which requires metadata).
 
 ### Migration Steps
 
-1. Find every call to `NoteMetadata::new(sender, type, tag)`.
-2. Remove the third argument and chain `.with_tag(tag)` on the result.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `this function takes 2 arguments but 3 arguments were supplied` | Signature changed | Remove the tag argument and use `.with_tag(tag)`. |
+1. Rename any value you treated as a "note id without metadata" to `NoteDetailsCommitment`.
+2. Replace `NoteId::new(recipient, asset_commitment)` with `NoteDetailsCommitment::new(&recipient, &assets)`.
+3. To obtain the public `NoteId`, call `note.id()`, or `NoteId::new(details_commitment, &metadata)`.
+4. Recompute and re‑persist any stored note IDs — 0.14 ids do not roundtrip, and an id now changes if metadata changes.
 
 ---
 
-## Note Scripts Are MASM Libraries with @note_script
+## `NoteMetadata` → `PartialNoteMetadata`; multiple attachments per note
 
 ### Summary
 
-Note scripts are no longer standalone programs with a `begin ... end` block. They are now MASM libraries that use the `@note_script` attribute on a `pub proc`. In Rust, you construct a `NoteScript` from a compiled `Library` instead of a `Program`.
+The metadata types were renamed and reshuffled to support **multiple attachments per note** (up to `NoteAttachments::MAX_COUNT` = 4):
 
-### Affected Code
-
-**MASM:**
-```masm
-# Before (0.13)
-use.miden::contracts::wallets::basic->wallet
-
-begin
-    exec.wallet::receive_asset
-end
-
-# After (0.14)
-use.miden::contracts::wallets::basic->wallet
-
-@note_script
-pub proc main
-    exec.wallet::receive_asset
-end
-```
-
-**Rust:**
-```rust
-// Before (0.13)
-let program = assembler.assemble_program(source)?;
-let script = NoteScript::new(program);
-
-// After (0.14)
-let library = assembler.assemble_library(source)?;
-let script = NoteScript::from_library(&library)?;
-```
-
-### Migration Steps
-
-1. In every `.masm` note script, replace the `begin ... end` block with `@note_script pub proc main ... end`.
-2. In Rust, switch from `assemble_program` to `assemble_library` and use `NoteScript::from_library(&library)?`.
-3. Ensure the procedure is marked `pub` — non-public procedures cannot be note entry points.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `no note_script attribute found in library` | Missing `@note_script` annotation | Add `@note_script` above the entry `pub proc`. |
-| `no method named new found for NoteScript` | Constructor changed | Use `NoteScript::from_library(&library)?`. |
-
----
-
-## NoteAssets::add_asset Removed; OutputNoteBuilder Accumulates
-
-### Summary
-
-The `NoteAssets::add_asset` method has been removed. You now construct `NoteAssets` in one shot with the full list of assets. The `OutputNoteBuilder` stores a `Vec<Asset>` internally and computes the commitment when `.build()` is called.
-
-### Affected Code
-
-```rust
-// Before (0.13)
-let mut assets = NoteAssets::default();
-assets.add_asset(asset_a)?;
-assets.add_asset(asset_b)?;
-
-// After (0.14)
-let assets = NoteAssets::new(vec![asset_a, asset_b])?;
-```
-
-### Migration Steps
-
-1. Collect all assets into a `Vec<Asset>` before constructing `NoteAssets`.
-2. Replace incremental `add_asset` calls with a single `NoteAssets::new(vec![...])`.
-3. If using `OutputNoteBuilder`, pass assets to the builder — it accumulates them internally and computes the commitment on `.build()`.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `no method named add_asset found for NoteAssets` | Method removed | Use `NoteAssets::new(vec![...])`. |
-
----
-
-## NoteType::Encrypted Removed
-
-### Summary
-
-The `NoteType` enum has been simplified to two variants: `Private` and `Public`. The former `Encrypted` variant has been removed.
-
-### Affected Code
-
-```rust
-// Before (0.13)
-let note_type = NoteType::Encrypted;
-
-// After (0.14)
-// Use NoteType::Private or NoteType::Public
-let note_type = NoteType::Private;
-```
-
-### Migration Steps
-
-1. Replace all uses of `NoteType::Encrypted` with `NoteType::Private` (or `NoteType::Public` depending on your intent).
-2. Update any match arms that handle `Encrypted` separately.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `no variant named Encrypted found for enum NoteType` | Variant removed | Use `NoteType::Private` or `NoteType::Public`. |
-
----
-
-## NoteHeader::commitment → to_commitment; NoteLocation Field Rename
-
-### Summary
-
-The method `NoteHeader::commitment` has been renamed to `NoteHeader::to_commitment`. Additionally, the `NoteLocation` field `node_index_in_block` has been renamed to `block_note_tree_index`.
-
-### Affected Code
-
-```rust
-// Before (0.13)
-let commitment = header.commitment();
-let index = location.node_index_in_block;
-
-// After (0.14)
-let commitment = header.to_commitment();
-let index = location.block_note_tree_index;
-```
-
-### Migration Steps
-
-1. Replace `.commitment()` with `.to_commitment()` on `NoteHeader`.
-2. Replace `node_index_in_block` with `block_note_tree_index` on `NoteLocation`.
-
----
-
-## OutputNote::Header Removed; PrivateNoteHeader Introduced
-
-### Summary
-
-The `OutputNote` enum has been restructured. The old `OutputNote::Full` and `OutputNote::Header` variants are gone. There are now two enums:
-
-- **`RawOutputNote`** with variants `Full` and `Partial`.
-- **`OutputNote`** with variants `Public(PublicOutputNote)` and `Private(PrivateNoteHeader)`.
-
-### Affected Code
-
-```rust
-// Before (0.13)
-match output_note {
-    OutputNote::Full(note) => { /* ... */ }
-    OutputNote::Header(header) => { /* ... */ }
-}
-
-// After (0.14)
-match output_note {
-    OutputNote::Public(public_note) => { /* ... */ }
-    OutputNote::Private(private_header) => { /* ... */ }
-}
-```
-
-### Migration Steps
-
-1. Replace `OutputNote::Full(note)` matches with `OutputNote::Public(public_note)`.
-2. Replace `OutputNote::Header(header)` matches with `OutputNote::Private(private_header)`.
-3. If you need raw full/partial note data, use `RawOutputNote::Full` or `RawOutputNote::Partial`.
-4. Update any type annotations referencing the old variants.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `no variant named Full found for enum OutputNote` | Enum restructured | Use `OutputNote::Public(PublicOutputNote)`. |
-| `no variant named Header found for enum OutputNote` | Variant removed | Use `OutputNote::Private(PrivateNoteHeader)`. |
-
----
-
-## WellKnownNote / WellKnownComponent → Standard...
-
-### Summary
-
-All `WellKnown*` types have been renamed to `Standard*`:
-
-| Before (0.13) | After (0.14) |
+| 0.14 | 0.15 |
 | --- | --- |
-| `WellKnownComponent` | `StandardAccountComponent` |
-| `WellKnownNote` | `StandardNote` |
-| `WellKnownNoteAttachment` | `StandardNoteAttachment` |
+| `NoteMetadata` (sender/type/tag + single attachment) | `PartialNoteMetadata` (sender/type/tag only) |
+| `NoteMetadataHeader` (the on‑stack metadata word) | `NoteMetadata` (metadata word + attachment headers + attachments commitment) |
+| `NoteAttachment` (single, `with_attachment`) | `NoteAttachments` (collection, `with_attachments`) |
 
-The module path is now `miden_standards::note::StandardNote`.
+`Note::new(assets, metadata, recipient)` now takes a **`PartialNoteMetadata`**; a new `Note::with_attachments(assets, partial_metadata, recipient, attachments)` carries the attachments. The single `NoteMetadata::with_attachment` / `.attachment()` API is gone.
 
 ### Affected Code
 
 ```rust
-// Before (0.13)
-use miden_standards::note::WellKnownNote;
-use miden_standards::component::WellKnownComponent;
-use miden_standards::note::WellKnownNoteAttachment;
-
-// After (0.14)
-use miden_standards::note::StandardNote;
-use miden_standards::component::StandardAccountComponent;
-use miden_standards::note::StandardNoteAttachment;
+// 0.15 — new API:
+use miden_protocol::note::{Note, PartialNoteMetadata, NoteType, NoteAttachments};
+let partial = PartialNoteMetadata::new(sender, NoteType::Public).with_tag(tag);
+let attachments = NoteAttachments::new(vec![attachment_a, attachment_b])?;   // 0..=4
+let note = Note::with_attachments(assets, partial, recipient, attachments);
+// (use Note::new(assets, partial, recipient) for a note with no attachments)
+let found = note.attachments().find(scheme);
 ```
 
 ### Migration Steps
 
-1. Find-and-replace `WellKnownComponent` → `StandardAccountComponent`.
-2. Find-and-replace `WellKnownNote` → `StandardNote`.
-3. Find-and-replace `WellKnownNoteAttachment` → `StandardNoteAttachment`.
-4. Update import paths accordingly.
+1. Search/replace the *type* used to construct a note from `NoteMetadata` to `PartialNoteMetadata`.
+2. Replace `NoteMetadataHeader` with `NoteMetadata` (the word‑shaped metadata is `NoteMetadata::to_metadata_word()`).
+3. Replace `.with_attachment(a)` with a `NoteAttachments::new(vec![...])` collection and `Note::with_attachments(...)`.
+4. Replace single `metadata.attachment()` reads with `note.attachments().get(i)` / `.find(scheme)` / `note.has_attachments()`.
 
 ---
 
-## Standard Component Name Prefix
+## Attachment MASM: `set_*` → `add_*`; `get_metadata` drops attachments
 
 ### Summary
 
-The `NAME` constants on standard account components have moved under the `miden::standards::components::*` namespace.
+Because a note can now hold several attachments, the kernel/protocol attachment procedures were rewritten:
+
+- `output_note::set_attachment` → **`add_attachment`** (and `set_word_attachment` → `add_word_attachment`, `set_array_attachment` → `add_attachment_from_memory`). They *append* instead of overwriting, and the stack signature dropped the `attachment_kind` field.
+- `note::extract_attachment_info_from_metadata` → **`metadata_into_attachment_schemes`**, returning the four attachment scheme markers.
+- All `get_metadata` procedures (`active_note`, `input_note`, `output_note`) **no longer return attachments** — they return just the single `METADATA` word.
 
 ### Affected Code
 
-```rust
-// Before (0.13)
-AuthSingleSig::NAME   // "miden::auth::single_sig"
-BasicWallet::NAME      // "miden::wallets::basic"
-BasicFungibleFaucet::NAME // "miden::faucets::basic_fungible"
-
-// After (0.14)
-AuthSingleSig::NAME   // "miden::standards::components::auth_single_sig"
-BasicWallet::NAME      // "miden::standards::components::basic_wallet"
-BasicFungibleFaucet::NAME // "miden::standards::components::basic_fungible_faucet"
+```masm
+# 0.15 — new API:
+# Operand Stack: [attachment_scheme, ATTACHMENT_COMMITMENT, note_idx]
+exec.output_note::add_attachment
+exec.active_note::get_metadata          # => [METADATA]
+exec.note::metadata_into_attachment_schemes
+# => [attachment_0_scheme, attachment_1_scheme, attachment_2_scheme, attachment_3_scheme]
 ```
 
 ### Migration Steps
 
-1. If you match on or compare against `NAME` constants, update the expected string values.
-2. Search your codebase for any hard-coded component name strings and update them to the `miden::standards::components::*` namespace.
+1. Rename `set_attachment` / `set_word_attachment` / `set_array_attachment` to `add_attachment` / `add_word_attachment` / `add_attachment_from_memory`, and drop the `attachment_kind` operand.
+2. Replace `extract_attachment_info_from_metadata` with `metadata_into_attachment_schemes`.
+3. Audit every `get_metadata` consumer: it now leaves only `[METADATA]` — remove the extra cleanup that handled the attachment word.
 
 ---
 
-## NoteExecutionHint Moved to miden-standards
+## `NoteType` encoding 2‑bit → 1‑bit; `Private` is the default
 
 ### Summary
 
-`NoteExecutionHint` has been relocated from `miden-protocol` to `miden-standards`.
+`NoteType` dropped from a 2‑bit encoding to 1 bit. The numeric encodings flipped and `NoteType::Private` is now the `#[default]`. Anything that serialized a note type, packed it into a tag, or relied on the old `Public = 0b01` / `Private = 0b10` values changes.
 
-### Affected Code
-
-```rust
-// Before (0.13)
-use miden_protocol::note::NoteExecutionHint;
-
-// After (0.14)
-use miden_standards::note::NoteExecutionHint;
-```
-
-### Migration Steps
-
-1. Update all imports of `NoteExecutionHint` to use `miden_standards::note::NoteExecutionHint`.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
+| | 0.14 | 0.15 |
 | --- | --- | --- |
-| `unresolved import miden_protocol::note::NoteExecutionHint` | Type moved to `miden-standards` | Import from `miden_standards::note::NoteExecutionHint`. |
-
----
-
-## 256 KiB Note Size Limit
-
-### Summary
-
-Public output notes are now subject to a maximum size of 256 KiB (`NOTE_MAX_SIZE = 2^18` bytes). Notes exceeding this limit will be rejected.
+| `Public` | `0b01` | `1` |
+| `Private` | `0b10` | `0` (default) |
 
 ### Migration Steps
 
-1. Audit any note construction that could produce large public notes (e.g., notes with many assets or large storage payloads).
-2. If your notes approach the 256 KiB limit, consider splitting them or reducing their payload.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `note size exceeds maximum allowed` | Public note exceeds 2^18 bytes | Reduce note payload or split into multiple notes. |
+1. Drop any hard‑coded `0b01` / `0b10` note‑type bit literals; use the `NoteType` variants.
+2. Re‑derive note tags / metadata words that packed the old 2‑bit type (`SwapNote::build_tag`, for example, now uses the 1‑bit encoding — script‑root bits 14 → 15).
+3. If you relied on a particular default, note it is now `Private`.
 
 ---
 
-## Note Constructors Moved to Associated Methods
+## Nullifier now includes metadata and attachments commitment
 
 ### Summary
 
-Free-standing note constructor functions have been replaced by associated methods on their respective types.
+The note nullifier hash now folds in the note's **metadata word** and **attachments commitment** in addition to the serial number, script root, storage commitment, and asset commitment. `Nullifier::new` gained two parameters and the `From<&NoteDetails>` conversion was replaced by `Nullifier::from_details_and_metadata`, because a nullifier can no longer be computed from details alone.
 
 ### Affected Code
 
 ```rust
-// Before (0.13)
-let note = create_p2id_note(sender, target, assets, recall_height)?;
-let note = create_swap_note(sender, offered, requested)?;
-let note = create_mint_note(faucet_id, amount, target)?;
-let note = create_burn_note(faucet_id, amount)?;
-let note = create_p2ide_note(sender, target, assets, recall_height)?;
-
-// After (0.14)
-let note = P2idNote::create(sender, target, assets, recall_height)?;
-let note = SwapNote::create(sender, offered, requested)?;
-let note = MintNote::create(faucet_id, amount, target)?;
-let note = BurnNote::create(faucet_id, amount)?;
-let note = P2ideNote::create(sender, target, assets, recall_height)?;
+// 0.15 — new API:
+let nf = Nullifier::new(
+    script_root, storage_commitment, asset_commitment, serial_num,
+    metadata.to_metadata_word(),       // new
+    metadata.attachments_commitment(), // new
+);
+let nf2 = Nullifier::from_details_and_metadata(&note_details, &metadata);
 ```
 
 ### Migration Steps
 
-1. Replace `create_p2id_note(...)` with `P2idNote::create(...)`.
-2. Replace `create_swap_note(...)` with `SwapNote::create(...)`.
-3. Replace `create_mint_note(...)` with `MintNote::create(...)`.
-4. Replace `create_burn_note(...)` with `BurnNote::create(...)`.
-5. Replace `create_p2ide_note(...)` with `P2ideNote::create(...)`.
-6. Add the appropriate `use` imports for the new types (e.g., `use miden_standards::note::P2idNote`).
+1. Thread the metadata word and attachments commitment into every `Nullifier::new` call.
+2. Replace `Nullifier::from(&details)` / `(&details).into()` with `Nullifier::from_details_and_metadata(&details, &metadata)`.
+3. Recompute and re‑persist nullifiers — 0.14 nullifiers will not match.
 
-### Common Errors
+---
 
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `cannot find function create_p2id_note` | Function moved to associated method | Use `P2idNote::create(...)`. |
-| `cannot find function create_swap_note` | Function moved to associated method | Use `SwapNote::create(...)`. |
+## `MAX_ASSETS_PER_NOTE` 255 → 64; `NOTE_MEM_SIZE` 3072 → 1024
+
+### Summary
+
+The per‑note asset cap was reduced from 255 to **64**, and the kernel note memory region (`NOTE_MEM_SIZE`) shrank from 3072 to **1024**. Notes carrying more than 64 assets now fail to build, and MASM that hard‑codes note‑memory offsets against the old 3072‑word region must be reworked.
+
+### Migration Steps
+
+1. Cap note asset lists at 64; split larger payloads across multiple notes.
+2. Audit any MASM that indexes into the note memory region against the new `NOTE_MEM_SIZE = 1024`.
+
+---
+
+## `SwapNote`/`MintNote` storage trimmed; `PSWAP` added
+
+### Summary
+
+Unused fields were removed from standard note storage: `payback_attachment` from `SwapNoteStorage` and `attachment` from `MintNoteStorage`. A new **`PSWAP`** (partial swap) note and `PswapNote` API (with a `PswapAttachment` scheme and `payback_note` / `remainder_note` discovery helpers) supports partial‑fill asset exchange with remainder re‑creation.
+
+### Migration Steps
+
+1. Stop reading/writing the removed `payback_attachment` / `attachment` storage fields on swap/mint notes.
+2. Use `PswapNote` for partial‑fill swaps; reconstruct private paybacks via `PswapNote::payback_note` / `remainder_note`.

--- a/docs/builder/migration/05-asset-vault-faucet.md
+++ b/docs/builder/migration/05-asset-vault-faucet.md
@@ -1,303 +1,79 @@
 ---
 sidebar_position: 5
 title: "Assets, Vault & Faucet"
-description: "Two-word asset representation, vault API changes, faucet burn updates, and TokenSymbol changes in v0.14"
+description: "AssetAmount newtype, AssetVaultKey balance lookups, the unified FungibleFaucet component, and AssetComposition changes in v0.15"
 ---
 
 # Assets, Vault & Faucet
 
 :::warning Breaking Change
-Assets are now represented as two words (`ASSET_KEY` + `ASSET_VALUE`) instead of a single `ASSET` word. This is the largest MASM-level change in v0.14 and affects every procedure that creates, inspects, adds, removes, or burns assets.
+Fungible amounts are now a validated `AssetAmount` newtype rather than a raw `u64`. The separate `BasicFungibleFaucet` and `NetworkFungibleFaucet` components are unified into a single `FungibleFaucet` (built with a `bon` builder) configured by a `TokenPolicyManager`. Vault balance lookups now take an `AssetVaultKey` instead of an `AccountId`.
 :::
 
 ---
 
-## ASSET to ASSET_KEY + ASSET_VALUE
+## `FungibleAsset::amount()` / `get_balance()` return `AssetAmount`
 
 ### Summary
 
-The single 4-felt `ASSET` word has been split into two words: `ASSET_KEY` (identity + faucet + callback flag) and `ASSET_VALUE` (amount or data hash). Every kernel procedure and standard-library helper that previously accepted or returned `ASSET` now works with the `ASSET_KEY, ASSET_VALUE` pair.
-
-:::note Canonical layout
-The full field-by-field layout — including how the per-asset callback flag is packed into the reserved low byte of `faucet_id_suffix` — is documented in [Asset encoding](../../reference/protocol/asset.md#encoding). This page covers the v0.13 → v0.14 delta only.
-:::
+A new validated `AssetAmount` newtype wraps fungible amounts. `FungibleAsset::amount()` now returns `AssetAmount` (was `u64`), and `AssetVault::get_balance()` returns `Result<AssetAmount, AssetError>` (was `Result<u64, AssetVaultError>`) **and takes an `AssetVaultKey` instead of an `AccountId`**. The vault key carries the asset's `AssetComposition`, so balance lookups are explicit about fungible‑vs‑non‑fungible.
 
 ### Affected Code
 
-**MASM (`native_account::add_asset`):**
-```masm
-# Before (0.13): stack = [ASSET, pad(12)]
-exec.native_account::add_asset
-# -> [ASSET, pad(12)]
-
-# After (0.14): stack = [ASSET_KEY, ASSET_VALUE, pad(8)]
-exec.native_account::add_asset
-# -> [ASSET_KEY, ASSET_VALUE, pad(8)]
-```
-
-**Rust:**
 ```rust
-// Before (0.13)
-let word: Word = fungible_asset.into();
-
-// After (0.14)
-let key: Word = fungible_asset.to_key_word();
-let value: Word = fungible_asset.to_value_word();
-
-// Reconstructing from key/value
-let asset = FungibleAsset::from_key_value_words(key, value)?;
+// 0.15 — new API:
+use miden_protocol::asset::{AssetAmount, AssetCallbackFlag, AssetVaultKey};
+let amt: AssetAmount = fungible_asset.amount();
+let raw: u64 = amt.as_u64();                  // or: u64::from(amt)
+let key = AssetVaultKey::new_fungible(faucet_id, AssetCallbackFlag::Disabled);
+let bal: AssetAmount = vault.get_balance(key)?;
 ```
+`AssetAmount` implements `From<u8/u16/u32>` and `TryFrom<u64>` (validating against the max fungible amount), plus `Add`/`Sub` and `Display`.
 
 ### Migration Steps
 
-1. Find every MASM site that pushes an `ASSET` word onto the stack before a kernel call. Replace the single word with `ASSET_KEY, ASSET_VALUE` and adjust padding from 12 to 8.
-2. In Rust, replace `.into()` conversions to `Word` with `.to_key_word()` and `.to_value_word()`.
-3. Replace any `Asset::from(word)` with `Asset::from_key_value_words(key, value)`.
-4. Update stack comments throughout your MASM to reflect the new two-word layout.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `FailedAssertion` at `add_asset` / `remove_asset` | Single `ASSET` word pushed instead of key+value pair | Split into `ASSET_KEY` and `ASSET_VALUE`. |
-| `no method named into found for FungibleAsset` (when targeting `Word`) | Direct `Word` conversion removed | Use `to_key_word()` and `to_value_word()`. |
-| Stack underflow in asset procedures | Padding not adjusted from 12 to 8 | Reduce padding to account for the extra word. |
+1. Wrap `u64` amounts you pass into faucet/asset constructors in `AssetAmount` (`AssetAmount::from(n)` for small ints, `AssetAmount::try_from(n)` for `u64`).
+2. Unwrap `AssetAmount` back to `u64` with `.as_u64()` / `u64::from(_)` where a raw integer is needed.
+3. Replace `vault.get_balance(faucet_id)` with `vault.get_balance(AssetVaultKey::new_fungible(faucet_id, callback_flag))`.
+4. Update error handling from `AssetVaultError` to `AssetError` on `get_balance`.
 
 ---
 
-## build_*_asset Renamed to create_*_asset
+## `FungibleFaucet` replaces `BasicFungibleFaucet` + `NetworkFungibleFaucet`
 
 ### Summary
 
-The `asset::build_fungible_asset` and `asset::build_non_fungible_asset` procedures have been renamed to `create_fungible_asset` and `create_non_fungible_asset`. They also accept a new `enable_callbacks` flag and return the two-word `ASSET_KEY, ASSET_VALUE` pair.
+The separate `BasicFungibleFaucet` and `NetworkFungibleFaucet` components were merged into a single **`FungibleFaucet`** component, and its old `FungibleFaucetBuilder` was replaced with a `bon`‑generated builder (`FungibleFaucet::builder()`). The constructor accepts a structured `TokenName` plus optional token‑metadata fields and an `AssetAmount` `max_supply`. A companion `FungibleTokenMetadata` component exposes the metadata via MASM getters. For the end‑to‑end client construction recipe (with `TokenPolicyManager`), see [(Rust) `FungibleFaucet` builder + `TokenPolicyManager`](./client-changes#rust-fungiblefaucet-builder--tokenpolicymanager-construction).
 
 ### Affected Code
 
-**MASM (asset creation):**
-```masm
-# Before (0.13): fungible stack = [faucet_id_prefix, faucet_id_suffix, amount, ...]
-exec.asset::build_fungible_asset
-# -> [ASSET, ...]
-
-# Before (0.13): non-fungible stack = [faucet_id_prefix, faucet_id_suffix, DATA_HASH, ...]
-exec.asset::build_non_fungible_asset
-# -> [ASSET, ...]
-
-# After (0.14): fungible stack = [enable_callbacks, faucet_id_suffix, faucet_id_prefix, amount, ...]
-exec.asset::create_fungible_asset
-# -> [ASSET_KEY, ASSET_VALUE, ...]
-
-# After (0.14): non-fungible stack = [enable_callbacks, faucet_id_suffix, faucet_id_prefix, DATA_HASH, ...]
-exec.asset::create_non_fungible_asset
-# -> [ASSET_KEY, ASSET_VALUE, ...]
-```
-
-**Rust:**
 ```rust
-// Before (0.13)
-let asset = FungibleAsset::new(faucet_id, amount)?;
-
-// After (0.14) — Rust API may vary; consult crate docs for exact constructor
-let asset = FungibleAsset::new(faucet_id, amount)?;
-// The MASM-level rename is the primary change; Rust constructors
-// now produce assets compatible with the two-word representation.
+// 0.15 — new API:
+use miden_protocol::asset::{AssetAmount, TokenSymbol};
+use miden_standards::account::faucets::{FungibleFaucet, TokenName};
+let faucet = FungibleFaucet::builder()
+    .name(TokenName::new("My Token")?)
+    .symbol(TokenSymbol::new("MTK")?)
+    .decimals(8)
+    .max_supply(AssetAmount::from(1_000_000u32))
+    .build()?;
 ```
 
 ### Migration Steps
 
-1. Rename all `exec.asset::build_fungible_asset` calls to `exec.asset::create_fungible_asset`.
-2. Rename all `exec.asset::build_non_fungible_asset` calls to `exec.asset::create_non_fungible_asset`.
-3. Add the `enable_callbacks` flag as the new top-of-stack element.
-4. Note the changed argument order: `[enable_callbacks, faucet_id_suffix, faucet_id_prefix, amount]` for fungible assets and `[enable_callbacks, faucet_id_suffix, faucet_id_prefix, DATA_HASH]` for non-fungible assets.
-5. Update consumers to expect `[ASSET_KEY, ASSET_VALUE]` on the stack instead of a single `[ASSET]`.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `unknown procedure asset::build_fungible_asset` | Procedure renamed | Use `asset::create_fungible_asset`. |
-| `unknown procedure asset::build_non_fungible_asset` | Procedure renamed | Use `asset::create_non_fungible_asset`. |
-| `FailedAssertion` in `create_*_asset` | Missing `enable_callbacks` flag or wrong argument order | Push `[enable_callbacks, faucet_id_suffix, faucet_id_prefix, amount]` for fungible assets, or `[enable_callbacks, faucet_id_suffix, faucet_id_prefix, DATA_HASH]` for non-fungible assets. |
+1. Replace `BasicFungibleFaucet` / `NetworkFungibleFaucet` imports with `FungibleFaucet`.
+2. Switch construction to `FungibleFaucet::builder()` with the required setters `name`, `symbol`, `decimals`, `max_supply`.
+3. Convert `max_supply` from `Felt` to `AssetAmount`.
 
 ---
 
-## get_balance / has_non_fungible_asset Removed
+## `AssetComposition` and the `AssetVaultKey` composition byte
 
 ### Summary
 
-The kernel no longer exposes `get_balance` or `has_non_fungible_asset`. Instead, a single `get_asset` procedure handles both fungible and non-fungible lookups. It takes an `ASSET_KEY` and returns the corresponding `ASSET_VALUE`.
-
-### Affected Code
-
-**MASM (fungible balance check):**
-```masm
-# Before (0.13): stack = [faucet_id, ...]
-exec.native_account::get_balance
-# -> [balance, ...]
-
-# After (0.14): stack = [ASSET_KEY, pad(12)]
-exec.native_account::get_asset
-# -> [ASSET_VALUE, pad(12)]
-# balance is ASSET_VALUE[0] (top of ASSET_VALUE word)
-```
-
-**MASM (non-fungible existence check):**
-```masm
-# Before (0.13): stack = [ASSET, pad(12)]
-exec.native_account::has_non_fungible_asset
-# -> [has_asset, pad(15)]
-
-# After (0.14): stack = [ASSET_KEY, pad(12)]
-exec.native_account::get_asset
-# -> [ASSET_VALUE, pad(12)]
-# If the asset exists, ASSET_VALUE will be the DATA_HASH;
-# if not, ASSET_VALUE will be [0, 0, 0, 0].
-```
-
-**Rust:**
-```rust
-// Before (0.13)
-let balance = account.vault().get_balance(faucet_id)?;
-let has_nft = account.vault().has_non_fungible_asset(&asset)?;
-
-// After (0.14)
-let asset_value = account.vault().get_asset(asset_key)?;
-// For fungible: amount = asset_value[0]
-// For non-fungible: check if asset_value != [0, 0, 0, 0]
-```
+A new **`AssetComposition`** enum (`None`, `Fungible`, `Custom`) discriminates assets, and the asset vault key's metadata byte now encodes the composition (plus the asset‑callback flag). `AssetVaultKey::new(asset_id, faucet_id, composition, callback_flag)` is the general constructor; `AssetVaultKey::new_fungible(faucet_id, callback_flag)` is the fungible shortcut. (`Custom` composition is reserved and currently rejected.)
 
 ### Migration Steps
 
-1. Replace every `exec.native_account::get_balance` with `exec.native_account::get_asset`. Construct the `ASSET_KEY` for the fungible faucet and read the amount from the first element of the returned `ASSET_VALUE`.
-2. Replace every `exec.native_account::has_non_fungible_asset` with `exec.native_account::get_asset`. Construct the `ASSET_KEY` and compare the returned `ASSET_VALUE` against `[0, 0, 0, 0]` to determine existence.
-3. The same pattern applies to `get_initial_asset` (for checking assets at transaction start).
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `unknown procedure native_account::get_balance` | Procedure removed | Use `native_account::get_asset` with the asset key. |
-| `unknown procedure native_account::has_non_fungible_asset` | Procedure removed | Use `native_account::get_asset` and check for zero value. |
-| Wrong balance value | Reading wrong element from `ASSET_VALUE` | The amount is in `ASSET_VALUE[0]` (top of stack after the call). |
-
----
-
-## AssetVault::remove_asset Returns Remaining Asset
-
-### Summary
-
-In Rust, `AssetVault::remove_asset` previously returned `Result<Asset>` (the removed asset). It now returns `Result<Option<Asset>>` where the value is the **remaining** asset in the vault after partial removal. For non-fungible assets, the return is always `None` (the entire asset is removed).
-
-### Affected Code
-
-**Rust:**
-```rust
-// Before (0.13)
-let removed: Asset = vault.remove_asset(asset)?;
-
-// After (0.14)
-let remaining: Option<Asset> = vault.remove_asset(asset)?;
-// remaining = Some(fungible_asset) if fungible with leftover balance
-// remaining = None if the vault entry was fully consumed (or non-fungible)
-```
-
-### Migration Steps
-
-1. Update all call sites of `AssetVault::remove_asset` to handle `Option<Asset>` instead of `Asset`.
-2. If you previously used the return value as "the asset that was removed", note that the semantics have changed to "the asset remaining in the vault".
-3. For non-fungible assets, expect `None` — the asset is either fully present or fully removed.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `expected Asset, found Option<Asset>` | Return type changed | Unwrap or pattern-match the `Option`. |
-| Logic error: treating return as "removed" amount | Semantics changed from removed to remaining | Adjust logic to interpret the value as remaining balance. |
-
----
-
-## faucet::burn and native_account::remove_asset Stack Effects
-
-### Summary
-
-Both `faucet::burn` and `native_account::remove_asset` have updated stack effects to match the two-word asset representation. Notably, `faucet::burn` no longer returns the asset on the stack.
-
-### Affected Code
-
-**MASM (`faucet::burn`):**
-```masm
-# Before (0.13): stack = [ASSET, ...] -> [ASSET, ...]
-exec.faucet::burn
-
-# After (0.14): stack = [ASSET_KEY, ASSET_VALUE, ...] -> [...]
-exec.faucet::burn
-# Stack is consumed — nothing is returned for the burned asset.
-```
-
-**MASM (`native_account::remove_asset`):**
-```masm
-# Before (0.13): stack = [ASSET, pad(12)] -> [ASSET, pad(12)]
-exec.native_account::remove_asset
-
-# After (0.14): stack = [ASSET_KEY, ASSET_VALUE, pad(8)] -> [REMAINING_ASSET_VALUE, pad(12)]
-exec.native_account::remove_asset
-# Returns the REMAINING asset value in the vault (not the removed one).
-```
-
-### Migration Steps
-
-1. For `faucet::burn`: remove any code that reads the return value from the stack. The procedure now consumes `[ASSET_KEY, ASSET_VALUE]` and leaves nothing.
-2. For `native_account::remove_asset`: update stack expectations. The output is `[REMAINING_ASSET_VALUE, pad(12)]`, not the removed asset.
-3. If you need the removed amount, compute it before calling `remove_asset` (e.g., subtract the remaining value from the original).
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| Stack underflow after `faucet::burn` | Code tries to read a return value that no longer exists | `burn` now returns nothing; remove post-call reads. |
-| Wrong amount after `remove_asset` | Return value is remaining, not removed | Compute removed amount separately if needed. |
-| `FailedAssertion` in `burn` or `remove_asset` | Single `ASSET` word passed instead of key+value | Pass `[ASSET_KEY, ASSET_VALUE]` with correct padding. |
-
----
-
-## TokenSymbol Changes
-
-### Summary
-
-The `TokenSymbol` type has several breaking changes:
-
-- **`to_string()`** is now available via the `Display` trait (infallible). Previously it could fail.
-- **`default()`** has been removed — there is no zero-value token symbol.
-- **`TryFrom<Felt>`** now rejects values below `MIN_ENCODED_VALUE`.
-- **`MAX_SYMBOL_LENGTH`** increased from **6** to **12** characters.
-
-### Affected Code
-
-**Rust:**
-```rust
-// Before (0.13)
-let symbol = TokenSymbol::default(); // zero-value placeholder
-let s = symbol.to_string()?;         // fallible conversion
-let sym = TokenSymbol::try_from(felt)?; // accepted any felt
-
-// After (0.14)
-// TokenSymbol::default() is removed — use a real symbol
-let s = format!("{}", symbol);        // Display trait, infallible
-let sym = TokenSymbol::try_from(felt)?; // rejects below MIN_ENCODED_VALUE
-// Symbols can now be up to 12 characters (was 6)
-```
-
-### Migration Steps
-
-1. Remove any calls to `TokenSymbol::default()`. Replace with an explicit symbol via `TokenSymbol::new("TOKEN")` or equivalent constructor.
-2. Replace fallible `to_string()` calls with `format!("{}", symbol)` or `.to_string()` (now infallible via `Display`).
-3. If you validate token symbol length, update the upper bound from 6 to 12.
-4. If you construct `TokenSymbol` from a `Felt`, ensure the value is at or above `MIN_ENCODED_VALUE`.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `no function or associated item named default found for TokenSymbol` | `default()` removed | Use an explicit symbol value. |
-| `encoded value below minimum` / `InvalidTokenSymbol` | `TryFrom<Felt>` now rejects small values | Ensure the felt is at or above `MIN_ENCODED_VALUE`. |
-| Compilation warning about unused `Result` on `to_string()` | Now returns `String` directly via `Display` | Remove error handling around `to_string()`. |
+1. Where you constructed a raw vault key word, use `AssetVaultKey::new_fungible` / `AssetVaultKey::new`.
+2. Branch on `AssetComposition` (via `key.composition()`) instead of inspecting raw bits.

--- a/docs/builder/migration/06-transaction-changes.md
+++ b/docs/builder/migration/06-transaction-changes.md
@@ -1,230 +1,53 @@
 ---
 sidebar_position: 6
 title: "Transaction Changes"
-description: "TransactionId hashing, ProvenTransaction construction, kernel event namespacing, stack order, and other transaction-level changes in v0.14"
+description: "FeeParameters fee faucet rename, typed transaction-script roots, and batch construction changes in v0.15"
 ---
 
 # Transaction Changes
 
 :::warning Breaking Change
-Transaction identity, construction, event namespacing, summary stack layout, output accessors, and block signing have all changed in v0.14. These changes affect anyone building, proving, verifying, or signing transactions and blocks.
+`FeeParameters::native_asset_id` was renamed to `fee_faucet_id` and `FeeParameters::new` is now infallible. The transaction-script root is now a typed `TransactionScriptRoot` rather than a raw `Word`. These changes affect anyone constructing fee parameters, reading transaction-script roots, or building batches by hand.
 :::
 
 ---
 
-## TransactionId Now Hashes the Fee Asset
+## `fee_faucet_id` replaces `native_asset_id` on `FeeParameters`
 
 ### Summary
 
-`TransactionId::new` now requires a `fee_asset: FungibleAsset` parameter so the fee is included in the transaction hash. The function takes 5 arguments (6 words total) instead of the previous 4.
-
-### Affected Code
-
-**Rust:**
-```rust
-// Before (0.13)
-let tx_id = TransactionId::new(init, final_state, input_notes, output_notes);
-
-// After (0.14)
-let tx_id = TransactionId::new(init, final_state, input_notes, output_notes, fee_asset);
-```
+`FeeParameters::native_asset_id` (field, getter, and `new` parameter) was renamed to **`fee_faucet_id`**. Because account IDs no longer encode faucet‑ness, `FeeParameters::new` no longer validates that the ID is a fungible faucet and is now **infallible** (returns `Self`, not `Result`).
 
 ### Migration Steps
 
-1. Add the `fee_asset: FungibleAsset` argument to every `TransactionId::new` call site.
-2. Ensure the `fee_asset` value matches the fee used in the transaction.
-3. If you compute or verify transaction IDs externally (e.g., in tests), update the hashing logic to include the fee asset.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `this function takes 5 arguments but 4 arguments were supplied` | Missing `fee_asset` parameter | Add the `FungibleAsset` fee as the fifth argument. |
-| Transaction ID mismatch in verification | Hash computed without fee asset | Recompute the ID with the fee asset included. |
+1. Rename `native_asset_id` → `fee_faucet_id` at the constructor, field, and getter.
+2. Drop the `?` / `FeeError` handling on `FeeParameters::new`.
 
 ---
 
-## ProvenTransactionBuilder Removed in Favor of ProvenTransaction::new
+## `TransactionScript::root()` returns `TransactionScriptRoot`
 
 ### Summary
 
-The `ProvenTransactionBuilder` has been removed. Instead, construct a `TxAccountUpdate` and pass it directly to `ProvenTransaction::new`.
-
-### Affected Code
-
-**Rust:**
-```rust
-// Before (0.13)
-let proven_tx = ProvenTransactionBuilder::new(account_id, init_hash, final_hash, proof)
-    .account_update_details(details)
-    .add_input_notes(input_notes)
-    .add_output_notes(output_notes)
-    .build()?;
-
-// After (0.14)
-let account_update = TxAccountUpdate::new(account_id, init_hash, final_hash, details);
-let proven_tx = ProvenTransaction::new(
-    account_update,
-    input_notes,
-    output_notes,
-    ref_block_num,
-    ref_block_commitment,
-    fee,
-    expiration_block_num,
-    proof,
-);
-```
+*(v0.15.2)* `TransactionScript::root()` now returns a typed **`TransactionScriptRoot`** newtype instead of a raw `Word` (convert with `.into()`). A new `TransactionScript::from_package(&Package)` builds a script from a compiled `miden-mast-package` package, and the new `tx::get_tx_script_root` kernel proc returns the executed tx‑script root (empty word if none).
 
 ### Migration Steps
 
-1. Remove all `ProvenTransactionBuilder` usage.
-2. Create a `TxAccountUpdate` from the account ID, initial hash, final hash, and update details.
-3. Call `ProvenTransaction::new` with the account update and all remaining fields as positional arguments.
-4. If you previously relied on builder defaults for optional fields, you must now provide them explicitly (e.g., `ref_block_num`, `ref_block_commitment`, `expiration_block_num`).
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `cannot find struct ProvenTransactionBuilder` | Builder removed | Use `ProvenTransaction::new` with `TxAccountUpdate`. |
-| `cannot find struct TxAccountUpdate` | Missing import | Add `use miden_objects::transaction::TxAccountUpdate;` (check crate docs for exact path). |
-| Wrong number of arguments to `ProvenTransaction::new` | Missing required positional parameters | Provide all 8 arguments: account_update, input_notes, output_notes, ref_block_num, ref_block_commitment, fee, expiration_block_num, proof. |
+1. Update the binding type of `tx_script.root()` to `TransactionScriptRoot`.
+2. Insert `.into()` / `Word::from(root)` where a `Word` is required.
 
 ---
 
-## Kernel Events Prefixed with miden::protocol
+## `ProvenBatch::new` → `new_unchecked`; `NoteConsumptionInfo` fields private
 
 ### Summary
 
-All kernel events have been renamespaced under `miden::protocol::`. The previous `miden::` prefix is no longer recognized.
+Batch/transaction housekeeping changes that affect anyone constructing these types by hand:
 
-### Affected Code
-
-**MASM:**
-```masm
-# Before (0.13)
-event("miden::account::vault_before_add_asset")
-event("miden::auth::request")
-
-# After (0.14)
-event("miden::protocol::account::vault_before_add_asset")
-event("miden::protocol::auth::request")
-```
+- `ProvenBatch::new` was renamed **`ProvenBatch::new_unchecked`** to signal it skips validation.
+- `NoteConsumptionInfo` (and related types) gained cycle counts and had their fields made private; use the accessor methods `successful()` / `failed()`.
 
 ### Migration Steps
 
-1. Search your MASM files for all `event("miden::` occurrences.
-2. Replace `miden::` with `miden::protocol::` in every event name.
-3. If you have event handlers or listeners matching on event names, update those patterns as well.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| Event not firing / handler not triggered | Event name changed but handler still matches old name | Update both the event emission and handler to use `miden::protocol::` prefix. |
-| `unknown event` or silent no-op | Old event name no longer exists | Rename to `miden::protocol::...`. |
-
----
-
-## Transaction Summary Stack Order Reversed
-
-### Summary
-
-The 4-word message that authentication procedures sign has its order reversed. Previously `SALT` was on top of the stack; now `ACCOUNT_DELTA_COMMITMENT` is on top.
-
-### Affected Code
-
-**MASM (stack layout for auth signing):**
-```masm
-# Before (0.13)
-# [SALT, OUTPUT_NOTES_COMMITMENT, INPUT_NOTES_COMMITMENT, ACCOUNT_DELTA_COMMITMENT, PUB_KEY]
-
-# After (0.14)
-# [ACCOUNT_DELTA_COMMITMENT, INPUT_NOTES_COMMITMENT, OUTPUT_NOTES_COMMITMENT, SALT, PUB_KEY]
-```
-
-### Migration Steps
-
-1. If you implement a custom authentication procedure that reads or signs the transaction summary, update the expected stack layout.
-2. The new order (top to bottom) is: `ACCOUNT_DELTA_COMMITMENT`, `INPUT_NOTES_COMMITMENT`, `OUTPUT_NOTES_COMMITMENT`, `SALT`, then `PUB_KEY`.
-3. Update any manual stack manipulation that assumed the old ordering.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| Signature verification failure | Auth procedure signing words in old order | Update to the new stack order before signing. |
-| `FailedAssertion` in custom auth | Stack words read in wrong positions | Reorder stack reads to match new layout. |
-
----
-
-## TransactionOutputs Fields Private
-
-### Summary
-
-Fields on `TransactionOutputs` are no longer public. Use accessor methods instead.
-
-### Affected Code
-
-**Rust:**
-```rust
-// Before (0.13)
-let account = outputs.account;
-let fee = outputs.fee;
-let expiration = outputs.expiration_block_num;
-let notes = outputs.output_notes;
-
-// After (0.14)
-let account = outputs.account();
-let fee = outputs.fee();
-let expiration = outputs.expiration_block_num();
-let notes = outputs.output_notes(); // now returns &RawOutputNotes
-```
-
-### Migration Steps
-
-1. Replace all direct field accesses on `TransactionOutputs` with the corresponding method calls.
-2. Note that `output_notes()` now returns `&RawOutputNotes` instead of the previous type. Update downstream code to work with `RawOutputNotes`.
-3. Since accessors return references, add borrows or clones where ownership was previously obtained via field access.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `field account of TransactionOutputs is private` | Fields no longer public | Use `outputs.account()`. |
-| `field fee of TransactionOutputs is private` | Fields no longer public | Use `outputs.fee()`. |
-| Type mismatch on output notes | `output_notes()` returns `&RawOutputNotes` | Update code to handle `RawOutputNotes` instead of the previous type. |
-
----
-
-## SignedBlock Added; BlockSigner Removed
-
-### Summary
-
-The `BlockSigner` trait has been removed. Instead, sign the block header commitment directly and construct a `SignedBlock`.
-
-### Affected Code
-
-**Rust:**
-```rust
-// Before (0.13)
-let signed = signer.sign(&header);
-
-// After (0.14)
-let sig = sk.sign(header.to_commitment());
-let signed_block = SignedBlock::new(header, body, sig);
-```
-
-### Migration Steps
-
-1. Remove all `BlockSigner` trait implementations and usages.
-2. Sign `header.to_commitment()` with your signing key directly.
-3. Construct `SignedBlock::new(header, body, signature)` with the header, block body, and resulting signature.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `cannot find trait BlockSigner` | Trait removed | Sign `header.to_commitment()` directly with your key. |
-| `cannot find struct SignedBlock` | Missing import | Add the appropriate import for `SignedBlock` from the Miden crate. |
-| Signature verification fails on block | Signing the header directly instead of its commitment | Sign `header.to_commitment()`, not the header itself. |
+1. Rename `ProvenBatch::new` → `ProvenBatch::new_unchecked`.
+2. Replace direct field access on `NoteConsumptionInfo` with the accessor methods.

--- a/docs/builder/migration/07-client-changes.md
+++ b/docs/builder/migration/07-client-changes.md
@@ -1,381 +1,496 @@
 ---
 sidebar_position: 7
 title: "Client Changes"
-description: "Web SDK resource-based API, Rust SDK keystore trait, lazy readers, state sync, and CLI changes in v0.14"
+description: "Client RPC rebuilt around GetAccount, removed check_nullifiers, required block_to, and Web/React/CLI surface changes in v0.15"
 ---
 
 # Client Changes
 
-:::info Affects Both Rust and Web SDKs
-v0.14 introduces significant API changes to both the Rust and Web Miden clients. The Web SDK adopts a resource-based API pattern, while the Rust SDK gains a new `Keystore` trait, lazy readers, and streamlined state sync. Review both sections if you maintain cross-platform code.
+:::warning Breaking Change
+v0.15 rebuilds the client RPC surface around the node's `GetAccount` endpoint: `get_account_proof` / `get_account_details` are reshaped, `check_nullifiers` is **removed** (use `sync_nullifiers`), and most sync methods now require an explicit `block_to`. The Web SDK moved to the 0.15 protocol surface — there is no more `"network"` storage mode, the WASM `AccountType` narrowed to `{ Private, Public }`, attachments are word‑vector‑shaped, `Felt` / `Word` throw on overflow, several methods return `undefined` / `string` instead of throwing or returning objects, the raw client's `proveTransactionWithProver` is renamed `proveTransaction`, and `storeIdentifier()` went async. Review every sub‑section below if you maintain Rust, Web, React, or CLI client code.
 :::
 
----
-
-## Web SDK
-
-### New resource-based MidenClient API
-
-The monolithic `WebClient` god-object has been replaced by `MidenClient` with dedicated resource sub-objects. All operations are now accessed through typed namespaces: `client.accounts`, `client.transactions`, `client.notes`, `client.tags`, `client.settings`, `client.compile`, and `client.keystore`.
-
-#### Construction
-
-```typescript
-// Before (0.13)
-import { WebClient } from "@miden-sdk/miden-sdk";
-
-const client = new WebClient();
-await client.createClient({
-  node_url: "https://rpc.testnet.miden.io",
-  store_name: "my-store",
-});
-```
-
-```typescript
-// After (0.14)
-import { MidenClient, AccountType } from "@miden-sdk/miden-sdk";
-
-const client = await MidenClient.create({
-  rpcUrl: "https://rpc.testnet.miden.io",
-  noteTransportUrl: "https://ntx.testnet.miden.io",
-  storeName: "my-store",
-});
-
-// Or use the testnet convenience constructor
-const client = await MidenClient.createTestnet();
-```
-
-#### Account creation
-
-```typescript
-// Before (0.13)
-const wallet = await client.newWallet(
-  AccountStorageMode.private(),
-  true,
-  undefined,
-);
-const faucet = await client.newFaucet(
-  AccountStorageMode.public(),
-  false,
-  "DAG",
-  8,
-  BigInt(10_000_000),
-);
-```
-
-```typescript
-// After (0.14)
-const wallet = await client.accounts.create(); // mutable, private wallet (defaults)
-const faucet = await client.accounts.create({
-  type: AccountType.FungibleFaucet,
-  symbol: "DAG",
-  decimals: 8,
-  maxSupply: 10_000_000n,
-  storage: "public",
-});
-```
-
-#### Sending assets
-
-```typescript
-// Before (0.13)
-const request = client.newSendTransactionRequest(
-  wallet.id(),
-  AccountId.fromHex(targetHex),
-  faucet.id(),
-  NoteType.private(),
-  BigInt(100),
-  null,
-  null,
-);
-const tx = await client.submitNewTransaction(wallet.id(), request);
-```
-
-```typescript
-// After (0.14)
-const { txId } = await client.transactions.send({
-  account: wallet,        // executing (sender) account
-  to: targetHex,          // string hex ID, AccountId, or Account all accepted
-  token: faucet,          // faucet account that minted the asset
-  amount: 100n,
-  waitForConfirmation: true,
-});
-```
-
-#### Consuming notes
-
-```typescript
-// Before (0.13)
-const notes = await client.getConsumableNotes(wallet.id());
-const req = client.newConsumeTransactionRequest(
-  [notes[0].inputNoteRecord().id().toString()],
-);
-await client.submitNewTransaction(wallet.id(), req);
-```
-
-```typescript
-// After (0.14)
-const notes = await client.notes.listAvailable({ account: wallet });
-await client.transactions.consume({ account: wallet, notes: [notes[0]] });
-
-// Or consume every available note in one call:
-await client.transactions.consumeAll({ account: wallet });
-```
-
-#### Listing accounts
-
-```typescript
-// Before (0.13)
-const accounts = await client.getAccounts();
-```
-
-```typescript
-// After (0.14)
-const accounts = await client.accounts.list();
-```
-
-#### Custom contracts
-
-The new API adds first-class support for deploying custom smart contracts:
-
-```typescript
-// After (0.14) — compile and deploy a custom contract
-const component = await client.compile.component({
-  code: contractMasm,
-  slots: [],
-});
-
-const contract = await client.accounts.create({
-  type: AccountType.MutableContract,
-  seed: new Uint8Array(32),
-  auth: secretKey,
-  components: [component],
-});
-
-// Compile a transaction script and execute it against the contract.
-const script = await client.compile.txScript({
-  code: scriptMasm,
-});
-await client.transactions.execute({ account: contract, script });
-```
+Sub‑sections are grouped by surface — **Rust client**, **Web SDK**, **React SDK**, and **CLI**. Each change keeps its own `##` heading prefixed with `(Rust)` / `(Web)` / `(React)` / `(CLI)`.
 
 ---
 
-### AccountId.fromHex and key getters return Result
+## (Rust) `NodeRpcClient` `GetAccount` surface reshaped
 
-`AccountId.fromHex()` and related key getter methods previously called `unwrap()` internally and panicked on invalid input. They now return a `Result` type that throws on error in JavaScript.
+### Summary
+The account‑fetching surface on the `NodeRpcClient` trait was rebuilt around the node's `/GetAccount` endpoint:
+- `get_account_proof(account_id, storage_requirements, account_state, known_account_code, known_vault_commitment)` was **replaced** by `get_account(account_id, request: GetAccountRequest)`, where `GetAccountRequest` bundles the previous positional args behind a builder.
+- `get_account_details` no longer returns a `FetchedAccount` enum — it returns `Result<Option<Account>, RpcError>` (`None` for accounts without public state), fetching all of a public account's storage maps and vault in a single round‑trip. It no longer returns anything for private accounts; use `get_account` for a private account's commitment.
+- New default helpers `resolve_oversize_vault` / `resolve_oversize_storage_maps` fill in vault/map entries the node flagged as oversize.
 
+`GetAccountRequest`, `StorageMapFetch`, `VaultFetch`, and `AccountStateAt` live under `miden_client::rpc::domain`.
+
+### Affected Code
+```rust
+// 0.15 — new API:
+use miden_client::rpc::domain::account::{GetAccountRequest, StorageMapFetch, VaultFetch};
+let (block, proof) = rpc_api
+    .get_account(account_id, GetAccountRequest::new()
+        .with_storage(StorageMapFetch::All)
+        .with_vault(VaultFetch::Always)
+        .with_known_code(Some(known_code)))
+    .await?;
+let account: Option<Account> = rpc_api.get_account_details(account_id).await?;
+```
+
+### Migration Steps
+1. Replace `get_account_proof(...)` calls with `get_account(account_id, GetAccountRequest::new()....)`; move each positional arg onto the corresponding builder method.
+2. Replace `match FetchedAccount { Public | Private }` on `get_account_details` with `Option<Account>` handling; route private‑account commitment lookups through `get_account`.
+3. The default `get_account_details` now calls `resolve_oversize_vault` / `resolve_oversize_storage_maps` for you.
+
+---
+
+## (Rust) `NodeRpcClient`: `SyncTarget`, `check_nullifiers` removed, required `block_to`
+
+### Summary
+Several `NodeRpcClient` methods changed to match the `0.15` RPC definitions:
+- `sync_chain_mmr`'s `block_to: Option<BlockNumber>` became `upper_bound: SyncTarget`. Use `SyncTarget::CommittedChainTip` for the old `None` behavior, `SyncTarget::ProvenChainTip` for the latest proven block, or `SyncTarget::BlockNumber(n)` for a specific height.
+- `check_nullifiers` (and `RpcEndpoint::CheckNullifiers`, `EndpointError::CheckNullifiers`, `CheckNullifiersError`) were **removed**. Use `sync_nullifiers` to retrieve nullifier updates.
+- `sync_nullifiers`, `sync_notes`, `sync_notes_with_details`, `sync_storage_maps`, and `sync_account_vault` lost their `Option<BlockNumber>` upper bound in favor of a required `block_to: BlockNumber`.
+- `get_block_by_number` gained an `include_proof: bool` parameter.
+- `submit_proven_batch` is a new required trait method.
+
+`SyncTarget` lives at `miden_client::rpc::domain::sync::SyncTarget`.
+
+### Affected Code
+```rust
+// 0.15 — new API:
+use miden_client::rpc::domain::sync::SyncTarget;
+let mmr = rpc_api.sync_chain_mmr(block_from, SyncTarget::CommittedChainTip).await?;
+let updates = rpc_api.sync_nullifiers(&prefixes, block_from, chain_tip).await?; // check_nullifiers is gone
+let block = rpc_api.get_block_by_number(block_num, /* include_proof */ false).await?;
+```
+
+### Migration Steps
+1. Replace `sync_chain_mmr(_, None)` with `sync_chain_mmr(_, SyncTarget::CommittedChainTip)`; map any explicit `Some(n)` to `SyncTarget::BlockNumber(n)`.
+2. Replace `check_nullifiers` with `sync_nullifiers` and adapt to `Vec<NullifierUpdate>` (drop the `SmtProof` path).
+3. Pass an explicit `block_to` (e.g. the client's current sync height / chain tip) to `sync_nullifiers`, `sync_notes`, `sync_storage_maps`, `sync_account_vault`.
+4. Add `include_proof` to `get_block_by_number` calls (`false` unless you need the block proof).
+5. If you implement `NodeRpcClient` yourself, add `submit_proven_batch`.
+
+---
+
+## (Rust) Note‑import APIs return `Vec<NoteDetailsCommitment>`
+
+### Summary
+`Client::import_notes`, `Client::sync_note_transport`, and the `SyncSummary::new_private_notes` field now yield `Vec<NoteDetailsCommitment>` instead of `Vec<NoteId>`. A metadata‑less import has no `NoteId` yet, so the client identifies such notes by their metadata‑independent details commitment. Resolve a commitment back to a record with `Client::get_input_notes(NoteFilter::DetailsCommitments(vec![..]))`.
+
+### Affected Code
+```rust
+// 0.15 — new API:
+use miden_client::store::NoteFilter;
+use miden_protocol::note::NoteDetailsCommitment;
+let imported: Vec<NoteDetailsCommitment> = client.import_notes(&note_files).await?;
+let private:  Vec<NoteDetailsCommitment> = sync_summary.new_private_notes;
+// Resolve commitments to the stored records (works even before metadata is known):
+let records = client.get_input_notes(NoteFilter::DetailsCommitments(imported)).await?;
+```
+
+### Migration Steps
+1. Change the bound type of `import_notes` / `sync_note_transport` results and the `SyncSummary::new_private_notes` field from `NoteId` to `NoteDetailsCommitment`.
+2. Where you used a returned `NoteId` to look a note up, switch to `NoteFilter::DetailsCommitments(..)` against `get_input_notes`.
+
+---
+
+## (Rust) `FungibleFaucet` builder + `TokenPolicyManager` construction
+
+### Summary
+The fungible‑faucet construction story was redesigned end to end. The client previously re‑exported `BasicFungibleFaucet` plus the `MintAuthControlled` / `MintOwnerControlled` / `BurnAuthControlled` / `BurnOwnerControlled` policy components. In `0.15`:
+- The faucet component is `FungibleFaucet`, built via `FungibleFaucet::builder()`.
+- Mint/burn policy is configured by installing a single `TokenPolicyManager` (`.with_mint_policy(MintPolicyConfig, PolicyRegistration).with_burn_policy(...)`), with standalone `MintAllowAll` / `MintOwnerOnly` / `BurnAllowAll` / `BurnOwnerOnly` policy components. The old `Mint*Controlled` / `Burn*Controlled` types were removed.
+
+These are re‑exported from `miden_client::account`.
+
+### Affected Code
+```rust
+// 0.15 — new API:
+use miden_client::account::{
+    AccountBuilder, AccountType, FungibleFaucet, TokenName, TokenPolicyManager,
+    MintPolicyConfig, BurnPolicyConfig, PolicyRegistration,
+};
+use miden_protocol::asset::AssetAmount;
+let faucet = FungibleFaucet::builder()
+    .name(TokenName::new(&symbol.to_string())?).symbol(symbol).decimals(10)
+    .max_supply(AssetAmount::new(max_supply)?).build()?;
+let policy_manager = TokenPolicyManager::new()
+    .with_mint_policy(MintPolicyConfig::AllowAll, PolicyRegistration::Active)?
+    .with_burn_policy(BurnPolicyConfig::AllowAll, PolicyRegistration::Active)?;
+let account = AccountBuilder::new(init_seed)
+    .account_type(account_visibility)              // AccountType::Public / ::Private
+    .with_auth_component(auth_component)
+    .with_component(faucet)
+    .with_components(policy_manager)
+    .build_with_schema_commitment()?;
+```
+
+### Migration Steps
+1. Replace `BasicFungibleFaucet::new(symbol, decimals, max_supply)` with `FungibleFaucet::builder()....build()`, wrapping `max_supply` in `AssetAmount::new(..)`.
+2. Replace the standalone mint‑policy component with a `TokenPolicyManager` configured via `with_mint_policy` / `with_burn_policy`, installed with `.with_components(policy_manager)`.
+3. Drop `Mint*Controlled` / `Burn*Controlled` imports.
+
+---
+
+## (Rust) `InputNoteRecord::new` takes `NoteAttachments`; store `attachments` column
+
+### Summary
+`InputNoteRecord::new` gained a second positional parameter, `attachments: NoteAttachments`, so input notes persist their attachment content. The SQLite store's `input_notes` table gained an `attachments` column. `NoteAttachments` is re‑exported from `miden_client::note`.
+
+### Migration Steps
+1. Thread a `NoteAttachments` (or `NoteAttachments::default()`) into every `InputNoteRecord::new` call as the second argument.
+2. If you use a custom `Store`, add an `attachments` column to your input‑notes table and persist/load it.
+
+---
+
+## (Rust) `sync_notes` / `sync_transactions` return updates directly
+
+### Summary
+`sync_notes` and `sync_transactions` now return the fetched updates directly. The wrapper structs `NoteSyncInfo` and `TransactionsInfo` were removed: `sync_notes` returns `Vec<NoteSyncBlock>` and `sync_transactions` returns `Vec<TransactionRecord>`.
+
+### Migration Steps
+1. Drop the `.blocks` / `.transactions` field access — the methods return the collections directly.
+2. Source the chain tip separately (e.g. `get_block_header_by_number(None, false)`) where you previously read it off `NoteSyncInfo`.
+
+---
+
+## (Rust) `get_note_script_by_root` returns `Option<NoteScript>`
+
+### Summary
+`NodeRpcClient::get_note_script_by_root` no longer errors when the node has no script registered for the requested root — it returns `Ok(None)`. Implementations must still verify a returned script's root matches the request.
+
+### Migration Steps
+1. Handle the `Option` — `None` means "no script for this root", which previously surfaced as an error.
+
+---
+
+## (Rust) `miden_client::note` re‑exports realigned
+
+### Summary
+The protocol split attachment data off `NoteMetadata`, and the client's `note` re‑exports follow:
+- **Removed:** `NoteAttachmentKind`, `NoteMetadataHeader`.
+- **Added:** `NoteAttachmentHeader`, `NoteAttachments`, `PartialNoteMetadata`.
+- `NoteScript::root()` now returns `NoteScriptRoot` (re‑exported from `miden_client::note`) instead of `Word`.
+
+### Migration Steps
+1. Replace `NoteAttachmentKind` / `NoteMetadataHeader` imports with `NoteAttachmentHeader` / `NoteAttachments` / `PartialNoteMetadata` as needed.
+2. Where `note_script.root()` was used as a `Word`, insert a `.into()` / `Word::from(..)` conversion.
+
+---
+
+## (Rust) `CommittedNoteMetadata` removed
+
+### Summary
+The `CommittedNoteMetadata` enum (with `Full(NoteMetadata)` and a header‑only `Header { sender, note_type, tag, attachment_kind }` variant) was removed. Sync responses now always carry full metadata, so `CommittedNote::metadata()` returns `&NoteMetadata` directly — no `Option`, no header‑only case.
+
+### Migration Steps
+1. Delete the `CommittedNoteMetadata` match — read `NoteMetadata` directly off the committed note.
+
+---
+
+## (Rust) `build_wallet_id` signature
+
+### Summary
+`build_wallet_id` dropped its trailing `is_mutable: bool` (code mutability isn't encoded in the account ID) and its `storage_mode: AccountStorageMode` parameter was replaced by `account_visibility: AccountType`.
+
+### Migration Steps
+1. Drop the `is_mutable` argument.
+2. Replace the `AccountStorageMode` argument with the corresponding `AccountType` visibility.
+
+---
+
+## (Rust) `compile_note_script` expects a `@note_script` library
+
+### Summary
+`client.code_builder().compile_note_script(src)` now expects a MASM **library** with a single procedure annotated `@note_script` instead of a bare `begin … end` program (the underlying assembly switched from `assemble_program` to `assemble_library`).
+
+### Migration Steps
+1. Wrap each note‑script body in `@note_script` + `pub proc main … end`; remove the `begin … end` framing.
+
+---
+
+## (Web) `AccountStorageMode.network()` removed
+
+### Summary
+The `0.15` chain has no separate network‑account flag. `AccountStorageMode.network()` was removed, and the `StorageMode` string union dropped `"network"` (it is now `"public" | "private"`). Anywhere you constructed a network‑mode account — `AccountStorageMode.network()`, `StorageMode.Network`, or `accounts.create({ storage: "network" })` — must switch to `"public"` or `"private"`. `AccountStorageMode.tryFromStr("network")` now rejects.
+
+### Affected Code
 ```typescript
-// Before (0.13) — panics on invalid hex
-const id = AccountId.fromHex(hexString);
-
-// After (0.14) — throws a descriptive error on invalid hex
-try {
-  const id = AccountId.fromHex(hexString);
-} catch (e) {
-  console.error("Invalid account ID:", e.message);
-}
+// 0.15 — new API:
+const mode = AccountStorageMode.public();          // or .private()
+await client.accounts.create({ storage: "public" });   // "public" | "private"
 ```
+
+### Migration Steps
+1. Replace every `AccountStorageMode.network()` with `.public()` or `.private()`.
+2. Replace `StorageMode.Network` / the `"network"` string with `"public"` or `"private"`.
+3. Audit `accounts.create({ storage })` and any `tryFromStr` call sites for `"network"`.
 
 ---
 
-### Keystore API moved to client.keystore sub-object
+## (Web) `AccountType` narrowed; faucet checks move to `Account`
 
-Top-level keystore functions have been consolidated into the `client.keystore` namespace:
+### Summary
+The on‑chain `AccountType` no longer encodes faucet‑vs‑regular or updatable‑vs‑immutable. The WASM‑exported `AccountType` enum narrowed from `{ FungibleFaucet, NonFungibleFaucet, RegularAccountImmutableCode, RegularAccountUpdatableCode }` to `{ Private, Public }`. As a result:
+- `AccountId.isFaucet()`, `AccountId.isNetwork()`, and `AccountId.isRegularAccount()` were **removed** (only `isPublic()` / `isPrivate()` remain).
+- Faucet / regular detection now lives on `Account`: `Account.isFaucet()` / `Account.isRegularAccount()`.
+- `Account.isNetwork()` and `Account.isUpdatable()` were **removed** outright.
 
+> This is the low‑level WASM `AccountType` enum. The high‑level resource‑API `AccountType` constant used by `accounts.create({ type: "FungibleFaucet" | ... })` is unchanged.
+
+### Affected Code
 ```typescript
-// Before (0.13)
-import { addAccountSecretKeyToWebStore, getAccountSecretKeyFromWebStore } from "@miden-sdk/miden-sdk";
-
-await addAccountSecretKeyToWebStore(accountId, secretKey);
-const key = await getAccountSecretKeyFromWebStore(accountId);
+// 0.15 — new API:
+if (account.isFaucet()) {}          // moved onto Account
+if (account.isRegularAccount()) {}
+if (account.id().isPublic()) {}     // isPublic()/isPrivate() still on both
+// account.isNetwork() / account.isUpdatable() have no replacement — drop them.
 ```
 
+### Migration Steps
+1. Move `accountId.isFaucet()` / `.isRegularAccount()` onto the materialised `Account`. You need the full `Account`, not just its `AccountId`.
+2. Remove `accountId.isNetwork()`, `account.isNetwork()`, and `account.isUpdatable()` — they have no replacement.
+3. Replace any `switch` on the WASM `AccountType` enum's faucet/regular variants with the `Account` predicates; the enum only carries `Private` / `Public` now.
+
+---
+
+## (Web) `NoteAttachment` reshaped to word‑vector content
+
+### Summary
+Attachments are now always word‑vector‑shaped. The `NoteAttachmentKind { Word, Array }` dispatch and the per‑variant accessors/constructors `NoteAttachment.newWord` / `.newArray` / `.asWord` / `.asArray`, the `attachmentKind` getter, and the `NoteMetadata.attachment()` getter were all **removed**. Build attachments with `NoteAttachment.fromWord(scheme, word)` or `NoteAttachment.fromWords(scheme, words)`, and read them back with `NoteAttachment.toWords()`. The attachment words now live on the note record (`InputNoteRecord.attachments()`), not on `NoteMetadata`. `NoteAttachmentScheme` is now u16‑backed: its constructor throws if the value exceeds the u16 range, and `NoteAttachmentScheme.asU32()` was removed.
+
+### Affected Code
 ```typescript
-// After (0.14)
-await client.keystore.insert(accountId, secretKey);
-const key = await client.keystore.get(pubKeyCommitment);       // takes a Word commitment
-const commitments = await client.keystore.getCommitments(accountId);
-const id = await client.keystore.getAccountId(pubKeyCommitment);
+// 0.15 — new API:
+const att = NoteAttachment.fromWord(scheme, word);    // single word
+const attMulti = NoteAttachment.fromWords(scheme, [w0, w1]);
+const words = att.toWords();                          // Word[] — inverse of fromWord/fromWords
+// NoteAttachmentKind, asWord, asArray, attachmentKind, scheme.asU32(),
+// and NoteMetadata.attachment() no longer exist.
 ```
+
+### Migration Steps
+1. Replace `NoteAttachment.newWord(scheme, word)` with `NoteAttachment.fromWord(scheme, word)` and `newArray(scheme, felts)` with `fromWords(scheme, words)`.
+2. Replace `att.asWord()` / `att.asArray()` / `att.attachmentKind()` reads with `att.toWords()` and decode the `Word[]` yourself.
+3. Replace `noteMetadata.attachment()` with `inputNoteRecord.attachments()`.
+4. Drop `NoteAttachmentScheme.asU32()`; the scheme is u16‑backed and its constructor validates the range.
 
 ---
 
-## Rust SDK
+## (Web) `InputNoteRecord.id()` returns `NoteId | undefined`; IDB re‑keyed
 
-### Keystore trait replaces TransactionAuthenticator in Client
+### Summary
+A partial (metadata‑less) input note has no note ID yet, so `InputNoteRecord.id()` now returns `NoteId | undefined`. A new `InputNoteRecord.attachments()` getter returns the note's attachments (`NoteAttachment[]`; empty when none). On the storage side, `miden-idxdb-store` now keys input notes by their **details commitment** instead of their note ID (matching the SQLite store): the `InputNotes` table's primary index changed from `noteId` to `detailsCommitment`, so a partial note later completed with its note ID updates the same row instead of creating a duplicate.
 
-The new `Keystore` super-trait extends `TransactionAuthenticator` and consolidates key management. The client no longer requires separate calls to register public key commitments.
-
-```rust
-// Before (0.13)
-keystore.insert_key(&secret).await?;
-client.register_account_public_key_commitments(
-    account_id,
-    &[public_key_commitment],
-).await?;
+### Affected Code
+```typescript
+// 0.15 — new API:
+const id = record.id();                          // NoteId | undefined
+if (id) { const idStr = id.toString(); }
+const attachments = record.attachments();        // NoteAttachment[]
 ```
 
-```rust
-// After (0.14)
-// Keystore::add_key handles both storage and commitment registration
-keystore.add_key(&secret, account_id).await?;
-```
-
-The `Client::new()` constructor now accepts `impl Keystore` instead of `impl TransactionAuthenticator`:
-
-```rust
-// Before (0.13)
-let client = Client::new(rpc, store, authenticator, ...);
-
-// After (0.14)
-let client = Client::new(rpc, store, keystore, ...);
-```
+### Migration Steps
+1. Guard every `record.id()` use against `undefined` (partial notes have no ID).
+2. Replace `noteMetadata.attachment()` reads with `record.attachments()`.
+3. If you query IndexedDB directly, switch input‑note lookups from `noteId` to `detailsCommitment`. Re‑sync existing `0.14` stores under `0.15`.
 
 ---
 
-### New AccountReader and InputNoteReader
+## (Web) `importNoteFile` / `notes.import` resolve to a hex `string`
 
-Lazy readers allow you to access account and note data without loading everything into memory at once.
+### Summary
+`WebClient.importNoteFile(...)` (and `notes.import(...)`) now resolves to a hex `string` instead of a `NoteId` object. Upstream `Client::import_notes` returns details‑commitments rather than note IDs, so the web method returns the note‑id hex for a metadata‑bearing file, or the details‑commitment hex for a details‑only file. Pass it to `NoteId.fromHex(...)` if you need a `NoteId` instance.
 
-```rust
-// Before (0.13) — loads the full Account object
-let account = client.get_account(account_id).await?.unwrap();
-let vault = account.vault();
-let storage = account.storage();
-```
-
-```rust
-// After (0.14) — lazy reader exposes commitments, balances, and storage items
-let reader = client.account_reader(account_id);
-let (header, status) = reader.header().await?;
-let balance = reader.get_balance(faucet_id).await?;
-let storage_item = reader.get_storage_item(slot_name).await?;
-// plus reader.nonce(), vault_root(), storage_commitment(), code_commitment()
-```
-
-```rust
-// After (0.14) — lazy, iterator-style traversal of notes consumable by an account
-let mut notes = client.input_note_reader(consumer_account_id);
-while let Some(note) = notes.next().await? {
-    // process each InputNoteRecord
-}
-```
+### Migration Steps
+1. Treat the return value as a hex `string`; drop any `.toString()` / `NoteId` method calls on it.
+2. If you need a `NoteId`, wrap the result with `NoteId.fromHex(hex)`.
+3. Be aware the returned hex may be a details‑commitment (not a note‑id) for details‑only files.
 
 ---
 
-### Lazy foreign-account loading
+## (Web) `Felt` and `Word` constructors throw on overflow
 
-Public foreign accounts are now fetched automatically via RPC when needed during transaction execution. You only need to provide `PartialAccount` data upfront for **private** foreign accounts.
+### Summary
+`new Felt(value)` and `new Word(values)` now throw when an input is at or beyond the field modulus, instead of silently constructing an out‑of‑range value. Each input must be a canonical field element. Wrap construction from untrusted input in `try`/`catch`.
 
-```rust
-// Before (0.13) — all foreign accounts had to be provided
-let foreign_accounts = vec![
-    ForeignAccount::public(public_account_id).await?,
-    ForeignAccount::private(private_partial_account),
-];
-let tx_request = TransactionRequestBuilder::new()
-    .with_foreign_accounts(foreign_accounts)
-    .build()?;
-
-// After (0.14) — only private foreign accounts need explicit loading
-let tx_request = TransactionRequestBuilder::new()
-    .with_foreign_accounts(vec![
-        ForeignAccount::private(private_partial_account),
-    ])
-    .build()?;
-// Public foreign accounts are auto-fetched via RPC during execution
-```
+### Migration Steps
+1. Reduce or validate values to the field modulus before constructing `Felt` / `Word`, or catch the thrown error.
+2. Audit any code that fed raw `u64` / `bigint` values (e.g. from external systems) into these constructors.
 
 ---
 
-### StorageMapKey is now a newtype
+## (Web) `syncNotes` `blockTo` required; `chainTip()` removed
 
-`StorageMapKey` was previously a type alias for `Word`. It is now a proper newtype, and the `LexicographicWord` wrapper has been removed.
+### Summary
+`RpcClient.syncNotes(blockFrom, blockTo, noteTags)`'s `blockTo` parameter is now **required** (was optional). The upstream RPC no longer returns the chain tip, so `NoteSyncInfo.chainTip()` was removed — use `client.syncState()` to learn the chain tip. `NoteSyncInfo.blockTo()` still exists.
 
-```rust
-// Before (0.13)
-use miden_objects::accounts::StorageMapKey;
-let key: StorageMapKey = [felt0, felt1, felt2, felt3]; // Was just a Word alias
-
-// After (0.14)
-use miden_protocol::account::StorageMapKey;
-use miden_protocol::Word;
-let key = StorageMapKey::new(Word::from([felt0, felt1, felt2, felt3]));
-// LexicographicWord is no longer needed — StorageMapKey handles ordering.
-// For sequential u32 keys, use the StorageMapKey::from_index(idx) shortcut.
-```
+### Migration Steps
+1. Always pass an explicit `blockTo` to `syncNotes`.
+2. Replace `NoteSyncInfo.chainTip()` reads with `client.syncState()`.
 
 ---
 
-### `sync_state()` no longer takes arguments; `StateSyncInput` now internal
+## (Web) `getNoteScriptByRoot` returns `NoteScript | undefined`
 
-`Client::sync_state()` builds its own `StateSyncInput` from the current store state — you no longer pass `account_ids`, `note_tags`, or `nullifiers` by hand. For custom sync scenarios, construct a `StateSyncInput` explicitly via `Client::build_sync_input()` and use the lower-level `StateSync` type.
+### Summary
+`RpcClient.getNoteScriptByRoot(scriptRoot)` now resolves to `NoteScript | undefined` instead of throwing when the node has no script for the given root.
 
-```rust
-// Before (0.13)
-client.sync_state(
-    &mut partial_mmr,
-    account_ids,
-    note_tags,
-    nullifiers,
-).await?;
-```
-
-```rust
-// After (0.14)
-let summary = client.sync_state().await?;
-
-// For custom sync scenarios, build the input manually:
-use miden_client::sync::StateSyncInput;
-let input: StateSyncInput = client.build_sync_input().await?;
-// …tweak `input.note_tags`, `input.input_notes`, etc. and drive
-// a `StateSync` instance directly.
-```
+### Migration Steps
+1. Replace the `try`/`catch` "not found" path with an `=== undefined` check.
+2. Keep a `try`/`catch` only for genuine transport/RPC failures.
 
 ---
 
-### MSRV 1.93
+## (Web) `FetchedNote` exposes `noteId`/`metadata`; `header` removed
 
-The minimum supported Rust version is now **1.93**. Update your toolchain:
+### Summary
+`FetchedNote` (returned by `RpcClient.getNotesById(...)`) now stores `noteId` and `metadata` directly and exposes them as getters. The synthetic `header` getter was **removed** — a `NoteHeader` can no longer be reconstructed from header‑shaped fields alone for private notes. A new `attachments` getter exposes the note's attachments (populated for both public and private fetched notes). The JS constructor signature is unchanged.
 
-```toml title="rust-toolchain.toml"
-[toolchain]
-channel = "1.93"
-```
-
----
-
-### CLI: CliConfig::load and CliClient::new
-
-The CLI configuration and client constructors have been renamed for consistency.
-
-```rust
-// Before (0.13)
-let config = CliConfig::from_system()?;
-let client = CliClient::from_system_user_config(config, keystore).await?;
-```
-
-```rust
-// After (0.14)
-let config = CliConfig::load()?;
-let client = CliClient::new(config, keystore).await?;
-```
+### Migration Steps
+1. Replace `fetched.header.id()` with `fetched.noteId` and `fetched.header.metadata()` with `fetched.metadata`.
+2. Remove any code that reconstructs a `NoteHeader` from a `FetchedNote`.
+3. Read attachments via `fetched.attachments` (works for private notes too).
 
 ---
 
-## New Client Features
+## (Web) `newFaucet` rebuilt on `FungibleFaucet` + `TokenPolicyManager`
 
-:::info New in v0.14
-These are new capabilities introduced in v0.14 that do not require migration but are worth adopting.
-:::
+### Summary
+`WebClient.newFaucet(...)` (and `accounts.create({ type: "FungibleFaucet", ... })`) now assembles a faucet from the `0.15` `FungibleFaucet` component plus a `TokenPolicyManager` that registers `AllowAll` mint and burn policies (transfer policies are intentionally omitted). `non_fungible = true` still fails fast. The JS signature `newFaucet(storageMode, nonFungible, tokenName, tokenSymbol, decimals, maxSupply, authScheme)` is unchanged. Separately, `BasicFungibleFaucetComponent.fromAccount(account)` now reads the new `0.15` metadata slot, so **faucets minted by prior SDK versions can no longer be introspected through it**.
 
-- **NoteScreener and batch screening** - The `Client::note_screener()` API provides efficient batch screening of notes against account filters, replacing manual note-by-note checking.
+### Migration Steps
+1. No call‑site change for creating faucets — the JS signature is the same.
+2. Re‑create faucets under `0.15` if you need `BasicFungibleFaucetComponent.fromAccount(...)` to introspect them.
+3. Keep passing `non_fungible = false`; `true` still throws "Non‑fungible faucets are not supported yet".
 
-- **Account history pruning** - New methods allow pruning old account state history to reduce local storage usage while preserving the current state.
+---
 
-- **GrpcClient automatic retry on rate limiting** - The gRPC client now automatically retries requests when rate-limited by the node, with up to 5 retries and honoring the server's `retry-after` header.
+## (Web) `idxdb-store`: `committedNoteIds` → `committedNoteTagSources`
 
-- **Automatic NTX note script registration** - Note scripts sent via the NTX transport are now registered automatically. Manual `register_note_script()` calls are no longer needed.
+### Summary
+On `miden-idxdb-store`'s `JsStateSyncUpdate`, the `committedNoteIds` field was renamed to `committedNoteTagSources` and now carries details‑commitment hex rather than note‑id hex. Anyone driving the IndexedDB store's sync apply path directly (or stubbing `JsStateSyncUpdate` in tests) must rename the field and feed details‑commitment hex.
 
-- **Typed RPC error parsing** - RPC errors are now parsed into structured Rust types, enabling programmatic error handling instead of string matching on error messages.
+### Migration Steps
+1. Rename `committedNoteIds` → `committedNoteTagSources` everywhere you construct or read `JsStateSyncUpdate`.
+2. Supply details‑commitment hex (not note‑id hex) for those entries.
+
+---
+
+## (Web) `getAccountProof` rewired; WASM `ClientError` gains a `code`
+
+### Summary
+Two smaller web changes:
+- `RpcClient.getAccountProof(accountId, storageRequirements?, blockNum?, knownVaultCommitment?)` keeps the **same JS signature** but is now wired onto the `0.15` `get_account(GetAccountRequest...)` upstream API. No JS call‑site change is required; it needs a `0.15` node.
+- WASM client errors now carry a stable, machine‑readable **`code`** property on the thrown JS error — currently `ACCOUNT_NOT_FOUND_ON_CHAIN` and `ACCOUNT_ALREADY_TRACKED`. This is additive (message‑string matching still works) but branching on `code` is the recommended pattern, and the worker shim forwards it.
+
+### Migration Steps
+1. Point `getAccountProof` callers at a `0.15` node (the underlying RPC was renamed/reshaped).
+2. Where you match on `ClientError` message text for "account not found on chain" or "already tracked", switch to `error.code`. Keep a fallback for errors without a `code` (only those two variants are mapped today).
+
+---
+
+## (Web) `WasmWebClient.proveTransactionWithProver` → `proveTransaction`
+
+### Summary
+On the raw WASM client (`WasmWebClient` — the low-level surface behind `MidenClient`), `proveTransactionWithProver(txResult, prover)` was **renamed `proveTransaction(txResult, prover?)`**, with the prover now an optional second parameter (omitting it uses the local prover). The high-level `MidenClient` resource API is unaffected, but anything driving the raw client directly — worker shims, offscreen/prover documents, `_withInnerWebClient` callbacks — must rename the call.
+
+### Affected Code
+```typescript
+// 0.15 — new API (raw WasmWebClient surface):
+const proven = await wasmWebClient.proveTransaction(txResult, prover);
+// prover may be omitted to prove locally:
+const proven2 = await wasmWebClient.proveTransaction(txResult);
+```
+
+### Migration Steps
+1. Rename `proveTransactionWithProver(txResult, prover)` to `proveTransaction(txResult, prover)`.
+2. Audit any code that already called a 0.14 `proveTransaction()` *without* a prover — the 0.15 signature is compatible (prover optional), no change needed.
+
+---
+
+## (Web) `storeIdentifier()` is now async
+
+### Summary
+`MidenClient.storeIdentifier()` now returns a **`Promise<string>`** instead of a plain `string` (the identifier is read from the client behind the worker/async boundary). Call sites that fed the result into `exportStore` / `importStore` or string operations must `await` it.
+
+### Migration Steps
+1. `await client.storeIdentifier()` everywhere; un-awaited uses surface as `Promise<string>`-vs-`string` type errors (or `[object Promise]` store names at runtime).
+
+---
+
+## (Web) `InputNoteRecord.nullifier()` returns `string | undefined`
+
+### Summary
+Because a 0.15 nullifier folds in the note's metadata (see [Nullifier now includes metadata and attachments commitment](./note-changes#nullifier-now-includes-metadata-and-attachments-commitment)), a **partial (metadata-less) input note record has no computable nullifier** — `InputNoteRecord.nullifier()` now returns `string | undefined`, pairing with `id()`'s `NoteId | undefined`. A record missing either is a partial note that sync has not yet completed.
+
+### Migration Steps
+1. Guard `record.nullifier()` against `undefined` alongside the existing `record.id()` guard; treat records missing either as not-yet-consumable and skip them from listings.
+
+---
+
+## (React) `useCreateWallet` / `useCreateFaucet` drop `"network"`
+
+### Summary
+Matching the `StorageMode` narrowing, the React `useCreateWallet({ storageMode })` and `useCreateFaucet({ storageMode })` hooks no longer accept `"network"`. The `storageMode` option type is now `"private" | "public"`.
+
+### Migration Steps
+1. Replace `storageMode: "network"` with `"public"` or `"private"` in every `createWallet` / `createFaucet` call.
+2. Update any local `StorageMode`‑typed state feeding these hooks.
+
+---
+
+## (CLI) `--account-type` accepts only `private` / `public`
+
+### Summary
+The `-t` / `--account-type` flag on `new-account` / `new-wallet` now takes only `private` or `public` (account *visibility*); the legacy values (`fungible-faucet`, `non-fungible-faucet`, `regular-account-immutable-code`, `regular-account-updatable-code`), the separate `--mutable` flag, and the standalone `--storage-mode` toggle were removed. Whether an account is a faucet is derived from its components — installing a `FungibleFaucet` component yields a fungible faucet (with an implicit `TokenPolicyManager`).
+
+### Affected Code
+```diff
+# 0.15 — new API:
++ miden-client new-wallet --account-type public
+```
+
+### Migration Steps
+1. Replace `--account-type <regular/faucet variant>` with `--account-type private|public`.
+2. Drop `--mutable` and `--storage-mode`; pick the faucet vs. wallet shape via the `-p` package/components.
+
+---
+
+## (CLI) `new-faucet` requires a `[fungible-faucet-metadata]` block
+
+### Summary
+The faucet init‑data file passed via `-i` now uses a typed `[fungible-faucet-metadata]` block (`symbol`, `decimals`, `max_supply`, optional `name`) instead of the old stringly‑typed `["miden::standards::fungible_faucets::metadata"]` section. Faucet accounts created with the previous layout are no longer recognized by `account list` / `account show`.
+
+### Affected Code
+```diff
+# 0.15 — new API: — init-data TOML
++ [fungible-faucet-metadata]
++ symbol = "BTC"
++ decimals = 10
++ max_supply = 10000000
+```
+
+### Migration Steps
+1. Rename the section to `[fungible-faucet-metadata]` and switch to typed scalars (`decimals` / `max_supply` are integers, not quoted strings).
+2. Re‑create existing faucets — the previous component layout is no longer recognized.
+
+---
+
+## (CLI) `address add` takes bech32; new `address encode`
+
+### Summary
+`address add` now takes `<ACCOUNT_ID> <BECH32_ADDRESS>` (a pre‑encoded address) instead of `<ACCOUNT_ID> <INTERFACE> [TAG_LEN]`. A new `address encode <ACCOUNT_ID> <INTERFACE> [TAG_LEN]` subcommand produces the bech32 string from the individual fields.
+
+### Affected Code
+```bash
+# 0.15 — new API:
+miden-client address encode <ACCOUNT_ID> <INTERFACE> [TAG_LEN]   # produces the bech32 string
+miden-client address add <ACCOUNT_ID> <BECH32_ADDRESS>          # stores the pre-encoded address
+```
+
+### Migration Steps
+1. Build the bech32 address first with `address encode <ACCOUNT_ID> <INTERFACE> [TAG_LEN]`.
+2. Pass that string to `address add <ACCOUNT_ID> <BECH32_ADDRESS>`.

--- a/docs/builder/migration/08-masm-changes.md
+++ b/docs/builder/migration/08-masm-changes.md
@@ -1,295 +1,92 @@
 ---
 sidebar_position: 8
 title: "MASM Changes"
-description: "New MASM features and standard library additions in v0.14"
+description: "Breaking MASM and standard-library changes in v0.15"
 ---
 
 # MASM Changes
 
-:::info New MASM Features
-Miden v0.14 introduces assembly-time string-literal constants (`word("...")`, `event("...")`) and new standard library modules for MASM, including native 128-bit unsigned integer arithmetic.
+:::warning Breaking Change
+Several core `miden::protocol::note` procedures were renamed; several kernel procedures dropped redundant outputs that duplicated their inputs; and the immediate form `adv_push.N` was removed. Custom note scripts and any MASM that consumed the removed outputs must be updated.
 :::
 
 ---
 
-## String-Literal Constants: `word("...")` and `event("...")`
+## Kernel/protocol proc renames: `build_recipient*`, `extract_*_from_metadata`
 
 ### Summary
 
-Miden v0.14 adds two constant expressions that derive their values from a string literal at assembly time:
+Several core MASM procedures in `miden::protocol::note` were renamed for consistency. These are used by every custom note script that computes a recipient or reads metadata.
 
-- `word("literal")` — hashes the literal with Blake3 and produces a `Word` (four field elements).
-- `event("literal")` — hashes the literal with Blake3 and reduces to a single `Felt` event id (the first element of the word, reduced modulo the Goldilocks prime).
+| 0.14 | 0.15 |
+| --- | --- |
+| `note::build_recipient_hash` | `note::compute_recipient` |
+| `note::build_recipient` | `note::compute_and_store_recipient` |
+| `note::extract_sender_from_metadata` | `note::metadata_into_sender` |
+| `note::extract_attachment_info_from_metadata` | `note::metadata_into_attachment_schemes` |
 
-Both run at assembly time, so the hashing cost is paid by the assembler — the emitted MAST sees only the final word/felt immediate.
+New convenience helpers were also added: `note::metadata_into_note_type` and `note::metadata_into_tag` (use the latter instead of slicing the header manually).
 
-:::note Kernel events also renamespaced in v0.14
-Event names on the kernel moved from `miden::…` to `miden::protocol::…` — see [Kernel Events Prefixed with `miden::protocol`](./transaction-changes#kernel-events-prefixed-with-midenprotocol).
-:::
+### Migration Steps
 
-### `word("...")`
-
-`word("literal")` is valid anywhere a `Word` constant expression is accepted, most commonly in a `const` declaration. The literal string is hashed with Blake3; the 32-byte digest is split into four little-endian `u64` limbs and each limb becomes a `Felt`.
-
-**Naming a storage slot:**
-
-```masm
-use.miden::protocol::active_account
-use.miden::protocol::native_account
-use.miden::core::sys
-
-const COUNTER_SLOT = word("miden::tutorials::counter")
-
-#! Inputs:  []
-#! Outputs: [count]
-pub proc get_count
-    push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    # => [count]
-
-    exec.sys::truncate_stack
-end
-
-#! Inputs:  []
-#! Outputs: []
-pub proc increment_count
-    push.COUNTER_SLOT[0..2] exec.active_account::get_item
-    add.1
-    push.COUNTER_SLOT[0..2] exec.native_account::set_item
-    # => []
-
-    exec.sys::truncate_stack
-end
-```
-
-`push.COUNTER_SLOT` pushes the full four-element word; `push.COUNTER_SLOT[0..2]` pushes a slice of the word. The derived word is deterministic — the same literal always hashes to the same word — so components that agree on a string convention share the same slot without a separately distributed constant.
-
-`word("...")` is only valid inside a `const` declaration. `push` and other instructions accept named constants but not inline `word("...")` calls, so always bind the expression to a name first.
-
-### `event("...")`
-
-`event("literal")` derives a `Felt` event id from the literal using the same hashing procedure as `word(...)`, then taking the first limb. This matches `EventId::from_name` in `miden-core`.
-
-Use `event("...")` in a `const` to name an event, then `emit.NAME`:
-
-```masm
-const U64_DIV_EVENT = event("miden::core::math::u64::u64_div")
-
-proc handler
-    # ... stack shaping ...
-    emit.U64_DIV_EVENT
-    # ... continue ...
-end
-```
-
-You can also emit a literal inline, without naming it:
-
-```masm
-begin
-    emit.event("miden::test::equiv")
-end
-```
-
-The assembler guarantees the three forms below produce the same MAST:
-
-```masm
-const EVT = event("miden::test::equiv")
-
-# (1) named constant
-begin
-    emit.EVT
-end
-
-# (2) inline literal
-begin
-    emit.event("miden::test::equiv")
-end
-
-# (3) manual push + emit
-begin
-    push.EVT
-    emit
-    drop
-end
-```
-
-### Where each is valid
-
-| Context                              | `word("...")` | `event("...")` |
-| ------------------------------------ | :-----------: | :------------: |
-| `const NAME = ...`                   |      yes      |      yes       |
-| `push.NAME` (immediate Word context) |      yes      |       —        |
-| `push.NAME` (immediate Felt context) |       —       |      yes       |
-| `emit.NAME`                          |       —       |      yes       |
-| `emit.event("...")` inline           |       —       |      yes       |
-| Inline `word("...")` in `push.`      |      no       |       —        |
-
-`emit.CONST` is accepted when `CONST` resolves (directly or via an alias chain) to an `event("...")` hash. A constant declared with `word("...")` or a plain integer will be rejected by the assembler.
-
-### Why prefer literal hashing?
-
-- **Readable MASM.** `event("miden::core::math::u64::u64_div")` documents intent directly in the source; the equivalent `push.<felt>` loses all context.
-- **Decoupled components.** Two MASM libraries that agree on a string name (e.g. `"miden::tutorials::counter"`) share a storage slot or event id without passing a constant between them.
-- **Assembly-time cost.** The Blake3 hash is computed once by the assembler; the running VM sees a plain immediate.
-
-### Notes and limitations
-
-- Hashing uses **Blake3**, not the VM's native hash. The derived values are convenient identifiers, not commitments produced inside a proof.
-- `word("")` and `event("")` (empty string) are valid and hash like any other input; collisions are vanishingly unlikely but not impossible.
-- Event ids are `Felt`s, so they are reduced modulo the Goldilocks prime ($p = 2^{64} - 2^{32} + 1$). Two distinct Blake3 digests whose first 8 little-endian bytes coincide modulo $p$ would collide — again, vanishingly unlikely for meaningful names.
-- These constants are evaluated inside the assembler (`miden-assembly` / `miden-assembly-syntax`). Code generated before v0.14 that did its own string-to-felt mapping for event ids must drop that logic — the assembler now owns it.
+1. Search/replace the four procedure names per the table.
+2. Where you manually extracted the tag from the metadata header, switch to `metadata_into_tag`.
 
 ---
 
-## 128-bit Integer Math: `std::math::u128`
+## Redundant kernel outputs removed
 
 ### Summary
 
-A new `std::math::u128` module provides full 128-bit unsigned integer arithmetic in MASM. A `u128` value is represented as four `u32` limbs in **little-endian** order `[a0, a1, a2, a3]`, where `a0` (the low limb) sits on top of the stack.
+Six kernel procedures stopped returning values that were identical to (or trivially recoverable from) their inputs. Custom MASM that consumed the now-removed outputs must drop the stale cleanup.
 
-For example, the value `0x00000001_00000002_00000003_00000004` is pushed as:
-
-```masm
-# Stack (top → bottom): [0x4, 0x3, 0x2, 0x1]
-#                         a0    a1    a2    a3
-push.0x00000001.0x00000002.0x00000003.0x00000004
-```
-
-### Usage Examples
-
-**Wrapping addition:**
-
-```masm
-use.std::math::u128
-
-# Push two u128 values (low limb on top)
-# a = 0x00000000_00000000_00000000_00000005
-push.0.0.0.5
-# b = 0x00000000_00000000_00000000_00000003
-push.0.0.0.3
-
-exec.u128::wrapping_add
-# Stack: [8, 0, 0, 0] (a + b = 8)
-```
-
-**Comparison (`lt`, `gte`):**
-
-```masm
-use.std::math::u128
-
-# a = 10
-push.0.0.0.10
-# b = 20
-push.0.0.0.20
-
-exec.u128::lt
-# Stack: [1] (10 < 20 is true)
-```
-
-**Bitwise operations (`and`, `xor`):**
-
-```masm
-use.std::math::u128
-
-push.0.0.0.0xFF
-push.0.0.0.0x0F
-
-exec.u128::and
-# Stack: [0x0F, 0, 0, 0]
-```
-
-**Shift left:**
-
-```masm
-use.std::math::u128
-
-push.0.0.0.1
-push.4  # shift amount
-
-exec.u128::shl
-# Stack: [16, 0, 0, 0] (1 << 4 = 16)
-```
-
-**Division and divmod:**
-
-```masm
-use.std::math::u128
-
-# a = 100
-push.0.0.0.100
-# b = 7
-push.0.0.0.7
-
-exec.u128::divmod
-# Stack: [quotient (4 limbs), remainder (4 limbs)]
-```
-
-### Available Procedures
-
-The full list of procedures in `std::math::u128`:
-
-| Category | Procedures |
-|----------|-----------|
-| **Arithmetic** | `overflowing_add`, `widening_add`, `wrapping_add`, `overflowing_sub`, `wrapping_sub`, `overflowing_mul`, `widening_mul`, `wrapping_mul`, `div`, `mod`, `divmod` |
-| **Comparison** | `eq`, `neq`, `eqz`, `lt`, `gt`, `lte`, `gte`, `min`, `max` |
-| **Bitwise** | `and`, `or`, `xor`, `not` |
-| **Bit counting** | `clz`, `ctz`, `clo`, `cto` |
-| **Shifts / Rotates** | `shl`, `shr`, `rotl`, `rotr` |
-
----
-
-## `u32overflowing_mul` → `u32widening_mul`
-
-### Summary
-
-Three rename pairs that better reflect that the result is *wider* than the operands (not arithmetic overflow):
-
-```masm
-# Before (0.13)
-u32overflowing_mul
-u32overflowing_madd
-exec.::std::math::u64::overflowing_mul
-
-# After (0.14)
-u32widening_mul
-u32widening_madd
-exec.::std::math::u64::widening_mul
-```
-
-`u32overflowing_add` is unchanged (the rename only applies to multiplication and madd). v0.14 also adds matching `u32widening_add` and `std::math::u64::widening_add` helpers.
-
----
-
-## `breakpoint` Instruction Removed
-
-The `breakpoint` MASM instruction was a no-op used with the old `miden debug` REPL. Both the REPL and the instruction are gone — any `.masm` source containing `breakpoint` will now fail to assemble. Delete those lines.
-
-```masm
-# Before (0.13)
-breakpoint  # used for debugging
-
-# After (0.14)
-# Just remove the line — breakpoint no longer exists
-```
-
----
-
-## Migration Steps
-
-1. Replace any hand-rolled string-to-felt mapping for event ids with `event("...")` — the assembler now owns this derivation.
-2. Where a storage-slot name or event id is shared across components, prefer `word("...")` / `event("...")` over distributing a pre-computed `Word` / `Felt` constant.
-3. If you have custom 128-bit arithmetic helpers in MASM, consider replacing them with the new `std::math::u128` module.
-4. Remember that `u128` values follow the same little-endian convention as the rest of v0.14 — the low limb (`a0`) is on top of the stack.
-5. Rename `u32overflowing_mul` → `u32widening_mul` and `u32overflowing_madd` → `u32widening_madd`.
-6. Rename `std::math::u64::overflowing_mul` → `std::math::u64::widening_mul`.
-7. Remove any `breakpoint` instructions from your MASM source.
-
----
-
-## Common Errors
-
-| Error Message | Cause | Solution |
+| Procedure | 0.14 output | 0.15 output |
 | --- | --- | --- |
-| `unknown module std::math::u128` | Using an older assembler version | Update to `miden-assembly` 0.22. |
-| Incorrect `u128` results | Limbs pushed in big-endian order | Push low limb last so it lands on top: `push.a3.a2.a1.a0`. |
-| `unknown instruction u32overflowing_mul` | Instruction renamed | Use `u32widening_mul`. |
-| `unknown instruction breakpoint` | Instruction removed | Delete the line. |
+| `active_note::get_assets` (also `input_note`/`output_note`) | `[num_assets, dest_ptr]` | `[num_assets]` |
+| `active_note::get_storage` | `[NOTE_STORAGE_COMMITMENT, num_storage_items, dest_ptr]` | `[num_storage_items]` |
+| `faucet::mint` | `[NEW_ASSET_VALUE]` | `[]` |
+| `note::write_assets_to_memory` | echoed inputs | trimmed |
+
+### Migration Steps
+
+1. Remove the `drop` / `movup`+`drop` that cleared the echoed `dest_ptr` after `get_assets` / `get_storage`.
+2. After `get_storage`, the `NOTE_STORAGE_COMMITMENT` word is no longer on the stack — delete the `dropw` that consumed it.
+3. After `faucet::mint`, do not expect `NEW_ASSET_VALUE`.
+
+---
+
+## `adv_push.N` immediate form removed; `adv_pushw` added
+
+### Summary
+
+The immediate form of `adv_push` (`adv_push.N`) was removed. `adv_push` now always pops exactly one element from the advice stack. To push N elements, emit N consecutive `adv_push` instructions (or `repeat.N adv_push end`). A new `adv_pushw` instruction pushes a full word (4 elements). On the Rust AST side, `Instruction::AdvPush(ImmU8)` became `Instruction::AdvPush` plus a new `Instruction::AdvPushW`.
+
+### Affected Code
+
+```masm
+# Before (0.14)
+adv_push.1
+adv_push.4
+
+# After (0.15)
+adv_push
+adv_pushw
+```
+
+### Migration Steps
+
+1. Replace every `adv_push.N` with N `adv_push` instructions (or `repeat.N adv_push end`).
+2. Where you previously used `adv_push.4` to fetch a word, consider `adv_pushw`.
+3. If you build MASM AST programmatically, replace `Instruction::AdvPush(n)` with N `Instruction::AdvPush` (or `Instruction::AdvPushW`).
+
+---
+
+## Internal `_impl` precompile procedures removed
+
+### Summary
+
+The internal `_impl` precompile helper procedures were removed from the core-lib public surface: `ecdsa_k256_keccak::verify_prehash_impl`, `eddsa_ed25519::verify_prehash_impl`, `keccak256::hash_bytes_impl`, and `sha512::hash_bytes_impl`. The public wrappers (`verify`, `verify_prehash`, `hash_bytes`, …) are unchanged and remain the supported entry points.
+
+### Migration Steps
+
+1. If you called any `*_impl` precompile helper directly by fully-qualified path, switch to the corresponding public wrapper.

--- a/docs/builder/migration/09-vm-assembler.md
+++ b/docs/builder/migration/09-vm-assembler.md
@@ -1,222 +1,108 @@
 ---
 sidebar_position: 9
 title: "VM & Assembler Changes"
-description: "Host trait consolidation, FastProcessor builder API, and other VM-level breaking changes in v0.14"
+description: "Sync-first execution, separated proving options, stricter assembly resolution, and the MAST/project wire-format bump (0.0.2 → 0.0.3) in Miden v0.15"
 ---
 
 # VM & Assembler Changes
 
 :::warning Breaking Change
-The VM host interface has been collapsed from three traits to one, the processor construction API has changed to a builder pattern, and several types have been cleaned up or relocated. These changes affect anyone embedding the Miden VM directly.
+Execution and proving are now **sync-first**: the single `Host` trait is split into `BaseHost` / `SyncHost` (plus an async `Host`), and `execute()` / `execute_sync()` return an `ExecutionOutput` instead of an `ExecutionTrace`. Separately, the MAST wire format bumped `0.0.2` → `0.0.3`, so `.masl` / `.masp` packages and serialized `MastForest` blobs produced under `0.22` will **not** load under `0.23` — re-assemble everything from source.
 :::
 
 ---
 
-## `SyncHost` / `BaseHost` Removed; `AsyncHost` → `Host`
+## Sync-first execution: `BaseHost`/`SyncHost`; `execute` returns `ExecutionOutput`
 
 ### Summary
 
-The previous three-trait hierarchy (`BaseHost`, `SyncHost`, `AsyncHost`) has been collapsed into a single `Host` trait. All methods now return `impl FutureMaybeSend<...>`, making the trait async-compatible by default. Additionally, `ProcessState` was renamed from `ProcessorState`, and the `on_assert_failed` callback was removed.
+Execution and proving became **sync-first with runtime-free async compatibility**. The single `Host` trait from `0.22` is split into three: `BaseHost` (shared source/label resolution + event-name lookup), `SyncHost: BaseHost` (synchronous `get_mast_forest` / `on_event`), and `Host: BaseHost` (the async variant). A blanket impl makes every `SyncHost` automatically a `Host`. The sync entry points (`execute_sync`, `prove_sync`, `FastProcessor::execute_sync`/`execute_mut_sync`) require `SyncHost`. Both `execute()` and `execute_sync()` now return **`ExecutionOutput`** instead of `ExecutionTrace` — trace building is explicit via `execute_trace_inputs*()` + `trace::build_trace()`. The deprecated `execute_sync_mut()` / `execute_for_trace*()` aliases and the unbound `TraceBuildInputs::new()` / `from_program()` constructors were removed.
 
 ### Affected Code
 
 ```rust
-// Before (0.13)
-impl BaseHost for MyHost {}
-
+// After (0.23): implement BaseHost + SyncHost; you get Host for free via the blanket impl.
+// (Before: a single async `impl Host for MyHost` with async get_mast_forest / on_event.)
+use miden_processor::{BaseHost, SyncHost, AdviceMutation, host::handlers::EventError, ProcessorState};
+impl BaseHost for MyHost {
+    fn get_label_and_source_file(&self, location: &Location) -> (SourceSpan, Option<Arc<SourceFile>>) { /* ... */ }
+}
 impl SyncHost for MyHost {
-    fn get_mast_forest(
-        &self,
-        node_digest: &Digest,
-    ) -> Option<Arc<MastForest>> {
-        // ...
-    }
-
-    fn on_event(
-        &mut self,
-        process: &ProcessState,
-        event_id: u32,
-    ) -> Result<(), ExecutionError> {
-        // ...
-    }
+    fn get_mast_forest(&self, d: &Word) -> Option<Arc<MastForest>> { /* ... */ }
+    fn on_event(&mut self, p: &ProcessorState<'_>) -> Result<Vec<AdviceMutation>, EventError> { /* ... */ }
 }
-```
 
-```rust
-// After (0.14)
-impl Host for MyHost {
-    fn get_mast_forest(
-        &self,
-        node_digest: &Digest,
-    ) -> impl FutureMaybeSend<Output = Option<Arc<MastForest>>> {
-        async {
-            // ...
-        }
-    }
-
-    fn on_event(
-        &mut self,
-        process: &ProcessorState,
-        event_id: u32,
-    ) -> impl FutureMaybeSend<Output = Result<(), ExecutionError>> {
-        async {
-            // ...
-        }
-    }
-}
+// Calling execute now returns ExecutionOutput (exposes `stack`, `advice`, `memory`):
+let output: ExecutionOutput = miden_processor::execute_sync(&program, stack_inputs, advice_inputs, &mut host, options)?;
 ```
 
 ### Migration Steps
 
-1. Remove `impl BaseHost for ...` and `impl SyncHost for ...` blocks.
-2. Implement the single `Host` trait instead.
-3. Wrap each method body in `async { ... }` and return `impl FutureMaybeSend<...>`.
-4. Rename any `ProcessState` references to `ProcessorState`.
-5. Remove any `on_assert_failed` implementations — the callback no longer exists.
+1. Split your `Host` impl into a `BaseHost` impl (label/source resolution) plus a `SyncHost` impl with plain (non-async) `get_mast_forest` / `on_event`.
+2. If you call the sync entry points, pass a `SyncHost`.
+3. Replace destructuring of an `ExecutionTrace` return with `ExecutionOutput` accessors; build a trace explicitly only when needed.
+4. Replace `FastProcessor::execute_sync_mut(...)` with `execute_mut_sync(...)`, and `execute_for_trace*` / `TraceBuildInputs::new()` with `execute_trace_inputs_sync()` / `execute_trace_inputs()`.
 
 ---
 
-## `FastProcessor` Builder API
+## `prove_sync` takes execution options separately
 
 ### Summary
 
-`FastProcessor::new_with_advice_inputs()` and `FastProcessor::new_debug()` have been removed. Construction now follows a builder pattern starting from `FastProcessor::new(stack_inputs)`.
+`ProvingOptions` no longer carries an `ExecutionOptions`. `prove_sync` / `prove` now take execution options and proving options as **two separate parameters** (and the sync path requires a `SyncHost`). The `with_execution_options(...)` / `execution_options()` accessors on `ProvingOptions` are gone. `prove_from_trace_sync()` now takes a `TraceProvingInputs`.
 
-### Affected Code
-
-```rust
-// Before (0.13)
-let processor = FastProcessor::new_with_advice_inputs(stack_inputs, advice_inputs);
-let processor = FastProcessor::new_debug(stack_inputs);
-```
-
-```rust
-// After (0.14)
-let processor = FastProcessor::new(stack_inputs)
-    .with_advice(advice_inputs)
-    .with_debugging(true)
-    .with_tracing(true);
-
-// Or with execution options:
-let processor = FastProcessor::new(stack_inputs)
-    .with_advice(advice_inputs)
-    .with_options(execution_options);
+```diff
+- let options = ProvingOptions::default().with_execution_options(exec_options);
+- let (stack_outputs, proof) = prove_sync(&program, stack_inputs, advice_inputs, &mut host, options)?;
++ use miden_processor::ExecutionOptions;
++ let (stack_outputs, proof) = prove_sync(
++     &program, stack_inputs, advice_inputs, &mut host,  // must be a SyncHost
++     ExecutionOptions::default(), ProvingOptions::default())?;
 ```
 
 ### Migration Steps
 
-1. Replace `new_with_advice_inputs(stack, advice)` with `new(stack).with_advice(advice)`.
-2. Replace `new_debug(stack)` with `new(stack).with_debugging(true)`.
-3. Chain `.with_options(...)` or `.with_tracing(true)` as needed.
+1. Stop calling `ProvingOptions::with_execution_options(...)`; pass `ExecutionOptions` as its own argument.
+2. Ensure the host you pass to `prove_sync` implements `SyncHost`.
+3. If you drove `prove_from_trace_sync()`, build a `TraceProvingInputs` from post-execution trace inputs.
 
 ---
 
-## `StackInputs` / `StackOutputs` API Cleanup
+## Live advice map bounded by total field elements
 
 ### Summary
 
-Both `StackInputs` and `StackOutputs` now derive `Copy`, so you can drop explicit `.clone()` calls. `StackInputs::new()` now takes a `&[Felt]` slice instead of a `Vec<Felt>`.
-
-### Affected Code
-
-```rust
-// Before (0.13)
-let inputs = StackInputs::new(vec![felt_a, felt_b, felt_c]);
-let inputs_copy = inputs.clone();
-
-// After (0.14)
-let inputs = StackInputs::new(&[felt_a, felt_b, felt_c]);
-let inputs_copy = inputs; // Copy, no clone needed
-```
+The live advice map is now bounded by total field-element count during execution. Advice-provider setup returns an error when the **initial** advice already exceeds the limit, and writes that would push the live map past the limit fail. `AdviceMap` gained a `total_element_count()` accessor.
 
 ### Migration Steps
 
-1. Replace `StackInputs::new(vec![...])` with `StackInputs::new(&[...])`.
-2. Remove unnecessary `.clone()` calls on `StackInputs` and `StackOutputs`.
+1. If you seed very large advice maps up front, split the data or stream it in during execution.
+2. Handle the new setup-time error from advice-provider construction instead of assuming it always succeeds.
 
 ---
 
-## `MastForest::strip_decorators` → `clear_debug_info`
+## Stricter assembly resolution: structured errors replace panics
 
 ### Summary
 
-`MastForest::strip_decorators()` has been renamed to `MastForest::clear_debug_info()` and now wipes the entire `DebugInfo` structure, not just decorators. A new convenience method `MastForest::write_stripped()` writes the forest with debug info removed without mutating the original.
-
-The MAST serialization format version was also bumped — `.masl` and `.masp` files produced by v0.13 will **not** deserialize under v0.14.
-
-### Affected Code
-
-```rust
-// Before (0.13)
-forest.strip_decorators();
-
-// After (0.14)
-forest.clear_debug_info();
-
-// Or write a stripped copy without mutating:
-forest.write_stripped(&mut output)?;
-```
+Several previously-panicking or silently-partial assembly paths now return structured errors: oversized modules are rejected at resolver construction, non-procedure invoke targets are rejected, self-recursive / rootless call graphs return typed cycle errors, and unresolved `pub use <digest> -> <name>` returns a normal assembly error. The linker also rejects non-`syscall` references to exported kernel procedures and rejects empty kernel packages. Code that assembled cleanly under `0.22` continues to assemble; the change is that malformed inputs now surface as recoverable `Report` errors instead of panics.
 
 ### Migration Steps
 
-1. Replace `strip_decorators()` calls with `clear_debug_info()`.
-2. Consider using `write_stripped()` if you only need stripped output without modifying the forest in memory.
-3. Re-assemble all `.masl` and `.masp` files from source — 0.13 serialized files will fail to deserialize.
-
-### Common Errors
-
-| Error Message | Cause | Solution |
-| --- | --- | --- |
-| `no method named strip_decorators found` | Method renamed | Use `clear_debug_info()`. |
-| `MastForest deserialization failed: unexpected version` | MAST format version bumped | Re-assemble from source under 0.22. |
+1. If you wrapped assembly in panic-catching logic for malformed inputs, replace it with normal `Result`/`Report` error handling.
+2. Fix any MASM that referenced an exported kernel procedure via `exec`/`call` instead of `syscall` — that is now a hard error.
 
 ---
 
-## `Process`, `VmStateIterator`, `execute_iter()` Removed
+## Post-last-operation decorators deprecated
 
 ### Summary
 
-The "slow" `Process` type, `VmStateIterator`, `VmState`, `AsmOpInfo`, `SlowProcessState`, and the top-level `miden_processor::execute_iter()` function have been removed. Execution goes exclusively through `FastProcessor`.
+Operation-indexed decorators placed *after* the last operation of a basic block are now rejected in both block assembly and serialized MAST forests. Decorators that should run after a block exits must use the `after_exit` slot instead. This only affects code that builds `MastForest`s programmatically — ordinary MASM source is unaffected.
 
-### Affected Code
+### Migration Steps
 
-```rust
-// Before (0.13)
-for state in execute_iter(&program, stack_inputs, advice_inputs, &mut host) {
-    let state: VmState = state?;
-    println!("clk={} op={:?}", state.clk(), state.op());
-}
-
-// After (0.14)
-let mut processor = FastProcessor::new(stack_inputs).with_advice(advice_inputs);
-let mut ctx = processor.get_initial_resume_context(&program)?;
-loop {
-    let outcome = processor.step(&program, &mut ctx, &mut host)?;
-    if outcome.is_done() { break; }
-}
-```
-
-For one-shot non-iterating execution, use `FastProcessor::execute_sync(...)` or the top-level `miden_processor::execute_sync(...)`.
-
----
-
-## `miden debug` / `analyze` / `repl` Removed
-
-The three CLI subcommands were removed along with `VmStateIterator`. The CLI now exposes only `compile`, `bundle`, `run`, `prove`, `verify`. There is no drop-in replacement; use the external debugger or write a small Rust program that drives `FastProcessor::step` if you need step-by-step inspection.
-
----
-
-## `Operation` Enum Trimmed to Basic-Block Ops
-
-### Summary
-
-Control-flow opcodes (`Join`, `Split`, `Loop`, `Call`, `Dyn`, `Dyncall`, `SysCall`, `Span`, `End`, `Respan`, `Halt`) were removed from `miden_core::Operation`; they live exclusively at the MAST node level (`MastNode::Join`, etc.). Pattern matches over those variants must move to traversals over `MastNode`.
-
----
-
-## `ExecutionOptions`, `ProvingOptions`, `ExecutionProof` Relocated
-
-These types have moved crates. See [Imports & Dependencies](./imports-dependencies) for the updated import paths.
+1. If you attach decorators programmatically, move any decorator targeting the post-last-op index to the block's `after_exit` decorator list.
 
 ---
 
@@ -224,39 +110,20 @@ These types have moved crates. See [Imports & Dependencies](./imports-dependenci
 
 ### Summary
 
-v0.14 introduces a **first-class Miden project file format** (`miden-project.toml`), implemented in the new `miden-project` crate. Projects describe a single package or a workspace of packages with dependencies (path, git, registry), profiles, lints, and per-package metadata — much like `Cargo.toml`. The assembler compiles a project directly to a `.masp` package via `Assembler::link_package`, with dependency resolution through `pubgrub`.
+The MAST forest serialization format was refactored around fixed-layout **full**, **stripped**, and **hashless** sections, with stable node IDs and stricter validation of untrusted forests. The wire-format version constant bumped from `[0, 0, 2]` to `[0, 0, 3]`. Serialized `.masl` / `.masp` / `MastForest` blobs produced under `0.22` will not deserialize under `0.23`. Deserialization of serialized libraries and kernel libraries is now treated as **untrusted** by default, rejecting spoofed/inconsistent node digests rather than trusting the bytes.
 
-This is **additive** for existing per-file assembly users — old `Assembler::compile_and_statically_link` / `assemble_library` APIs still work — but it is the recommended layout for any new MASM project of more than a single file.
-
-### Standalone Package Example
-
-```toml title="my-app/miden-project.toml"
-[package]
-name = "example"
-version = "0.1.0"
-
-[lib]
-path = "lib/mod.masm"
-
-[dependencies]
-miden-protocol = { path = "../protocol/userspace" }
-
-[profile.test]
-inherits = "dev"
-network = "local"
-
-[lints.miden]
-unused = "error"
-```
-
-### Building from Rust
+### Affected Code
 
 ```rust
-use miden_assembly::Assembler;
-
-let package = Assembler::default()
-    .link_package("./my-app/miden-project.toml")?;
+// Any blob serialized under 0.22 (VERSION = [0, 0, 2]) fails to read under 0.23:
+let forest = MastForest::read_from_bytes(&old_bytes)?; // Err: unexpected version
 ```
+
+### Migration Steps
+
+1. Re-assemble every `.masl` / `.masp` package and re-serialize any cached `MastForest` blobs from source under `0.23`.
+2. If you persisted MAST forests or packages to disk or a database, invalidate and regenerate them.
+3. If you deserialize forests from an untrusted source, expect stricter validation — malformed or spoofed-digest forests now return an error instead of loading.
 
 ---
 

--- a/docs/builder/migration/index.md
+++ b/docs/builder/migration/index.md
@@ -1,18 +1,18 @@
 ---
-title: "v0.14 Migration Guide"
-description: "Complete guide for upgrading from Miden v0.13 to v0.14"
+title: "v0.15 Migration Guide"
+description: "Complete guide for upgrading from Miden v0.14 to v0.15"
 ---
 
-# Miden Testnet 0.14.0
+# Miden Testnet 0.15.0
 
-This guide covers all breaking changes you need to migrate an application to Miden 0.14.0. Like the 0.13 guide, it is intentionally user-facing: you do not need to know or care which internal crate (VM, protocol, client) a change came from. If you are:
+This guide covers all breaking changes you need to migrate an application to Miden 0.15.0. Like the 0.14 guide, it is intentionally user-facing: you do not need to know or care which internal crate (VM, protocol, client) a change came from. If you are:
 
 - building accounts, notes, or transactions
 - running a client, web client or React SDK
 - writing or compiling MASM
 - interacting with storage, auth, or RPCs
 
-this document is for you.
+this document is for you. It folds together the breaking changes from the protocol crates (`miden-base`, `0.14` → `0.15.3`), the VM crates (`miden-vm`, `0.22` → `0.23`), `miden-client` (`0.14` → `0.15`), and the Web SDK (`@miden-sdk/*` `0.14` → `0.15`). Because `miden-client` and the Web SDK still ship from unified-in-progress `main`/`next` branches, this guide unions the breaking surface from both.
 
 ---
 
@@ -22,22 +22,38 @@ Try upgrading first — most projects can start with a dependency update:
 
 ```toml title="Cargo.toml"
 # Replace these
-miden-protocol  = "0.13"
-miden-standards = "0.13"
-miden-assembly  = "0.20"
-miden-core      = "0.20"
-miden-processor = "0.20"
-miden-prover    = "0.20"
-miden-crypto    = "0.19"
+miden-client              = "0.14"
+miden-client-sqlite-store = "0.14"
+miden-protocol            = "0.14"
+miden-standards           = "0.14"
+miden-tx                  = "0.14"
+miden-assembly            = "0.22"
+miden-core                = "0.22"
+miden-core-lib            = "0.22"
+miden-processor           = "0.22"
+miden-prover              = "0.22"
+miden-crypto              = "0.23"
 
 # With these
-miden-protocol  = "0.14"
-miden-standards = "0.14"
-miden-assembly  = "0.22"
-miden-core      = "0.22"
-miden-processor = "0.22"
-miden-prover    = "0.22"
-miden-crypto    = "0.23"
+miden-client              = "0.15"
+miden-client-sqlite-store = "0.15"
+miden-protocol            = "0.15.3"
+miden-standards           = "0.15.3"
+miden-tx                  = "0.15.3"
+miden-assembly            = "0.23"
+miden-core                = "0.23"
+miden-core-lib            = "0.23"
+miden-processor           = "0.23"
+miden-prover              = "0.23"
+miden-crypto              = "0.25"
+```
+
+```json title="package.json (Web SDK)"
+{
+  "@miden-sdk/miden-sdk": "^0.15.0",
+  "@miden-sdk/react": "^0.15.0",
+  "miden-idxdb-store": "^0.15.0"
+}
 ```
 
 Then run:
@@ -48,48 +64,40 @@ cargo update && cargo build
 
 If you encounter errors, continue reading for detailed migration steps.
 
+:::warning 0.14 artifacts do not round-trip
+Because the native hash and the MAST/serialization formats changed upstream, **0.14 artifacts (accounts, notes, proofs, serialized stores, `.masl`/`.masp` packages) do not round-trip.** Re-assemble from source and re-sync into a fresh store.
+:::
+
 ---
 
 :::info Who should read this?
 This guide is for:
-- **Rust client developers** migrating from v0.13 → v0.14
+- **Rust client developers** migrating from v0.14 → v0.15
 - **Web SDK developers** using the JavaScript/TypeScript SDK
 - **Smart contract authors** writing MASM or using protocol APIs
-- **App developers** using `miden-protocol`, `miden-standards`, or client crates
+- **App developers** using the protocol, standards, or client crates
 
-If you're starting fresh on v0.14, you can skip this guide and go directly to the [Get Started guide](../get-started).
+If you're starting fresh on v0.15, you can skip this guide and go directly to the [Get Started guide](../get-started).
 :::
 
 ---
 
 ## At a Glance
 
-Big themes in 0.14:
+Big themes in 0.15:
 
 | Change | Summary |
 |--------|---------|
-| **Poseidon2 hashing** | The native hash function changed from RPO to Poseidon2. Every MAST root, commitment, and persisted digest changes. Rebuild all artifacts. |
-| **Little-endian stack** | The operand stack is now little-endian. `u64`, `u256`, `hperm`, `hmerge`, `mem_stream`, `adv_pipe` all have the low limb on top. |
-| **Two-word assets** | `ASSET` is now `ASSET_KEY` + `ASSET_VALUE`. Every procedure touching assets has a new stack signature. |
-| **NoteStorage** | `NoteInputs` renamed to `NoteStorage` end-to-end (Rust, MASM, errors). |
-| **MASM library scripts** | Note and auth scripts are now MASM libraries with `@note_script` / `@auth_script` attributes. |
-| **AuthSingleSig** | Six per-scheme auth components consolidated into `AuthSingleSig`, `AuthSingleSigAcl`, `AuthMultisig`. |
-| **Web MidenClient** | The flat `WebClient` replaced by resource-based `MidenClient` API. |
-| **Ownable2Step** | New built-in two-step ownership transfer component for faucets. |
-| **128-bit math** | New `std::math::u128` module in the standard library. |
+| **Account IDs simplified** | The account ID no longer encodes faucet/regular, mutability, or network mode. The old `AccountType` enum is gone; `AccountStorageMode` is **renamed `AccountType`** (`{ Private, Public }`). Faucet/network-ness now comes from components; the ID version is renamed `0` → `1`. |
+| **Note identity split** | The old `NoteId` (recipient + assets) becomes **`NoteDetailsCommitment`**; the new `NoteId` also commits to metadata, and nullifiers now fold in metadata + the attachments commitment — none roundtrip with 0.14. |
+| **Multiple attachments per note** | `NoteMetadata` → `PartialNoteMetadata`, `NoteMetadataHeader` → `NoteMetadata`; attachments live on the note/record as a `NoteAttachments` collection (≤ 4). `NoteType` is now 1-bit, default `Private`. |
+| **Faucets unified** | `BasicFungibleFaucet` + `NetworkFungibleFaucet` → one **`FungibleFaucet`** (`bon` builder) + `FungibleTokenMetadata` + a `TokenPolicyManager` for mint/burn policies. Amounts are a validated **`AssetAmount`** newtype. |
+| **Typed roots everywhere** | `NoteScript::root()` → `NoteScriptRoot`, `TransactionScript::root()` → `TransactionScriptRoot`, `procedure_digest!` → `procedure_root!`, plus `AccountComponentName`. |
+| **VM 0.23 / crypto 0.25 are digest-changing** | SMT leaf hashing gains a Poseidon2 domain separator, the MAST wire format bumped `0.0.2` → `0.0.3` (old `.masl`/`.masp` won't load), execution is **sync-first** (`BaseHost`/`SyncHost`; `execute` → `ExecutionOutput`), and `adv_push.N` was removed. |
+| **Client RPC rebuilt around `GetAccount`** | `get_account_proof`/`get_account_details` reshaped, `check_nullifiers` removed (use `sync_nullifiers`), most sync methods now require an explicit `block_to`. |
+| **Web SDK on the 0.15 protocol surface** | `"network"` storage mode is gone, the WASM `AccountType` narrowed to `{ Private, Public }`, attachments are word-vector-shaped, `Felt`/`Word` throw on overflow, several methods return `undefined`/`string`, `proveTransactionWithProver` is renamed `proveTransaction`, and `storeIdentifier()` went async. |
 
----
-
-## New Features in v0.14
-
-These are additive features you may want to adopt (not breaking changes):
-
-- **NoteScreener and batch screening**: A new `Client::note_screener()` API adds batch note consumability checks for more efficient note screening workflows.
-- **Account history pruning**: The client now exposes account history pruning APIs for storage and state management.
-- **GrpcClient automatic retry on rate limiting**: `GrpcClient` now automatically retries rate-limited requests up to five times and honors `retry-after` when provided.
-- **Automatic NTX note script registration**: NTX note scripts are now registered automatically — no more manual script registration as part of transaction submission.
-- **Typed RPC error parsing**: RPC errors are now parsed into typed client errors, improving programmatic error handling.
-- **128-bit integer math**: New `std::math::u128` module provides full unsigned integer arithmetic, comparison, bitwise, and shift/rotate operations.
+If you only skim a few sections, skim **Account Changes**, **Note Changes**, **Assets, Vault & Faucet**, **Hashing, SMT & Crypto Changes**, and **Client Changes**.
 
 ---
 
@@ -97,11 +105,18 @@ These are additive features you may want to adopt (not breaking changes):
 
 | Component | Required | Tested With |
 |-----------|----------|-------------|
-| Miden VM crates | 0.22+ | 0.22.0 |
-| miden-crypto | 0.23+ | 0.23.0 |
-| miden-protocol | 0.14+ | 0.14.3 |
-| miden-standards | 0.14+ | 0.14.3 |
-| Rust | 1.91+ | 1.91.0 |
+| Miden VM crates | 0.23+ | 0.23.0 |
+| miden-crypto | 0.25+ | 0.25.0 |
+| miden-protocol | 0.15+ | 0.15.3 |
+| miden-standards | 0.15+ | 0.15.3 |
+| miden-client | 0.15+ | 0.15.0 |
+| Web SDK (`@miden-sdk/*`) | 0.15+ | 0.15.0 |
+| Rust (client) | 1.93+ | 1.93.0 |
+| Rust (base crates) | 1.90+ | 1.90.0 |
+
+:::note `miden-prover`, not `miden-prove`
+The prover crate is **`miden-prover`** in this line — it is *not* `miden-prove`. Keep depending on `miden-prover`.
+:::
 
 ---
 
@@ -111,15 +126,15 @@ Work through these sections in order for a complete migration:
 
 | Section | Topics |
 |---------|--------|
-| [1. Imports & Dependencies](./imports-dependencies) | Cargo.toml bumps, import relocations, MSRV, `Felt` rename |
-| [2. Hashing & Stack Changes](./hashing-stack) | Poseidon2, little-endian stack, Falcon module rename |
-| [3. Account Changes](./account-changes) | Components, AuthSingleSig, `@auth_script`, Ownable2Step |
-| [4. Note Changes](./note-changes) | NoteStorage, `@note_script`, OutputNote variants, StandardNote |
-| [5. Assets, Vault & Faucet](./asset-vault-faucet) | Two-word assets, create_* rename, get_asset, vault changes |
-| [6. Transaction Changes](./transaction-changes) | TransactionId, ProvenTransaction, events, SignedBlock |
-| [7. Client Changes](./client-changes) | Web MidenClient, Rust Keystore, AccountReader, StateSync |
-| [8. MASM Changes](./masm-changes) | 128-bit math, event namespace |
-| [9. VM & Assembler Changes](./vm-assembler) | Host trait, FastProcessor, type relocations |
+| [1. Imports & Dependencies](./imports-dependencies) | Crate bumps, package.json, MSRV 1.93, no round-trip of 0.14 artifacts |
+| [2. Hashing, SMT & Crypto Changes](./hashing-stack) | Poseidon2-domain-separated SMT leaves, `miden-crypto` 0.25 renames, `PartialSmt` / `LargeSmt` / 0.24 API breaks |
+| [3. Account Changes](./account-changes) | `AccountType` removed/renamed, network-account allowlist, `procedure_root!`, typed roots |
+| [4. Note Changes](./note-changes) | `NoteDetailsCommitment`, `PartialNoteMetadata`, multiple attachments, 1-bit `NoteType`, nullifier change, PSWAP |
+| [5. Assets, Vault & Faucet](./asset-vault-faucet) | `AssetAmount`, unified `FungibleFaucet`, `AssetVaultKey`, `AssetComposition` |
+| [6. Transaction Changes](./transaction-changes) | `fee_faucet_id`, `TransactionScriptRoot`, `ProvenBatch::new_unchecked` |
+| [7. Client Changes](./client-changes) | `GetAccount` surface, `sync_nullifiers`, `TokenPolicyManager`, Web/React/CLI changes |
+| [8. MASM Changes](./masm-changes) | `metadata_into_*` renames, trimmed kernel outputs, `adv_push.N` removed |
+| [9. VM & Assembler Changes](./vm-assembler) | Sync-first execution, `prove_sync`, stricter assembly, MAST wire format `0.0.3` |
 
 ---
 
@@ -127,25 +142,32 @@ Work through these sections in order for a complete migration:
 
 Complete these steps to verify your migration:
 
-- [ ] Bump all Miden crate versions in `Cargo.toml` per section 1
-- [ ] Update `rust-toolchain.toml` to Rust 1.91+ (if using miden-client)
-- [ ] Re-assemble all `.masl` and `.masp` files from source (Poseidon2 hash change)
-- [ ] Discard any cached commitments, transaction IDs, or proofs from v0.13
-- [ ] Audit MASM stack arithmetic for little-endian limb order
-- [ ] Update asset handling to two-word `ASSET_KEY` + `ASSET_VALUE` format
-- [ ] Rename `NoteInputs` → `NoteStorage` everywhere
-- [ ] Add `@note_script` / `@auth_script` attributes to MASM entrypoints
-- [ ] Replace per-scheme auth components with `AuthSingleSig`
-- [ ] Update `AccountComponent::new` to pass `AccountComponentMetadata`
-- [ ] Replace `commitment()` calls with `to_commitment()`
-- [ ] Update `NoteMetadata::new` to use `with_tag()` builder
-- [ ] Replace `WellKnownNote` / `WellKnownComponent` with `Standard…` equivalents
-- [ ] Migrate note constructors to associated methods (`P2idNote::create`, etc.)
-- [ ] Update Web SDK from `WebClient` to `MidenClient` resource API
-- [ ] Replace `TransactionAuthenticator` with `Keystore` trait in Rust client
+- [ ] Bump all Miden crate versions in `Cargo.toml` per section 1 (and `@miden-sdk/*` to `^0.15.0` together)
+- [ ] Update the client toolchain to Rust 1.93+
+- [ ] Re-assemble all `.masl` and `.masp` files from source (MAST wire format `0.0.3`)
+- [ ] Re-sync into a fresh store; discard cached commitments, note IDs, nullifiers, and proofs from 0.14
+- [ ] Re-derive persisted SMT roots / leaf digests / `PartialSmt` values under `miden-crypto` 0.25
+- [ ] *(If you implement a custom `LargeSmt` storage backend)* move reads to `SmtStorageReader` and add `type Reader` + `reader()` to your `SmtStorage` impl
+- [ ] *(If you use `miden-crypto` directly)* apply the 0.24 API breaks (`WORD_SIZE*` → `Word::NUM_ELEMENTS` / `Word::SERIALIZED_SIZE`, `LexicographicWord` → `Word`, `Felt` deref removed, `StarkProof` log trace heights + `air_order`)
+- [ ] Replace the old `AccountType` / `AccountStorageMode` usage with the new `AccountType` (`Private`/`Public`)
+- [ ] Rename note "ids without metadata" to `NoteDetailsCommitment`; recompute note IDs and nullifiers
+- [ ] Move to `PartialNoteMetadata` + `NoteAttachments`; audit `NoteType` (now 1-bit, default `Private`)
+- [ ] Switch faucets to `FungibleFaucet::builder()` + `TokenPolicyManager`; wrap amounts in `AssetAmount`
+- [ ] Replace `get_account_proof` with `get_account(GetAccountRequest…)` and `check_nullifiers` with `sync_nullifiers`
+- [ ] Pass explicit `block_to` to the sync methods that now require it
+- [ ] Web: drop `"network"` storage, move faucet checks onto `Account`, reshape attachments, guard `Felt`/`Word` construction
+- [ ] Split your `Host` impl into `BaseHost` + `SyncHost`; handle `ExecutionOutput`
 - [ ] Run `cargo build` — **no errors**
 - [ ] Run `cargo test` — **all tests pass**
 
 :::tip You're done!
-If your project builds and all tests pass, you've successfully migrated to v0.14.
+If your project builds and all tests pass, you've successfully migrated to v0.15.
 :::
+
+---
+
+## Need Help?
+
+- **Discord:** [Miden Discord](https://discord.gg/0xMiden) — the `#dev-support` channel.
+- **GitHub issues:** file against the relevant repo — [`miden-client`](https://github.com/0xMiden/miden-client/issues), [`web-sdk`](https://github.com/0xMiden/web-sdk/issues), [`protocol`](https://github.com/0xMiden/protocol/issues), or [`miden-vm`](https://github.com/0xMiden/miden-vm/issues).
+- **Changelogs:** the per-repo `CHANGELOG.md` files carry the full list of changes, including non-breaking features and fixes omitted from this guide.


### PR DESCRIPTION
## Summary

Adds the **v0.15 (Miden Testnet 0.15.0) migration guide** under `docs/builder/migration/`, converted from #312 and folding in the review follow-ups. It mirrors the v0.14 guide's 10-file structure and reuses the same slugs, so `sidebars.ts` needs no changes. The v0.14 content is already snapshotted in `versioned_docs/version-0.14/`.

## What's covered

| Page | Topics |
|---|---|
| `index` | At-a-glance themes, compatibility matrix, section map, final checklist |
| `01` imports & dependencies | Crate/package bumps (protocol 0.15.3, VM 0.23, crypto 0.25, client 0.15, web SDK 0.15), MSRV 1.93, no round-trip of 0.14 artifacts |
| `02` hashing, SMT & crypto | Poseidon2 domain-separated SMT leaves, `miden-crypto` 0.25 renames, **+ `PartialSmt` / `LargeSmt`→`SmtStorageReader` / `miden-crypto` 0.24 breaks** |
| `03`–`06` | Account, note, asset/vault/faucet, transaction changes |
| `07`–`09` | Client (Rust/Web/React/CLI), MASM, VM & assembler + project file format |

Every breaking change from #312 is covered, plus the three follow-ups from @huitseeker's review comment (folded into `02`).

## Verification

- ✅ 0 MDX/JSX hazards (all prose generics/braces backticked); consistent heading levels (`##` change / `###` subsection, no leftover `####`); frontmatter + `description` on all 10 pages; internal cross-link anchors resolve to real headings.
- ✅ Reviewed by Codex (gpt-5.5, xhigh) — applied its fidelity/precision findings (exact `0.15.3` versions, restored source context, section-anchored cross-links).
- ✅ **`npm run build` passes locally** with the CI ingestion replicated (mirrored the ingested `rust-client`/`tutorials` trees and ingested `reference/{protocol,miden-vm,node}` from the source repos). Result: `[SUCCESS] Generated static files`, all 10 migration pages resolve in sidebar validation, and **0 broken links/anchors originate from this PR's content**. The remaining build warnings are all pre-existing — internal cross-links inside ingested reference/tutorial pages and the untouched `version-0.14`/`0.13` snapshots — none from the new `next`-version migration pages. CI ingestion + build remains the authoritative link gate.
- ✅ **v0.15 TS snippets verified against the shipped SDK**: `@miden-sdk/miden-sdk@0.15.0` and `@miden-sdk/react@0.15.0` are now published (`latest`). The guide's TS surface (5 snippets in `07-client-changes`) was checked against the real `0.15.0` `.d.ts`: `AccountStorageMode.public()/.private()`, `accounts.create({ storage })`, `account.isFaucet()/isRegularAccount()/id().isPublic()` (with `isNetwork()`/`isUpdatable()` confirmed removed), `NoteAttachment.fromWord/fromWords(…: Word[])/toWords(): Word[]` (with `NoteAttachmentKind` confirmed gone), `record.id()/attachments()`, and `proveTransaction(txResult, prover?)` (optional prover) — all match the published types.

## Test plan

- [x] Local build passes with CI ingestion replicated — no new broken links/anchors from this PR's content
- [ ] CI build passes with ingested `rust-client`/`tutorials` docs (authoritative gate, pinned refs) — runs **post-merge on `main`** (`deploy-docs.yml` has no `pull_request` trigger), so it can't be exercised pre-merge; the local-ingestion build above is the pre-merge stand-in
- [x] Sidebar renders the Migration Guide section unchanged (slugs reused) — `sidebars.ts` diff is empty and the migration filenames/IDs are identical to the `version-0.14` snapshot
- [x] Spot-check rendering of the at-a-glance/compatibility tables and admonitions — built `next` pages render the 3 tables (compatibility matrix + section map) and themed admonitions (info/note/tip/warning) with 0 leaked `:::` markers

## Out of scope

- Wiring the v0.15 snippets into the `docs-tests` tsc harness against `@miden-sdk@0.15.0` (now unblocked — the 0.15 packages are published; this PR verifies the API references against the shipped `.d.ts` directly, but the harness itself is not yet bumped to 0.15)
- Non-breaking 0.15 features (see per-repo `CHANGELOG.md`)

