### PR TITLE
fix(ingestion): rebase ingested doc links to mount path on aggregation

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -210,6 +210,19 @@ jobs:
             echo "Synced compiler → docs/reference/compiler"
           fi
 
+          # Rebase root-absolute internal links in ingested reference sections.
+          # Each section is ingested from a repo whose docs are their own standalone
+          # Docusaurus site (baseUrl "/"), so internal links are authored
+          # root-absolute (e.g. "/full-node/installation"). Mounted here under
+          # /reference/<section>/ and served per-version, those links lose the mount
+          # prefix and version segment and 404. The script converts them to
+          # version-safe relative .md links (resolved + validated by Docusaurus).
+          # A no-op for sections that already use relative links (protocol, miden-vm).
+          for section in protocol miden-vm node compiler; do
+            [ -d "docs/reference/$section" ] || continue
+            node scripts/rebase-ingested-links.mjs "docs/reference/$section"
+          done
+
           # Builder docs → docs/builder/*
           # Sync tutorials into tutorials — selective ingest.
           # rust-compiler/, index.md, miden-bank/index.md, recipes/_category_.json,
@@ -252,6 +265,15 @@ jobs:
             if [ -d "vendor/tutorials/docs/src/img" ]; then
               cp -r vendor/tutorials/docs/src/img docs/builder/tutorials/recipes/
             fi
+            # Depth fixup for the rust-client→recipes/rust rename. In the vendor
+            # tree rust-client/ sits directly under docs/src, so links up to the
+            # tutorials root use one "../" (e.g. ../miden_node_setup.md). The
+            # rename nests them one level deeper (recipes/rust/), so those links
+            # need an extra "../". Image refs (../img/...) are unaffected because
+            # the img dir is mirrored into recipes/ alongside them (above).
+            find docs/builder/tutorials/recipes/rust docs/builder/tutorials/recipes/web \
+              -type f \( -name '*.md' -o -name '*.mdx' \) -print0 2>/dev/null \
+              | xargs -0 perl -i -pe 's{\]\(\.\./miden_node_setup(\.md)?}{](../../miden_node_setup$1}g'
             # Restore locally-authored files over vendor versions.
             git checkout HEAD -- docs/builder/tutorials/miden-bank/index.md 2>/dev/null || true
             git checkout HEAD -- docs/builder/tutorials/recipes/_category_.json 2>/dev/null || true

--- a/scripts/rebase-ingested-links.mjs
+++ b/scripts/rebase-ingested-links.mjs
@@ -1,0 +1,85 @@
+#!/usr/bin/env node
+// Rebase root-absolute internal links in an ingested reference section.
+//
+// Each section under docs/reference/<x>/ is ingested from a repo whose docs are
+// their OWN standalone Docusaurus site (baseUrl "/"), so internal links are
+// authored root-absolute, e.g. `](/full-node/installation)`. Once mounted under
+// /reference/<x>/ here — and served per-version (/next/…, /0.15/…, bare) — those
+// absolute links lose both the mount prefix AND the version segment, so they 404.
+//
+// We convert each root-absolute link to a RELATIVE link to the target `.md` file.
+// Docusaurus resolves relative `.md` links at build time, version-aware and
+// validated by onBrokenLinks — so they work in every version the section appears
+// in, and survive being snapshotted by cut-versions.
+//
+// Usage: node scripts/rebase-ingested-links.mjs <sectionDir>
+// Unresolvable targets (e.g. cross-site or genuinely dead) are left untouched and
+// reported, so the build's link checker still surfaces them.
+
+import { readdirSync, statSync, readFileSync, writeFileSync, existsSync } from "fs";
+import { join, relative, dirname, posix } from "path";
+
+const sectionDir = process.argv[2];
+if (!sectionDir || !existsSync(sectionDir)) {
+  console.error(`rebase-ingested-links: section dir not found: ${sectionDir}`);
+  process.exit(0); // no-op rather than fail the deploy if a section is absent
+}
+
+const walk = (dir) =>
+  readdirSync(dir).flatMap((name) => {
+    const p = join(dir, name);
+    return statSync(p).isDirectory() ? walk(p) : [p];
+  });
+
+// Resolve a section-root-absolute target (e.g. "full-node/installation",
+// "full-node/", "rpc") to an actual doc file under the section, or null.
+const resolveTarget = (targetPath) => {
+  const clean = targetPath.replace(/^\//, "").replace(/\/$/, "");
+  const noExt = clean.replace(/\.mdx?$/, "");
+  const candidates = noExt === ""
+    ? ["index.md", "index.mdx"]
+    : [`${noExt}.md`, `${noExt}.mdx`, `${noExt}/index.md`, `${noExt}/index.mdx`];
+  for (const c of candidates) {
+    const abs = join(sectionDir, c);
+    if (existsSync(abs)) return abs;
+  }
+  return null;
+};
+
+let filesChanged = 0;
+let linksRebased = 0;
+const unresolved = [];
+
+// Match markdown links/images whose target starts with "/" (root-absolute),
+// excluding protocol-relative ("//") and pure anchors. Capture target + optional #anchor.
+const LINK_RE = /(\]\()(\/(?!\/)[^)\s#]*)(#[^)\s]*)?(\))/g;
+
+for (const file of walk(sectionDir)) {
+  if (!/\.mdx?$/.test(file)) continue;
+  const src = readFileSync(file, "utf8");
+  let touched = false;
+
+  const out = src.replace(LINK_RE, (m, open, target, anchor = "", close) => {
+    const resolved = resolveTarget(target);
+    if (!resolved) {
+      unresolved.push(`${relative(sectionDir, file)} -> ${target}`);
+      return m; // leave untouched; build link-checker will flag if truly broken
+    }
+    // Relative path from the current file's directory to the target file (POSIX).
+    let rel = relative(dirname(file), resolved).split(/[\\/]/).join(posix.sep);
+    if (!rel.startsWith(".")) rel = `./${rel}`;
+    touched = true;
+    linksRebased++;
+    return `${open}${rel}${anchor}${close}`;
+  });
+
+  if (touched) {
+    writeFileSync(file, out);
+    filesChanged++;
+  }
+}
+
+console.log(
+  `rebase-ingested-links: ${sectionDir} — rebased ${linksRebased} link(s) across ${filesChanged} file(s)` +
+    (unresolved.length ? `; ${unresolved.length} unresolved (left as-is):\n  - ${unresolved.join("\n  - ")}` : "")
+);

--- a/versioned_docs/version-0.14/builder/tutorials/recipes/rust/create_deploy_tutorial.md
+++ b/versioned_docs/version-0.14/builder/tutorials/recipes/rust/create_deploy_tutorial.md
@@ -20,7 +20,7 @@ In this tutorial, we will create a Miden account for _Alice_ and deploy a fungib
 
 ## Prerequisites
 
-Before you begin, ensure that a Miden node is running locally in a separate terminal window. To get the Miden node running locally, you can follow the instructions on the [Miden Node Setup](../miden_node_setup.md) page.
+Before you begin, ensure that a Miden node is running locally in a separate terminal window. To get the Miden node running locally, you can follow the instructions on the [Miden Node Setup](../../miden_node_setup.md) page.
 
 ## Public vs. private accounts & notes
 


### PR DESCRIPTION
## Summary

A site-wide broken-link crawl (986 pages) surfaced 404s whose root cause is the **ingestion**, not authored content. Each reference section (`node`, `miden-vm`, `protocol`, `compiler`) is ingested from a repo whose docs are their **own standalone Docusaurus site** (`baseUrl: "/"`, `onBrokenLinks: throw`), so their internal links are authored **root-absolute** (e.g. `](/full-node/installation)`). When this repo aggregates them under `/reference/<section>/` and serves them per-version, those links lose the mount prefix *and* version segment and 404. The node repo's v0.15 `full-node` / `network-operator` / `rpc` restructure made this visible across ~14 links (including the reported `/full-node/installation`).

This fixes it **at the ingestion layer** (where the mount happens), so the external repos stay internally clean and the docs repo rebases on the way in.

## What changed

1. **`scripts/rebase-ingested-links.mjs`** — run per reference section during ingestion. Converts root-absolute internal links to **version-safe relative `.md` links** (resolved + validated by Docusaurus, correct in every version, preserved through `cut-versions`). A no-op for sections already using relative links (protocol, miden-vm). On the node section it rebases 17 links across 8 files, e.g. `](/full-node/installation)` → `](./installation.md)`, `](/official-network-urls)` → `](../official-network-urls.md)`.
2. **Recipes-depth fixup** (`deploy-docs.yml` + the committed 0.14 snapshot) — the `rust-client`→`recipes/rust` rename nests recipe pages one level deeper, so links to the tutorials root (`../miden_node_setup.md`) needed an extra `../`. The vendor tree is correct; the rename was the artifact.

> Why relative `.md` and not a path prefix: a prefix like `/reference/node/…` is **not version-aware** in Docusaurus — it points at the released version, which (for `next`-only pages like `full-node`) 404s. Relative `.md` links resolve within whatever version the page is served in.

## Validation (local, before publishing)

Ran the **full ingestion locally** (node@next, tutorials@main, etc.), built, served, and crawled the served site with **Playwright** (976 pages, ~1,077 unique link targets):

- ✅ Entire **node cluster** (`full-node/*`, `network-operator/*`, `rpc/*`, `official-network-urls`, `local-network-development`) now resolves — `200`, real content (`h1="Installation"`, `h1="Public RPC"`), click-through verified.
- ✅ Both **recipes `miden_node_setup`** links resolve.
- ✅ `npm run build` → `[SUCCESS]`, no new broken-link warnings from the fixed sections.

Net: **16 broken links fixed and verified** (14 node + 2 recipes).

## Out of scope — upstream content issues (flagged for owners)

The crawl found 21 other broken links that are **not** the ingestion class and can't be cleanly fixed here:

- **18 — `0xMiden/tutorials`:** the miden-bank `index.md` `DocCard` items use relative-without-`./` paths → doubled (`/miden-bank/miden-bank/<page>`). These are component hrefs, which their own `onBrokenLinks` doesn't validate.
- **1 — `0xMiden/miden-client`:** `local-node-testing.md` cross-links the node's old `operator/usage` path, removed in the v0.15 restructure.
- **1 — `0xMiden/miden-vm`:** generated stdlib content hardcodes `/user_docs/libcore/word`.
- **1 — frozen 0.13 archive** snapshot.

These need source PRs to the respective repos.

## Test plan

- [ ] CI ingestion + build passes (authoritative gate, runs post-merge on `main`)
- [ ] Spot-check `/full-node/installation`, `/rpc/public-api`, `/builder/tutorials/recipes/rust/create_deploy_tutorial` resolve in the browser
- [ ] Confirm the rebase step logs the per-section rewrite counts in the deploy run
