### PR TITLE
docs(tutorials): render miden-bank cards with the docs Card component

### DIFF
--- a/docs/builder/tutorials/miden-bank/index.md
+++ b/docs/builder/tutorials/miden-bank/index.md
@@ -30,20 +30,6 @@ This tutorial is designed for hands-on learning. Each part builds on the previou
 
 ### Parts Overview
 
-| Part       | Topic                                                    | What You'll Build                   |
-| ---------- | -------------------------------------------------------- | ----------------------------------- |
-| **Part 0** | [Project Setup](./00-project-setup.md)                   | Create project with `miden new`     |
-| **Part 1** | [Account Components](./01-account-components.md)         | Bank struct with storage            |
-| **Part 2** | [Constants & Constraints](./02-constants-constraints.md) | Business rules and validation       |
-| **Part 3** | [Asset Management](./03-asset-management.md)             | Deposit logic with balance tracking |
-| **Part 4** | [Note Scripts](./04-note-scripts.md)                     | Deposit note for receiving assets   |
-| **Part 5** | [Cross-Component Calls](./05-cross-component-calls.md)   | How bindings enable calls           |
-| **Part 6** | [Transaction Scripts](./06-transaction-scripts.md)       | Initialization script               |
-| **Part 7** | [Output Notes](./07-output-notes.md)                     | Withdraw with P2ID output           |
-| **Part 8** | [Complete Flows](./08-complete-flows.md)                 | End-to-end verification             |
-
-## Tutorial Cards
-
 <CardGrid cols={2}>
   <Card title="Project Setup" href="./project-setup" eyebrow="Part 0">
     Create your project with <code>miden new</code> and understand the workspace structure.
@@ -110,14 +96,6 @@ The complete source code for this tutorial is available in the [examples/miden-b
 git clone https://github.com/0xMiden/miden-tutorials.git
 cd miden-tutorials/examples/miden-bank
 ```
-
-## Supplementary Guides
-
-These standalone guides complement the tutorial:
-
-- **[Testing with MockChain](https://docs.miden.xyz/builder/tutorials/rust-compiler/testing)** - Learn to test your contracts
-- **[Debugging](https://docs.miden.xyz/builder/tutorials/rust-compiler/debugging)** - Troubleshoot common issues
-- **[Common Pitfalls](https://docs.miden.xyz/builder/tutorials/rust-compiler/pitfalls)** - Avoid known gotchas
 
 ## Getting Help
 


### PR DESCRIPTION
## Summary

The miden-bank tutorial index renders 9 "next step" cards via hand-rolled `@theme/DocCard` items with relative hrefs (`miden-bank/<slug>`). Those resolve correctly on the **tutorials standalone site** (`trailingSlash: false`, index at `/miden-bank` → `/miden-bank/<slug>`), but **double** under docs.miden.xyz, whose index pages carry a trailing slash (`/builder/tutorials/miden-bank/` → `/builder/tutorials/miden-bank/miden-bank/<slug>`), 404ing all 9.

Since no single relative href works under both trailing-slash configs, this switches to the docs site's own **`<CardGrid>` / `<Card>`** components with `./<slug>` hrefs — the same pattern as `builder/get-started/index.md` — which resolve correctly here and carry the docs card styling.

## What changed

- **Current version** — author a docs-repo-local `docs/builder/tutorials/miden-bank/index.md`. The ingestion already preserves a local override via `git checkout HEAD -- .../miden-bank/index.md` (it just wasn't tracked before, so the vendor copy with the broken DocCards was winning). Also consolidates the redundant plain "Parts Overview" table into the card grid, and drops the "Supplementary Guides" section (it linked only to removed `rust-compiler/{testing,debugging,pitfalls}` pages).
- **0.14 snapshot** — in-place swap of the DocCard grid for the same `<CardGrid>` (the released site shows the doubling today).

> Why not fix it in the tutorials repo: the tutorials source is correct for *their* site, and changing it there breaks *their* build (their `onBrokenLinks: throw` rejects the docs-site-shaped hrefs). The mismatch is docs.miden.xyz's trailing-slash behavior vs. every ingested site's `trailingSlash: false` — addressed here on the docs side.

## Verification

- ✅ `npm run build` (CI ingestion replicated) → `[SUCCESS]`; **zero** `miden-bank/miden-bank` doubling warnings in either `current` or `0.14`.
- ✅ Served the build + Playwright render of `/next/builder/tutorials/miden-bank/`: **9 cards**, docs `<CardGrid cols={2}>`/`<Card>` styling (eyebrow + title + description), all hrefs single-segment (`…/miden-bank/<slug>`), click-through resolves.

## Notes / out of scope

- Maintaining a docs-repo-local `index.md` means it diverges from the vendor tutorial intro over time — that's inherent to the existing "locally-authored index" ingestion design.
- The `rust-compiler/{testing,debugging,pitfalls}` links (removed pages) still appear in the *other* vendor miden-bank pages (`02/04/07/08`); that's a separate upstream-tutorials cleanup.