### PR TITLE
fix(docs): repoint local-node-testing node link to the v0.15 structure

### DIFF
--- a/docs/builder/tools/clients/local-node-testing.md
+++ b/docs/builder/tools/clients/local-node-testing.md
@@ -72,7 +72,7 @@ make compose-genesis
 make compose-up
 ```
 
-For the full node operator workflow, see the [node usage guide](../../../reference/node/operator/usage.md#using-docker-compose).
+For the full node operator workflow, see the [local network development guide](../../../reference/node/local-network-development.md).
 
 ## Export the genesis account
 

--- a/versioned_docs/version-0.14/builder/tools/clients/local-node-testing.md
+++ b/versioned_docs/version-0.14/builder/tools/clients/local-node-testing.md
@@ -72,7 +72,7 @@ make compose-genesis
 make compose-up
 ```
 
-For the full node operator workflow, see the [node usage guide](../../../reference/node/operator/usage.md#using-docker-compose).
+For the full node operator workflow, see the [node usage guide](../../../reference/node/operator/usage.md).
 
 ## Export the genesis account
 


### PR DESCRIPTION
## Summary

`docs/builder/tools/clients/local-node-testing.md` linked to `reference/node/operator/usage#using-docker-compose`, which the v0.15 node-docs restructure removed (the page moved out of `operator/` into the new `full-node/` / `network-operator/` / `local-network-development` layout).

- **Current version:** repointed to `reference/node/local-network-development.md` — the docker-compose local-network guide, the natural fit for the local-node-testing flow.
- **Frozen 0.14 snapshot:** `local-network-development` doesn't exist there (old node structure), and the `#using-docker-compose` anchor was already broken on the still-present `operator/usage` page — so this just drops the dead anchor and keeps the valid page link.

## Verification

- ✅ `npm run build` (with CI ingestion replicated) → `[SUCCESS]`; the `operator/usage` broken reference is gone for both `current` and `0.14`.
- ✅ Diff is two link-only changes.

## Context

Found during the broken-link sweep behind #317. This was mis-attributed to miden-client earlier — `local-node-testing.md` is authored in this repo, not ingested, so it's the right place to fix.

## Out of scope

The miden-bank `DocCard` doubling (the other big broken-link cluster) is **not** an upstream tutorials bug — the tutorials source is correct for their own `trailingSlash: false` site; it doubles only under docs.miden.xyz's trailing-slash behavior. Tracked separately.