### PR TITLE
fix(ci): use next as node ingestion fallback

### DIFF
--- a/.github/workflows/cut-versions.yml
+++ b/.github/workflows/cut-versions.yml
@@ -80,8 +80,9 @@ jobs:
           const read = (p) => fs.existsSync(p) ? fs.readFileSync(p, 'utf8') : '';
           const m = YAML.parse(read(path) || '{}') || {};
 
-          // Prefer manual inputs if provided; else manifest; else fallback to "main"
-          const getRef = (input, manifestVal) => input && input.trim() ? input.trim() : (manifestVal || 'main');
+          // Prefer manual inputs, then the manifest, then each repository's development branch.
+          const getRef = (input, manifestVal, fallback = 'main') =>
+            input && input.trim() ? input.trim() : (manifestVal || fallback);
 
           const inputs = {
             version_label: process.env.INPUT_VERSION_LABEL || ''
@@ -92,7 +93,7 @@ jobs:
           // Build outputs
           const out = {
             version_label: inputs.version_label || (m.version || '').trim(),
-            miden_node_ref:      getRef(process.env.INPUT_MIDEN_NODE_REF,      refs['node']),
+            miden_node_ref:      getRef(process.env.INPUT_MIDEN_NODE_REF,      refs['node'], 'next'),
             miden_vm_ref:        getRef(process.env.INPUT_MIDEN_VM_REF,        refs['miden-vm']),
             miden_base_ref:      getRef(process.env.INPUT_MIDEN_BASE_REF,      refs['protocol']),
             miden_client_ref:    getRef(process.env.INPUT_MIDEN_CLIENT_REF,    refs['miden-client']),


### PR DESCRIPTION
## Summary

Update the version-cut ingestion workflow to use each repository’s development branch as its final fallback, with `next` selected for `0xMiden/node`. Node deleted `main` under its new branching policy, while `next` remains the active development branch. Manifest pins and manual overrides continue to take precedence.

## Verification

- Red/green resolver check with the Node entry removed from a temporary release manifest: `main` before, `next` after
- Confirmed `refs/heads/main` is absent and `refs/heads/next` exists in `0xMiden/node`
- Shallow-checked out Node `next` at `5066b383549b7448271ebf4d33a9530340b64328`
- Ran the deployment workflow’s aggregation block; 47 Node docs ingested and 17 internal links rebased across 8 files
- `NODE_OPTIONS=--max-old-space-size=12288 npm run build` — success
- `git diff --check`

## Test plan

- [x] Manifest Node refs still override the fallback
- [x] Missing Node manifest ref resolves to `next`
- [x] Node `next` can be checked out and ingested
- [x] Full production docs build completes

## Out of scope

- Existing broken-link, broken-anchor, and historical version warnings