### PR TITLE
fix: wrap long doc table cells

### DIFF
--- a/src/custom/_components.css
+++ b/src/custom/_components.css
@@ -675,7 +675,7 @@ article table td:not(:first-child):not(:last-child) {
 .theme-doc-markdown table td:last-child,
 article table th:last-child,
 article table td:last-child {
-  white-space: nowrap;
+  white-space: normal;
 }
 
 .theme-doc-markdown thead,
@@ -723,10 +723,14 @@ article tbody tr:hover {
 }
 
 /* Inline code inside tables stays legible */
+.theme-doc-markdown th code,
 .theme-doc-markdown td code,
+article th code,
 article td code {
   font-size: 13px;
   padding: 1px 4px;
+  white-space: normal;
+  overflow-wrap: anywhere;
 }
 
 /* ==========================================


### PR DESCRIPTION
Closes #261.

## Summary
- Allow the final column in documentation tables to wrap instead of forcing `nowrap`.
- Allow inline code inside table cells to wrap when values are too long for the content column.

## Why
The Asset callbacks table contains long callback storage slot names and explanatory text. The previous table styling forced the last column onto a single line, which could push the table past the document width and overlap the right-hand table of contents.

## Testing
- `npm ci`
- `git diff --check`

I also ran:
- `npm run typecheck` - fails in this fresh clone with existing Docusaurus theme alias/type resolution errors unrelated to this CSS change.
- `npm run build` - fails in this fresh clone because `sidebars.ts` references docs that are populated by the repository's ingestion workflow; the local checkout does not include those ingested current docs.