### PR TITLE
fix: repoint two 404 external links in builder docs

### DIFF
--- a/docs/builder/tools/clients/react-sdk/account-state-and-balances.md
+++ b/docs/builder/tools/clients/react-sdk/account-state-and-balances.md
@@ -22,7 +22,7 @@ The important boundary is:
 - **`useExecuteProgram()`** runs locally and does not prove, submit, or change state.
 
 For the full package README and source-level examples, see
-[`miden-client/packages/react-sdk/README.md`](https://github.com/0xMiden/miden-client/blob/v0.15.0/packages/react-sdk/README.md).
+[`web-sdk/packages/react-sdk/README.md`](https://github.com/0xMiden/web-sdk/blob/v0.15.9/packages/react-sdk/README.md).
 
 ## Provider setup
 


### PR DESCRIPTION
Two links in `docs/` return 404. Both verified with `curl` before and after, per the URL rule in CLAUDE.md.

## 1. Foundry scripting guide

`docs/builder/get-started/your-first-smart-contract/deploy.md:42`

```
404  https://getfoundry.sh/guides/scripting-with-solidity
200  https://getfoundry.sh/forge/scripting
```

Foundry moved the page. Their own `llms.txt` lists the current one:

> `- [Scripting](/forge/scripting): Deploy and interact with contracts using Forge scripts.`

which matches what the sentence is pointing at ("executable Rust binaries that handle all your contract interactions"). `https://getfoundry.sh/guides/` itself is still 200, so only the leaf moved.

## 2. React SDK README

`docs/builder/tools/clients/react-sdk/account-state-and-balances.md:25`

```
404  https://github.com/0xMiden/miden-client/blob/v0.15.0/packages/react-sdk/README.md
200  https://github.com/0xMiden/web-sdk/blob/v0.15.9/packages/react-sdk/README.md
```

The tag `v0.15.0` does exist on `miden-client`, but there is **no `packages/` directory** in that repo — not at that tag, and not on its default branch. The React SDK lives in `web-sdk`:

- `@miden-sdk/react` on npm (latest `0.15.9`, matching this docs line) declares `repository: git+https://github.com/0xMiden/web-sdk.git`
- `0xMiden/web-sdk/packages/react-sdk/README.md` exists and is 56 KB

Pinned to `v0.15.9` — the latest `0.15.x` tag, preserving the original intent to pin rather than track a moving branch. `v0.15.0` is not a tag on `web-sdk` (its tags start at `v0.15.4`). Link text updated from `miden-client/...` to `web-sdk/...` so it still names the file it points at.

## Notes

- **`npm run build` does not complete on a bare clone.** It fails in `sidebars.ts` with `These sidebar document ids do not exist:` for `builder/tools/bridging/*`, `builder/tools/clients/rust-client/*` and friends — the docs that `deploy-docs.yml` ingests from external repos before building. I confirmed the failure is **identical on untouched `main`**, so it is pre-existing and not from this change. Both edits here are external absolute URLs, which Docusaurus's `onBrokenLinks` does not check, so they cannot affect the build either way. Flagging it in case a documented local-build path (or an ingest script) would be worth having.
- **`versioned_docs/` left untouched.** The same two links appear in the snapshots (`version-0.11` through `version-0.15`). Those are generated by the cut-versions workflow, so fixing `docs/` is what makes future cuts correct; happy to update the snapshots too if you'd rather they were consistent.
- While checking, I noticed three links using pre-rename repo names that GitHub still redirects — `0xMiden/miden-tutorials` → `tutorials`, `0xMiden/miden-node/discussions` → `node/discussions`, and `0xMiden/miden-client/issues` → **`rust-sdk/issues`**. They all resolve today so I left them out of this PR, but the last one in particular suggests the same repo-reorg drift as fix #2. Say the word and I'll fold them in.