### PR TITLE
fix(redirects): redirect old rust-compiler guide paths to tutorials/helpers

### DIFF
--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -142,6 +142,9 @@ const config: Config = {
           // old /builder/guides/* paths to the new location.
           if (existingPath.startsWith("/builder/tutorials/helpers")) {
             redirects.push(existingPath.replace("/builder/tutorials/helpers", "/builder/guides"));
+            // The testing/debugging/pitfalls guides also previously lived under
+            // tutorials/rust-compiler/; the miden-bank tutorial still links there.
+            redirects.push(existingPath.replace("/builder/tutorials/helpers", "/builder/tutorials/rust-compiler"));
           }
           // tools/explorer renamed to tools/network (now covers status,
           // RPC, faucet, remote prover — not just the block explorer).


### PR DESCRIPTION
## Summary

The miden-bank tutorial links to `tutorials/rust-compiler/{testing,debugging,pitfalls}` in several pages, but those guides moved to `tutorials/helpers/`. The links are written as absolute `https://docs.miden.xyz/...` URLs, so Docusaurus's link checker treats them as external and never flagged them — they 404 in the browser.

This is a path migration, so it's handled the same way the file already handles the rest: `createRedirects` aliases the existing `helpers/*` pages from their old locations. It already adds the `/builder/guides/*` alias; this adds the `/builder/tutorials/rust-compiler/*` alias too.

Fixes (all bare `/builder/...` URLs, so one rule covers every version that links them):
- `rust-compiler/testing` → `helpers/testing`
- `rust-compiler/debugging` → `helpers/debugging`
- `rust-compiler/pitfalls` → `helpers/pitfalls` (anchors `#felt-arithmetic-underflowoverflow` and `#array-ordering-rustmasm-reversal` preserved — both headings exist on the new page)

## Verification

- ✅ `npm run build` → `[SUCCESS]`; redirect files generated at `/builder/tutorials/rust-compiler/{testing,debugging,pitfalls}` pointing to `…/helpers/…`.
- ✅ Served build: the previously-404 paths now resolve (200 redirect → helpers page).

## Note / out of scope

The complete fix would also update the source URLs in the vendor tutorials pages (`miden-bank/02,04,07,08`) to point at `helpers/` directly, but the redirect makes every old link — including external bookmarks — resolve, which is the more complete fix.