### PR TITLE
fix(migration): correct Discord/SyncTarget errors and document asset-key MASM changes

### DIFF
--- a/docs/builder/migration/05-asset-vault-faucet.md
+++ b/docs/builder/migration/05-asset-vault-faucet.md
@@ -73,7 +73,9 @@ let faucet = FungibleFaucet::builder()
 
 A new **`AssetComposition`** enum (`None`, `Fungible`, `Custom`) discriminates assets, and the asset vault key's metadata byte now encodes the composition (plus the asset‑callback flag). `AssetVaultKey::new(asset_id, faucet_id, composition, callback_flag)` is the general constructor; `AssetVaultKey::new_fungible(faucet_id, callback_flag)` is the fungible shortcut. (`Custom` composition is reserved and currently rejected.)
 
+**What composition means:** it describes how two instances of the same asset combine in a vault — `None` (non‑fungible: instances never merge), `Fungible` (instances merge by summing amounts), and `Custom` (reserved for faucet‑defined logic; rejected at construction today). Because composition is carried in the key's metadata byte rather than derived from the faucet ID, the vault key is self‑describing. Read it back with `AssetVaultKey::composition()` and the callback flag with `AssetVaultKey::callback_flag()`. See the [asset encoding reference](../../reference/protocol/asset#encoding) and [composition reference](../../reference/protocol/asset#composition) for the full layout, and [MASM Changes](./masm-changes#asset-vault-key-composition) for the procedure‑level effects.
+
 ### Migration Steps
 
 1. Where you constructed a raw vault key word, use `AssetVaultKey::new_fungible` / `AssetVaultKey::new`.
-2. Branch on `AssetComposition` (via `key.composition()`) instead of inspecting raw bits.
+2. Branch on `AssetComposition` (via `AssetVaultKey::composition()`) instead of inspecting raw bits.

--- a/docs/builder/migration/07-client-changes.md
+++ b/docs/builder/migration/07-client-changes.md
@@ -48,7 +48,7 @@ let account: Option<Account> = rpc_api.get_account_details(account_id).await?;
 
 ### Summary
 Several `NodeRpcClient` methods changed to match the `0.15` RPC definitions:
-- `sync_chain_mmr`'s `block_to: Option<BlockNumber>` became `upper_bound: SyncTarget`. Use `SyncTarget::CommittedChainTip` for the old `None` behavior, `SyncTarget::ProvenChainTip` for the latest proven block, or `SyncTarget::BlockNumber(n)` for a specific height.
+- `sync_chain_mmr`'s `block_to: Option<BlockNumber>` became `upper_bound: SyncTarget`. `SyncTarget` has exactly two variants: use `SyncTarget::CommittedChainTip` for the old `None` behavior, or `SyncTarget::ProvenChainTip` for the latest proven block. There is no explicit block-height target.
 - `check_nullifiers` (and `RpcEndpoint::CheckNullifiers`, `EndpointError::CheckNullifiers`, `CheckNullifiersError`) were **removed**. Use `sync_nullifiers` to retrieve nullifier updates.
 - `sync_nullifiers`, `sync_notes`, `sync_notes_with_details`, `sync_storage_maps`, and `sync_account_vault` lost their `Option<BlockNumber>` upper bound in favor of a required `block_to: BlockNumber`.
 - `get_block_by_number` gained an `include_proof: bool` parameter.
@@ -66,7 +66,7 @@ let block = rpc_api.get_block_by_number(block_num, /* include_proof */ false).aw
 ```
 
 ### Migration Steps
-1. Replace `sync_chain_mmr(_, None)` with `sync_chain_mmr(_, SyncTarget::CommittedChainTip)`; map any explicit `Some(n)` to `SyncTarget::BlockNumber(n)`.
+1. Replace `sync_chain_mmr(_, None)` with `sync_chain_mmr(_, SyncTarget::CommittedChainTip)`. v0.15 dropped explicit-height targeting, so map any explicit `Some(n)` to `SyncTarget::CommittedChainTip` as well (or `SyncTarget::ProvenChainTip` if you need the latest proven block).
 2. Replace `check_nullifiers` with `sync_nullifiers` and adapt to `Vec<NullifierUpdate>` (drop the `SmtProof` path).
 3. Pass an explicit `block_to` (e.g. the client's current sync height / chain tip) to `sync_nullifiers`, `sync_notes`, `sync_storage_maps`, `sync_account_vault`.
 4. Add `include_proof` to `get_block_by_number` calls (`false` unless you need the block proof).

--- a/docs/builder/migration/08-masm-changes.md
+++ b/docs/builder/migration/08-masm-changes.md
@@ -7,7 +7,7 @@ description: "Breaking MASM and standard-library changes in v0.15"
 # MASM Changes
 
 :::warning Breaking Change
-Several core `miden::protocol::note` procedures were renamed; several kernel procedures dropped redundant outputs that duplicated their inputs; and the immediate form `adv_push.N` was removed. Custom note scripts and any MASM that consumed the removed outputs must be updated.
+Several core `miden::protocol::note` procedures were renamed; several kernel procedures dropped redundant outputs that duplicated their inputs; the asset vault key's metadata byte was redefined to encode `AssetComposition`; and the immediate form `adv_push.N` was removed. Custom note scripts and any MASM that consumed the removed outputs or inspected the asset-key metadata must be updated.
 :::
 
 ---
@@ -31,6 +31,59 @@ New convenience helpers were also added: `note::metadata_into_note_type` and `no
 
 1. Search/replace the four procedure names per the table.
 2. Where you manually extracted the tag from the metadata header, switch to `metadata_into_tag`.
+
+---
+
+## Asset vault key: `AssetComposition` metadata + `key_to_*` helpers
+
+### Summary
+
+The asset vault key's metadata byte was redefined to encode the new `AssetComposition`. The MASM word is still called `ASSET_KEY` (it was **not** renamed — `AssetVaultKey` is the Rust type name), and its word-level layout is unchanged:
+
+```
+ASSET_KEY = [asset_id_suffix, asset_id_prefix, faucet_id_suffix_and_metadata, faucet_id_prefix]
+```
+
+What changed is the asset-metadata packed into the low 8 bits of the third element (`faucet_id_suffix_and_metadata`):
+
+| Bits | Meaning |
+| --- | --- |
+| 0–1 | `AssetComposition` — `COMPOSITION_NONE` (0), `COMPOSITION_FUNGIBLE` (1), `COMPOSITION_CUSTOM` (2). `Custom` is reserved and currently rejected. |
+| 2 | asset-callback flag (**moved from bit 0** in v0.14). |
+| 3–7 | reserved; must be zero. |
+
+The `COMPOSITION_NONE` / `COMPOSITION_FUNGIBLE` / `COMPOSITION_CUSTOM` constants are exported from `miden::protocol::asset`.
+
+### Affected Code
+
+New and updated procedures in `miden::protocol::asset` (call as `exec.asset::<proc>`):
+
+| Procedure | Inputs → Outputs | Notes |
+| --- | --- | --- |
+| `asset::key_to_composition` | `[ASSET_KEY] → [asset_composition, ASSET_KEY]` | **New.** Compare the result against the `COMPOSITION_*` constants. |
+| `asset::key_to_callbacks_enabled` | `[ASSET_KEY] → [callbacks_enabled, ASSET_KEY]` | Returns `1` if callbacks are enabled, `0` otherwise (reads bit 2). |
+| `asset::key_to_faucet_id` | `[ASSET_KEY] → [faucet_id_suffix, faucet_id_prefix, ASSET_KEY]` | **Not renamed.** Now masks off the metadata internally. |
+| `asset::key_into_faucet_id` | `[ASSET_KEY] → [faucet_id_suffix, faucet_id_prefix]` | **Not renamed.** Consumes the key. |
+| `asset::key_to_asset_id` / `asset::key_into_asset_id` | `[ASSET_KEY] → [asset_id_suffix, asset_id_prefix(, ASSET_KEY)]` | **Not renamed.** |
+
+```masm
+# Read the callback flag (bit moved 0 → 2; use the helper, don't mask manually)
+exec.asset::key_to_callbacks_enabled
+# => [callbacks_enabled, ASSET_KEY]
+
+# Branch on the asset's composition
+exec.asset::key_to_composition
+# => [asset_composition, ASSET_KEY]
+eq.COMPOSITION_FUNGIBLE
+```
+
+### Migration Steps
+
+1. If you read the callback flag by masking **bit 0** of the metadata, switch to `asset::key_to_callbacks_enabled` — the flag now lives in **bit 2**.
+2. To branch on the asset type, call `asset::key_to_composition` and compare against the `COMPOSITION_*` constants instead of inspecting raw bits.
+3. No change is needed for `asset::key_to_faucet_id`, `asset::key_into_faucet_id`, `asset::key_to_asset_id`, or `asset::key_into_asset_id` — their names and stack effects are unchanged.
+
+See [Assets, Vault & Faucet](./asset-vault-faucet) for the matching Rust-side `AssetComposition` / `AssetVaultKey` changes.
 
 ---
 

--- a/docs/builder/migration/08-masm-changes.md
+++ b/docs/builder/migration/08-masm-changes.md
@@ -34,7 +34,7 @@ New convenience helpers were also added: `note::metadata_into_note_type` and `no
 
 ---
 
-## Asset vault key: `AssetComposition` metadata + `key_to_*` helpers
+## Asset vault key & composition {#asset-vault-key-composition}
 
 ### Summary
 
@@ -66,6 +66,8 @@ New and updated procedures in `miden::protocol::asset` (call as `exec.asset::<pr
 | `asset::key_into_faucet_id` | `[ASSET_KEY] → [faucet_id_suffix, faucet_id_prefix]` | **Not renamed.** Consumes the key. |
 | `asset::key_to_asset_id` / `asset::key_into_asset_id` | `[ASSET_KEY] → [asset_id_suffix, asset_id_prefix(, ASSET_KEY)]` | **Not renamed.** |
 
+The transaction kernel also adds `is_fungible_asset_key` (`[ASSET_KEY] → [is_fungible_asset, ASSET_KEY]`), equivalent to `key_to_composition` followed by `eq.COMPOSITION_FUNGIBLE`. The asset constructors (`create_fungible_key`, `create_fungible_asset_unchecked`, `create_non_fungible_asset_unchecked`) keep their v0.14 signatures — they encode the composition internally.
+
 ```masm
 # Read the callback flag (bit moved 0 → 2; use the helper, don't mask manually)
 exec.asset::key_to_callbacks_enabled
@@ -81,7 +83,7 @@ eq.COMPOSITION_FUNGIBLE
 
 1. If you read the callback flag by masking **bit 0** of the metadata, switch to `asset::key_to_callbacks_enabled` — the flag now lives in **bit 2**.
 2. To branch on the asset type, call `asset::key_to_composition` and compare against the `COMPOSITION_*` constants instead of inspecting raw bits.
-3. No change is needed for `asset::key_to_faucet_id`, `asset::key_into_faucet_id`, `asset::key_to_asset_id`, or `asset::key_into_asset_id` — their names and stack effects are unchanged.
+3. No change is needed for `asset::key_to_faucet_id`, `asset::key_into_faucet_id`, `asset::key_to_asset_id`, or `asset::key_into_asset_id` — their names and stack effects are unchanged. Only code that **hand-decodes** the metadata byte is affected by the bit-layout shift; callers using these helper procs are not.
 
 See [Assets, Vault & Faucet](./asset-vault-faucet) for the matching Rust-side `AssetComposition` / `AssetVaultKey` changes.
 

--- a/docs/builder/migration/index.md
+++ b/docs/builder/migration/index.md
@@ -169,5 +169,6 @@ If your project builds and all tests pass, you've successfully migrated to v0.15
 ## Need Help?
 
 - **Telegram:** [Build on Miden](https://t.me/BuildOnMiden) — technical discussion and support.
+- **Forum:** [Miden discussions](https://github.com/0xMiden/miden-node/discussions) — longer-form questions and design discussion.
 - **GitHub issues:** file against the relevant repo — [`miden-client`](https://github.com/0xMiden/miden-client/issues), [`web-sdk`](https://github.com/0xMiden/web-sdk/issues), [`protocol`](https://github.com/0xMiden/protocol/issues), or [`miden-vm`](https://github.com/0xMiden/miden-vm/issues).
 - **Changelogs:** the per-repo `CHANGELOG.md` files carry the full list of changes, including non-breaking features and fixes omitted from this guide.

--- a/docs/builder/migration/index.md
+++ b/docs/builder/migration/index.md
@@ -168,6 +168,6 @@ If your project builds and all tests pass, you've successfully migrated to v0.15
 
 ## Need Help?
 
-- **Discord:** [Miden Discord](https://discord.gg/0xMiden) — the `#dev-support` channel.
+- **Telegram:** [Build on Miden](https://t.me/BuildOnMiden) — technical discussion and support.
 - **GitHub issues:** file against the relevant repo — [`miden-client`](https://github.com/0xMiden/miden-client/issues), [`web-sdk`](https://github.com/0xMiden/web-sdk/issues), [`protocol`](https://github.com/0xMiden/protocol/issues), or [`miden-vm`](https://github.com/0xMiden/miden-vm/issues).
 - **Changelogs:** the per-repo `CHANGELOG.md` files carry the full list of changes, including non-breaking features and fixes omitted from this guide.


### PR DESCRIPTION
## Summary

Closes the gaps the v0.15 migration guide drew on the Devnet v0.15 Slack thread (Mieszko: missing MASM asset coverage + no explanation of `AssetComposition`; mico: hallucinated Discord link). All claims verified against shipped source — `protocol` v0.15.3, `miden-client` v0.15.2. Both errors originate in migration issue #312 (the guide was transcribed from it); the issue body is being corrected separately.

## Changes

- **`fix(migration)`: Discord → Telegram + Forum.** The Need Help section linked a non-existent Miden Discord. Repointed to the canonical channels: Build on Miden Telegram and the GitHub Discussions forum.
- **`fix(migration)`: drop `SyncTarget::BlockNumber(n)`.** The shipped `SyncTarget` enum has only `CommittedChainTip` / `ProvenChainTip`; the guide's `Some(n)` → `SyncTarget::BlockNumber(n)` step does not compile. Rewrote the summary and step.
- **`docs(migration)`: asset vault key MASM coverage (section 08).** New "Asset vault key & composition" section: the metadata byte now encodes `AssetComposition` (bits 0–1) with the callback flag moved to bit 2; documents `asset::key_to_composition`, `key_to_callbacks_enabled`, the kernel `is_fungible_asset_key` helper, the `COMPOSITION_*` constants, and that `key_to_faucet_id` / `key_into_faucet_id` / `key_to_asset_id` and the asset constructors were **not** renamed. Only code that hand-decodes the metadata byte is affected.
- **`docs(migration)`: composition ramifications + reference link (section 05).** Added a "what composition means" paragraph (None/Fungible/Custom merge semantics), the `composition()` / `callback_flag()` accessors, and links to the `/reference/protocol/asset` encoding + composition sections that Mieszko found useful, plus a cross-link to the new MASM section.

## Verification

- Every MASM procedure name, stack effect, constant, and metadata bit position verified against `protocol` tag `v0.15.3` (`asm/.../asset.masm`, `src/asset/vault/vault_key.rs`, `src/asset/asset_composition.rs`).
- `SyncTarget` and channel corrections verified against `miden-client` v0.15.2; Telegram + Forum URLs return 200.
- Reference anchors `#encoding` and `#composition` confirmed present in `protocol:docs/src/asset.md`; internal cross-links match existing conventions.
- Note: a full local `npm run build` can't complete in a fresh worktree because rust-client / miden-bank / guardian / reference pages are ingested only at CI-deploy time. Changes here are markdown-only.

## Test plan

- [ ] CI build passes (with ingestion); `../../reference/protocol/asset#encoding` / `#composition` resolve.
- [ ] Need Help shows Telegram + Forum, no Discord.
- [ ] Section 7 no longer references `SyncTarget::BlockNumber`.
- [ ] Section 8 renders the "Asset vault key & composition" table; section 5 links to it and to the encoding reference.
