### PR TITLE
docs(builder): backport faucet link + landing intro to v0.14

### DIFF
--- a/versioned_docs/version-0.14/builder/index.md
+++ b/versioned_docs/version-0.14/builder/index.md
@@ -6,7 +6,9 @@ pagination_next: null
 
 # Build on Miden
 
-Accounts, notes, and transactions — authored in Rust, compiled to MASM, proved client-side.
+Miden is a zero-knowledge layer 2 where every account is an independent state machine and state is private by default. You author accounts, notes, and transactions in Rust, compile them to Miden Assembly (MASM), and prove them client-side — the network verifies each proof without ever seeing your private state.
+
+This is the developer's entry point. **New to Miden?** Start with [Get started](./get-started) to install the toolchain and send your first transaction, then build [Your first smart contract](./get-started/your-first-smart-contract), and dip into the [Reference](../reference) when you want to know how it all works underneath. Already oriented? Jump straight to any section below.
 
 ## Start here
 
@@ -18,6 +20,10 @@ Accounts, notes, and transactions — authored in Rust, compiled to MASM, proved
     Walk through writing, proving, and deploying a counter contract in Rust.
   </Card>
 </CardGrid>
+
+<Callout variant="tip" title="Testnet & faucet">
+Building against the public testnet? Grab free test assets from the [faucet](https://faucet.testnet.miden.io/), and find every public endpoint — RPC, block explorer, status — on the [Network](./tools/network) page.
+</Callout>
 
 ## Build
 

--- a/versioned_docs/version-0.14/builder/tools/network.md
+++ b/versioned_docs/version-0.14/builder/tools/network.md
@@ -9,7 +9,7 @@ description: "Miden testnet endpoints — status, explorer, RPC, faucet, remote 
 Public Miden testnet services — explorer, RPC, faucet, remote prover, and status. The canonical live inventory lives at [status.testnet.miden.io](https://status.testnet.miden.io/); the page below is an editorial overview that won't go stale as new endpoints ship.
 
 <Callout variant="info" title="Devnet">
-The same services exist on devnet under the `devnet` subdomain — e.g., `status.devnet.miden.io`, `devnet.midenscan.com`. Swap `testnet` → `devnet` in any URL on this page to point at devnet instead.
+The same services exist on devnet under the `devnet` subdomain — e.g., `status.devnet.miden.io`, `faucet.devnet.miden.io`, `devnet.midenscan.com`. Swap `testnet` → `devnet` in any URL on this page to point at devnet instead.
 </Callout>
 
 <CardGrid cols={2}>
@@ -27,8 +27,8 @@ The same services exist on devnet under the `devnet` subdomain — e.g., `status
   <Card title="RPC" eyebrow="Submit · Query">
     gRPC endpoint the node exposes for submitting proven transactions and querying account / note / block state. Clients connect here by default; see [status.testnet.miden.io](https://status.testnet.miden.io/) for the current URL.
   </Card>
-  <Card title="Faucet" eyebrow="Test assets">
-    Dispenses test assets (testnet MID and fungible test tokens) to the account ID you specify. Check status for the current faucet endpoint.
+  <Card title="Faucet ↗" href="https://faucet.testnet.miden.io/" eyebrow="Test assets">
+    Dispenses test assets (testnet MID and fungible test tokens) to the account ID you specify. Open [faucet.testnet.miden.io](https://faucet.testnet.miden.io/) to mint, or check the status page for the current endpoint.
   </Card>
   <Card title="Remote prover" eyebrow="Delegated proving">
     Off-loads proof generation to a hosted prover when the client doesn't have the compute for client-side proving. Opt in via the client's `proverUrl` option.


### PR DESCRIPTION
## Summary
PRs #330 and #331 added the testnet faucet link and an expanded builder landing intro, but they edited the **current/unstable** docs (`docs/`). `docs.miden.xyz` serves the **v0.14** snapshot by default, so the live default pages (`/builder/`, `/builder/tools/network`) still show the old content with no faucet link. This backports both changes into `versioned_docs/version-0.14/` so they appear on the live site.

## Changes
- `versioned_docs/version-0.14/builder/tools/network.md` — Faucet card links to [faucet.testnet.miden.io](https://faucet.testnet.miden.io/); devnet callout names `faucet.devnet.miden.io`.
- `versioned_docs/version-0.14/builder/index.md` — expanded intro + 'New to Miden?' guided path + Testnet & faucet callout.

Identical edits to the merged #330/#331 — no new content, just mirrored into the released version.

## Verification
- faucet.testnet.miden.io / faucet.devnet.miden.io return 200.
- All internal links (`./get-started`, `./get-started/your-first-smart-contract`, `../reference`, `./tools/network`) resolve within the version-0.14 tree.

## Notes
Manual `versioned_docs/` edit is intentional here — backporting a content fix to the released version, which is the sanctioned exception in the repo's CLAUDE.md.