### PR TITLE
docs(builder): expand the landing intro and surface testnet/faucet

### DIFF
--- a/docs/builder/index.md
+++ b/docs/builder/index.md
@@ -6,7 +6,9 @@ pagination_next: null
 
 # Build on Miden
 
-Accounts, notes, and transactions — authored in Rust, compiled to MASM, proved client-side.
+Miden is a zero-knowledge layer 2 where every account is an independent state machine and state is private by default. You author accounts, notes, and transactions in Rust, compile them to Miden Assembly (MASM), and prove them client-side — the network verifies each proof without ever seeing your private state.
+
+This is the developer's entry point. **New to Miden?** Start with [Get started](./get-started) to install the toolchain and send your first transaction, then build [Your first smart contract](./get-started/your-first-smart-contract), and dip into the [Reference](../reference) when you want to know how it all works underneath. Already oriented? Jump straight to any section below.
 
 ## Start here
 
@@ -18,6 +20,10 @@ Accounts, notes, and transactions — authored in Rust, compiled to MASM, proved
     Walk through writing, proving, and deploying a counter contract in Rust.
   </Card>
 </CardGrid>
+
+<Callout variant="tip" title="Testnet & faucet">
+Building against the public testnet? Grab free test assets from the [faucet](https://faucet.testnet.miden.io/), and find every public endpoint — RPC, block explorer, status — on the [Network](./tools/network) page.
+</Callout>
 
 ## Build
 


### PR DESCRIPTION
## Summary
The first page of the builder docs (/builder/) opened with a single-line tagline and dropped readers straight into a wall of cards — no real introduction or guidance on where to start. It also didn't surface the testnet faucet anywhere.

## Changes
- Replace the one-line tagline with a short intro: what you build on Miden (accounts/notes/transactions in Rust → MASM, client-side proofs, private-by-default state) framed with the site's canonical 'zero-knowledge layer 2' language.
- Add a **'New to Miden?'** guided path — install → first smart contract → reference — so a newcomer isn't guessing which card to click.
- Add a **Testnet & faucet** callout linking the [faucet](https://faucet.testnet.miden.io/) and the [Network](https://docs.miden.xyz/builder/tools/network) page, making the faucet discoverable from the first page of the docs.
- Existing card sections are unchanged.

Light touch by design — kept it scannable, no scrolling wall.

## Verification
- `Callout` is a globally registered MDX component; all internal links (`./get-started`, `./get-started/your-first-smart-contract`, `../reference`, `./tools/network`) resolve to existing pages.
- faucet.testnet.miden.io returns 200.

## Test plan
- [ ] /builder/ renders the new intro and guided path correctly.
- [ ] Testnet & faucet callout renders and both links work.

## Out of scope
- The Migration card still reads `v0.13 → v0.14`; the site is still on v14 (no v15 snapshot yet), so left as-is.