### PR TITLE
docs: fix stale client repo entry in llms.txt, point agents at shipped SDK guidance

### DIFF
--- a/static/llms.txt
+++ b/static/llms.txt
@@ -6,6 +6,7 @@
 - [Next / unstable builder docs](https://docs.miden.xyz/next/builder/): Current development builder docs, currently labeled 0.15 unstable.
 - [Next / unstable reference](https://docs.miden.xyz/next/reference/): Current development protocol, VM, node, and compiler docs.
 - [Agent skill](https://docs.miden.xyz/skill.md): Compact Miden context for AI coding assistants.
+- Building a JavaScript or React app: the `@miden-sdk/*` npm packages ship their own agent guidance, an `AGENTS.md` index plus a `skills/` directory readable at `node_modules/@miden-sdk/<pkg>/`. It is version-matched to the installed release, so prefer it over this site for API specifics. `npm create @miden-sdk@latest` copies it into the project.
 - [GitHub organization](https://github.com/0xMiden): Source repositories.
 
 ## Builder Documentation
@@ -68,7 +69,8 @@
 - [docs](https://github.com/0xMiden/docs): Docusaurus documentation site.
 - [protocol](https://github.com/0xMiden/protocol): Protocol types, account model, notes, assets, transactions, and MASM protocol library.
 - [miden-vm](https://github.com/0xMiden/miden-vm): Virtual machine and assembler.
-- [miden-client](https://github.com/0xMiden/miden-client): Rust client, Web SDK, and React SDK.
+- [rust-sdk](https://github.com/0xMiden/rust-sdk): Rust client library and CLI. Formerly `miden-client`.
+- [web-sdk](https://github.com/0xMiden/web-sdk): `@miden-sdk/miden-sdk`, `@miden-sdk/react`, and `@miden-sdk/vite-plugin`.
 - [node](https://github.com/0xMiden/node): Miden node implementation.
 - [compiler](https://github.com/0xMiden/compiler): Rust-to-MASM compiler.
 - [tutorials](https://github.com/0xMiden/tutorials): Tutorial source content.


### PR DESCRIPTION
Two changes to `static/llms.txt`.

## The `miden-client` entry is wrong

```
- [miden-client](https://github.com/0xMiden/miden-client): Rust client, Web SDK, and React SDK.
```

That repository was renamed — `https://github.com/0xMiden/miden-client` 301s to [`0xMiden/rust-sdk`](https://github.com/0xMiden/rust-sdk) — and it no longer contains the Web SDK or the React SDK, which live in [`0xMiden/web-sdk`](https://github.com/0xMiden/web-sdk). So the one line an agent would follow to find the TypeScript SDK source sends it to a repo that does not have it, and the redirect hides the problem rather than surfacing it. Split into two accurate entries.

The other seven repository links check out fine (all 200, no redirects).

## Agents should know the SDK ships its own guidance

As of [web-sdk#310](https://github.com/0xMiden/web-sdk/pull/310), each `@miden-sdk/*` package publishes an `AGENTS.md` index and a `skills/` directory inside its npm tarball. The point is version-matching: an agent working in a consumer's repo gets guidance for the release in that repo's lockfile, rather than whatever its training data remembers or whatever this site currently documents. For API specifics that is strictly better than a docs page, which can only describe one version.

Added a line under the header pointing there, framed so an agent reading `llms.txt` knows to prefer it for JavaScript and React work.

## Notes

- `llms-full.txt` is still absent (404). Worth adding, but it wants generation from the Docusaurus build rather than a hand-maintained static file, so it is out of scope here.

## Test plan

- [x] `https://github.com/0xMiden/rust-sdk` and `/web-sdk` both return 200 with no redirect
- [ ] `https://docs.miden.xyz/llms.txt` serves the updated file after deploy