### PR TITLE
fix(docs): contain wide markdown tables

### DIFF
--- a/src/custom/_components.css
+++ b/src/custom/_components.css
@@ -643,8 +643,9 @@
    width proportionally. */
 .theme-doc-markdown table,
 article table {
-  display: table;
+  display: block;
   width: 100%;
+  max-width: 100%;
   min-width: 100%;
   table-layout: auto;
   border: 1px solid var(--color-border);
@@ -654,7 +655,9 @@ article table {
   border-spacing: 0;
   margin: 1.5rem 0;
   box-shadow: var(--shadow-sm);
-  overflow: hidden; /* clip content at the rounded corners */
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
 }
 
 /* Narrow trailing columns (common pattern — "Part" numbers, short
@@ -724,17 +727,6 @@ article tbody tr:hover {
 article td code {
   font-size: 13px;
   padding: 1px 4px;
-}
-
-@media (max-width: 768px) {
-  .theme-doc-markdown table,
-  article table {
-    display: block;
-    max-width: 100%;
-    overflow-x: auto;
-    overflow-y: hidden;
-    -webkit-overflow-scrolling: touch;
-  }
 }
 
 /* ==========================================

--- a/src/custom/_sidebar.css
+++ b/src/custom/_sidebar.css
@@ -11,6 +11,7 @@
 /* Main docs content area - wider to fill space */
 .theme-doc-markdown {
   max-width: 100%; /* Use full available width */
+  min-width: 0;
 }
 
 /* ThemeClassNames.docs.docSidebarMenu */


### PR DESCRIPTION
This keeps wide markdown tables contained inside the article column instead of letting them push underneath the right-hand TOC.

The table styling already switched to scrollable blocks on small screens; this applies the same containment at desktop widths and lets the markdown area shrink correctly inside the docs layout.

Closes #326.

Checked: `git diff --check`.

I also tried `npm run typecheck` and `./node_modules/.bin/docusaurus.cmd build`; both currently fail on main before this change. Typecheck is blocked by existing Docusaurus `@theme/*` alias errors, and build is blocked by missing sidebar doc ids in `sidebars.ts`.